### PR TITLE
Split out test.watch into watch container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,15 +34,25 @@ services:
 
   test:
     <<: *api_base
+    environment:
+      <<: *api_environment
+      MIX_ENV: test
+      PORT: 4001
+    ports:
+      - 49236:4001
+
+  watch:
+    <<: *api_base
     command: bash -c "mix do deps.get, compile, test.watch"
     depends_on:
+      - test
       - web
     environment:
       <<: *api_environment
       MIX_ENV: dev
-      PORT: 4001
+      PORT: 4002
     ports:
-      - 49236:4001
+      - 49237:4002
 
   apiary:
     image: apiaryio/client


### PR DESCRIPTION
This splits out a `watch` container and makes `test` still use the `test` `MIX_ENV` so the database gets spun up correctly.
