### PR TITLE
Add first spike of organizations and slugged routes

### DIFF
--- a/lib/code_corps.ex
+++ b/lib/code_corps.ex
@@ -1,5 +1,9 @@
 defmodule CodeCorps do
+  @moduledoc false
+
   use Application
+
+  alias CodeCorps.Endpoint
 
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
@@ -25,7 +29,7 @@ defmodule CodeCorps do
   # Tell Phoenix to update the endpoint configuration
   # whenever the application is updated.
   def config_change(changed, _new, removed) do
-    CodeCorps.Endpoint.config_change(changed, removed)
+    Endpoint.config_change(changed, removed)
     :ok
   end
 end

--- a/lib/code_corps/validators/slug_validator.ex
+++ b/lib/code_corps/validators/slug_validator.ex
@@ -1,0 +1,46 @@
+defmodule CodeCorps.Validators.SlugValidator do
+  @moduledoc """
+  Used for validating slug fields in a given changeset.
+  """
+
+  alias Ecto.Changeset
+
+  def validate_slug(changeset, field_name) do
+    # Matches slugs with:
+    # - only letters
+    # - prefixed/suffixed underscores
+    # - prefixed/suffixed numbers
+    # - single inside dashes
+    # - single/multiple inside underscores
+    # - one character
+    #
+    # Prevents slugs with:
+    # - prefixed symbols
+    # - prefixed/suffixed dashes
+    # - multiple consecutive dashes
+    # - single/multiple/multiple consecutive slashes
+    valid_slug_pattern = ~r/\A((?:(?:(?:[^-\W]-?))*)(?:(?:(?:[^-\W]-?))*)\w+)\z/
+
+    # Prevents slugs that conflict with reserved routes
+    reserved_routes = ~w(
+      about account admin android api app apps blog bug bugs cache charter
+      comment comments contact contributor contributors cookies
+      developer developers discover donate engineering enterprise explore
+      facebook favorites feed followers following github help home image images
+      integration integrations invite invitations ios issue issues jobs learn
+      likes lists log-in log-out login logout mention mentions new news
+      notification notifications oauth oauth_clients organization organizations
+      ping popular post_image post_images post_like post_likes post post
+      press pricing privacy
+      project projects repositories role roles rules search security session
+      sessions settings shop showcases sidekiq sign-in sign-out signin signout
+      signup sitemap slug slugs spotlight stars status tag tags
+      tasks team teams terms training trends trust tour twitter
+      user_role user_roles user_skill user_skills user users watching year
+    )
+
+    changeset
+    |> Changeset.validate_format(field_name, valid_slug_pattern)
+    |> Changeset.validate_exclusion(field_name, reserved_routes)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -44,6 +44,7 @@ defmodule CodeCorps.Mixfile do
       {:comeonin, "~> 2.0"},
       {:mix_test_watch, "~> 0.2", only: :dev}, # Test watcher
       {:credo, "~> 0.4", only: [:dev, :test]}, # Code style suggestions
+      {:inflex, "~> 1.7.0"},
     ]
   end
 

--- a/priv/repo/migrations/20160804000000_create_organization.exs
+++ b/priv/repo/migrations/20160804000000_create_organization.exs
@@ -1,0 +1,15 @@
+defmodule CodeCorps.Repo.Migrations.CreateOrganization do
+  use Ecto.Migration
+
+  def change do
+    create table(:organizations) do
+      add :name, :string
+      add :description, :string
+      add :slug, :string
+
+      timestamps()
+    end
+
+    create index(:organizations, ["lower(slug)"], name: :organizations_lower_slug_index, unique: true)
+  end
+end

--- a/priv/repo/migrations/20160804001111_create_slugged_route.exs
+++ b/priv/repo/migrations/20160804001111_create_slugged_route.exs
@@ -1,0 +1,15 @@
+defmodule CodeCorps.Repo.Migrations.CreateSluggedRoute do
+  use Ecto.Migration
+
+  def change do
+    create table(:slugged_routes) do
+      add :slug, :string
+      add :organization_id, references(:organizations, on_delete: :nothing)
+      add :user_id, references(:users, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:slugged_routes, ["lower(slug)"], name: :slugged_routes_lower_slug_index, unique: true)
+  end
+end

--- a/test/controllers/organization_controller_test.exs
+++ b/test/controllers/organization_controller_test.exs
@@ -1,0 +1,109 @@
+defmodule CodeCorps.OrganizationControllerTest do
+  use CodeCorps.ConnCase
+
+  alias CodeCorps.Organization
+  alias CodeCorps.Repo
+  alias CodeCorps.SluggedRoute
+
+  @valid_attrs %{description: "Build a better future.", name: "Code Corps"}
+  @invalid_attrs %{}
+
+  setup do
+    conn =
+      %{build_conn | host: "api."}
+      |> put_req_header("accept", "application/vnd.api+json")
+      |> put_req_header("content-type", "application/vnd.api+json")
+
+    {:ok, conn: conn}
+  end
+
+  defp relationships do
+    %{}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, organization_path(conn, :index)
+    assert json_response(conn, 200)["data"] == []
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    organization = Repo.insert! %Organization{}
+    conn = get conn, organization_path(conn, :show, organization)
+    data = json_response(conn, 200)["data"]
+    assert data["id"] == "#{organization.id}"
+    assert data["type"] == "organization"
+    assert data["attributes"]["name"] == organization.name
+    assert data["attributes"]["description"] == organization.description
+    assert data["attributes"]["slug"] == organization.slug
+  end
+
+  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, user_path(conn, :show, -1)
+    end
+  end
+
+  test "creates and renders resource when data is valid", %{conn: conn} do
+    conn = post conn, organization_path(conn, :create), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "organization",
+        "attributes" => @valid_attrs,
+        "relationships" => relationships
+      }
+    }
+
+    organization_id = json_response(conn, 201)["data"]["id"]
+    assert organization_id
+    organization = Repo.get_by(Organization, @valid_attrs)
+    assert organization
+    slugged_route = Repo.get_by(SluggedRoute, slug: "code-corps")
+    assert slugged_route
+    assert organization.id == slugged_route.organization_id
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, organization_path(conn, :create), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "organization",
+        "attributes" => @invalid_attrs,
+        "relationships" => relationships
+      }
+    }
+
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "updates and renders chosen resource when data is valid", %{conn: conn} do
+    organization = Repo.insert! %Organization{}
+    conn = put conn, organization_path(conn, :update, organization), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "organization",
+        "id" => organization.id,
+        "attributes" => @valid_attrs,
+        "relationships" => relationships
+      }
+    }
+
+    assert json_response(conn, 200)["data"]["id"]
+    assert Repo.get_by(Organization, @valid_attrs)
+  end
+
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    organization = Repo.insert! %Organization{}
+    conn = put conn, organization_path(conn, :update, organization), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "organization",
+        "id" => organization.id,
+        "attributes" => @invalid_attrs,
+        "relationships" => relationships
+      }
+    }
+
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+end

--- a/test/controllers/slugged_route_controller_test.exs
+++ b/test/controllers/slugged_route_controller_test.exs
@@ -1,0 +1,37 @@
+defmodule CodeCorps.SluggedRouteControllerTest do
+  use CodeCorps.ConnCase
+
+  alias CodeCorps.SluggedRoute
+  alias CodeCorps.Repo
+
+  @valid_attrs %{organization_id: 42, slug: "some content", user_id: 42}
+  @invalid_attrs %{}
+
+  setup do
+    conn =
+      %{build_conn | host: "api."}
+      |> put_req_header("accept", "application/vnd.api+json")
+      |> put_req_header("content-type", "application/vnd.api+json")
+
+    {:ok, conn: conn}
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    slug = "test-slug"
+    slugged_route = Repo.insert! %SluggedRoute{slug: slug}
+    conn = get conn, "/#{slug}"
+    data = json_response(conn, 200)["data"]
+    assert data["id"] == "#{slugged_route.id}"
+    assert data["type"] == "slugged-route"
+    assert data["attributes"]["slug"] == slugged_route.slug
+    assert data["attributes"]["organization_id"] == slugged_route.organization_id
+    assert data["attributes"]["user_id"] == slugged_route.user_id
+  end
+
+  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, slugged_route_path(conn, :show, -1)
+    end
+  end
+
+end

--- a/test/lib/code_corps/validators/slug_validator_test.exs
+++ b/test/lib/code_corps/validators/slug_validator_test.exs
@@ -1,0 +1,100 @@
+defmodule CodeCorps.Validators.SlugValidatorTest do
+  use ExUnit.Case, async: true
+
+  import CodeCorps.Validators.SlugValidator
+
+  test "with only letters" do
+    changeset = process_slug("testslug") # can't be `slug` because reserved
+    assert changeset.valid?
+  end
+
+  test "with prefixed underscores" do
+    changeset = process_slug("_slug")
+    assert changeset.valid?
+  end
+
+  test "with suffixed underscores" do
+    changeset = process_slug("slug_")
+    assert changeset.valid?
+  end
+
+  test "with prefixed numbers" do
+    changeset = process_slug("123slug")
+    assert changeset.valid?
+  end
+
+  test "with suffixed numbers" do
+    changeset = process_slug("slug123")
+    assert changeset.valid?
+  end
+
+  test "with multiple dashes" do
+    changeset = process_slug("slug-slug-slug")
+    assert changeset.valid?
+  end
+
+  test "with multiple underscores" do
+    changeset = process_slug("slug_slug_slug")
+    assert changeset.valid?
+  end
+
+  test "with multiple consecutive underscores" do
+    changeset = process_slug("slug___slug")
+    assert changeset.valid?
+  end
+
+  test "with one character" do
+    changeset = process_slug("s")
+    assert changeset.valid?
+  end
+
+  test "with prefixed symbols" do
+    changeset = process_slug("@slug")
+    refute changeset.valid?
+  end
+
+  test "with prefixed dashes" do
+    changeset = process_slug("-slug")
+    refute changeset.valid?
+  end
+
+  test "with suffixed dashes" do
+    changeset = process_slug("slug-")
+    refute changeset.valid?
+  end
+
+  test "with multiple consecutive dashes" do
+    changeset = process_slug("slug---slug")
+    refute changeset.valid?
+  end
+
+  test "with single slashes" do
+    changeset = process_slug("slug/slug")
+    refute changeset.valid?
+  end
+
+  test "with multiple slashes" do
+    changeset = process_slug("slug/slug/slug")
+    refute changeset.valid?
+  end
+
+  test "with multiple consecutive slashes" do
+    changeset = process_slug("slug///slug")
+    refute changeset.valid?
+  end
+
+  test "with reserved routes" do
+    changeset = process_slug("about")
+    refute changeset.valid?
+  end
+
+  defp process_slug(slug) do
+    slug
+    |> cast_slug
+    |> validate_slug(:slug)
+  end
+
+  defp cast_slug(slug) do
+    Ecto.Changeset.cast({%{slug: nil}, %{slug: :string}}, %{"slug" => slug}, [:slug])
+  end
+end

--- a/test/models/organization_test.exs
+++ b/test/models/organization_test.exs
@@ -1,0 +1,29 @@
+defmodule CodeCorps.OrganizationTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.Organization
+
+  @valid_attrs %{description: "Building a better future.", name: "Code Corps"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Organization.changeset(%Organization{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Organization.changeset(%Organization{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+
+  test "create changeset with valid attributes" do
+    changeset = Organization.create_changeset(%Organization{}, @valid_attrs)
+    assert changeset.valid?
+    assert changeset.changes.slug == "code-corps"
+  end
+
+  test "create changeset with invalid attributes" do
+    changeset = Organization.create_changeset(%Organization{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/slugged_route_test.exs
+++ b/test/models/slugged_route_test.exs
@@ -1,0 +1,24 @@
+defmodule CodeCorps.SluggedRouteTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.SluggedRoute
+
+  @valid_organization_attrs %{slug: "organization-slug", organization_id: 1}
+  @valid_user_attrs %{slug: "user-slug", user_id: 1}
+  @invalid_attrs %{}
+
+  test "changeset with valid organization attributes" do
+    changeset = SluggedRoute.changeset(%SluggedRoute{}, @valid_organization_attrs)
+    assert changeset.valid?
+  end
+
+  test "user changeset with valid user attributes" do
+    changeset = SluggedRoute.changeset(%SluggedRoute{}, @valid_user_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = SluggedRoute.changeset(%SluggedRoute{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -3,7 +3,7 @@ defmodule CodeCorps.UserTest do
 
   alias CodeCorps.User
 
-  @valid_attrs %{email: "some content", password: "some content", username: "some content"}
+  @valid_attrs %{email: "test@user.com", password: "somepassword", username: "testuser"}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do
@@ -16,9 +16,16 @@ defmodule CodeCorps.UserTest do
     refute changeset.valid?
   end
 
-  test "changeset does not accept long usernames" do
+  test "changeset with invalid email" do
+    attrs = Map.put(@valid_attrs, :email, "notanemail")
+    changeset = User.changeset(%User{}, attrs)
+    assert {:email, {"has invalid format", []}} in changeset.errors
+  end
+
+  test "registration_changeset does not accept long usernames" do
     attrs = Map.put(@valid_attrs, :username, String.duplicate("a", 40))
-    assert {:username, "should be at most 39 character(s)"} in errors_on(%User{}, attrs)
+    changeset = User.registration_changeset(%User{}, attrs)
+    assert {:username, {"should be at most %{count} character(s)", count: 39}} in changeset.errors
   end
 
   test "registration_changeset password must be at least 6 chars long" do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,15 +1,16 @@
 defmodule CodeCorps.TestHelpers do
   alias CodeCorps.Repo
+  alias CodeCorps.User
 
   def insert_user(attrs \\ %{}) do
     changes = Map.merge(%{
-      email: "username",
-      username: "user#{Base.encode16(:crypto.rand_bytes(8))}",
+      email: "test@user.com",
+      username: "user#{Base.encode16(:crypto.strong_rand_bytes(8))}",
       password: "password",
     }, attrs)
 
-    %CodeCorps.User{}
-    |> CodeCorps.User.registration_changeset(changes)
+    %User{}
+    |> User.registration_changeset(changes)
     |> Repo.insert!()
   end
 end

--- a/web/controllers/organization_controller.ex
+++ b/web/controllers/organization_controller.ex
@@ -1,0 +1,62 @@
+defmodule CodeCorps.OrganizationController do
+  use CodeCorps.Web, :controller
+
+  alias CodeCorps.Organization
+  alias JaSerializer.Params
+
+  import Organization, only: [changeset: 2]
+
+  plug :scrub_params, "data" when action in [:create, :update]
+
+  def index(conn, _params) do
+    organizations =
+      Organization
+      |> preload([:slugged_route])
+      |> Repo.all
+    render(conn, "index.json-api", data: organizations)
+  end
+
+  def create(conn, %{"data" => data = %{"type" => "organization", "attributes" => _organization_params}}) do
+    changeset = Organization.create_changeset(%Organization{}, Params.to_attributes(data))
+
+    case Repo.insert(changeset) do
+      {:ok, organization} ->
+        organization = Repo.preload(organization, [:slugged_route])
+
+        conn
+        |> put_status(:created)
+        |> put_resp_header("location", organization_path(conn, :show, organization))
+        |> render("show.json-api", data: organization)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    organization =
+      Organization
+      |> preload([:slugged_route])
+      |> Repo.get!(id)
+    render(conn, "show.json-api", data: organization)
+  end
+
+  def update(conn, %{"id" => id, "data" => data = %{"type" => "organization", "attributes" => _organization_params}}) do
+    changeset =
+      Organization
+      |> preload([:slugged_route])
+      |> Repo.get!(id)
+      |> changeset(Params.to_attributes(data))
+
+    case Repo.update(changeset) do
+      {:ok, organization} ->
+        render(conn, "show.json-api", data: organization)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
+    end
+  end
+
+end

--- a/web/controllers/slugged_route_controller.ex
+++ b/web/controllers/slugged_route_controller.ex
@@ -1,0 +1,13 @@
+defmodule CodeCorps.SluggedRouteController do
+  use CodeCorps.Web, :controller
+
+  alias CodeCorps.SluggedRoute
+
+  def show(conn, %{"slug" => slug}) do
+    slugged_route =
+      SluggedRoute
+      |> preload([:organization, :user])
+      |> Repo.get_by!(slug: slug)
+    render(conn, "show.json-api", data: slugged_route)
+  end
+end

--- a/web/models/organization.ex
+++ b/web/models/organization.ex
@@ -1,0 +1,61 @@
+defmodule CodeCorps.Organization do
+  @moduledoc """
+  Represents an organization on Code Corps, e.g. "Code Corps" itself.
+  """
+
+  use CodeCorps.Web, :model
+
+  alias CodeCorps.SluggedRoute
+
+  import CodeCorps.Validators.SlugValidator
+
+  schema "organizations" do
+    field :name, :string
+    field :description, :string
+    field :slug, :string
+
+    has_one :slugged_route, SluggedRoute
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name, :description, :slug])
+    |> validate_required([:name])
+  end
+
+  @doc """
+  Builds a changeset for creating an organization.
+  """
+  def create_changeset(struct, params) do
+    struct
+    |> changeset(params)
+    |> generate_slug()
+    |> validate_required([:slug])
+    |> validate_slug(:slug)
+    |> put_slugged_route()
+  end
+
+  defp generate_slug(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{name: name}} ->
+        put_change(changeset, :slug, Inflex.parameterize(name))
+      _ ->
+        changeset
+    end
+  end
+
+  defp put_slugged_route(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{slug: slug}} ->
+        slugged_route_changeset = SluggedRoute.changeset(%SluggedRoute{}, %{slug: slug})
+        put_assoc(changeset, :slugged_route, slugged_route_changeset)
+      _ ->
+        changeset
+    end
+  end
+end

--- a/web/models/slugged_route.ex
+++ b/web/models/slugged_route.ex
@@ -1,0 +1,29 @@
+defmodule CodeCorps.SluggedRoute do
+  @moduledoc """
+  A slugged route is used for routing slugged requests like `/joshsmith` or
+  `/code-corps` to their respective owner: either a user or an organization.
+  """
+
+  use CodeCorps.Web, :model
+
+  import CodeCorps.Validators.SlugValidator
+
+  schema "slugged_routes" do
+    belongs_to :organization, CodeCorps.Organization
+    belongs_to :user, CodeCorps.User
+
+    field :slug, :string
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:slug])
+    |> validate_required(:slug)
+    |> validate_slug(:slug)
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -22,13 +22,12 @@ defmodule CodeCorps.Router do
   scope "/", CodeCorps, host: "api." do
     pipe_through :api
 
+    resources "/organizations", OrganizationController, except: [:new, :edit]
+
     get "/users/email_available", UserController, :email_available
     get "/users/username_available", UserController, :username_available
     resources "/users", UserController, except: [:new, :edit]
-  end
 
-  # Other scopes may use custom stacks.
-  # scope "/api", CodeCorps do
-  #   pipe_through :api
-  # end
+    get "/:slug", SluggedRouteController, :show
+  end
 end

--- a/web/views/changeset_view.ex
+++ b/web/views/changeset_view.ex
@@ -1,6 +1,8 @@
 defmodule CodeCorps.ChangesetView do
   use CodeCorps.Web, :view
 
+  alias Ecto.Changeset
+
   @doc """
   Traverses and translates changeset errors.
 
@@ -8,7 +10,7 @@ defmodule CodeCorps.ChangesetView do
   `CodeCorps.ErrorHelpers.translate_error/1` for more details.
   """
   def translate_errors(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+    Changeset.traverse_errors(changeset, &translate_error/1)
   end
 
   def render("error.json-api", %{changeset: changeset}) do

--- a/web/views/organization_view.ex
+++ b/web/views/organization_view.ex
@@ -1,8 +1,8 @@
-defmodule CodeCorps.UserView do
+defmodule CodeCorps.OrganizationView do
   use CodeCorps.Web, :view
   use JaSerializer.PhoenixView
 
-  attributes [:username, :email, :inserted_at, :updated_at]
+  attributes [:name, :description, :slug, :inserted_at, :updated_at]
 
   has_one :slugged_route, serializer: CodeCorps.SluggedRouteView
 end

--- a/web/views/slugged_route_view.ex
+++ b/web/views/slugged_route_view.ex
@@ -1,0 +1,9 @@
+defmodule CodeCorps.SluggedRouteView do
+  use CodeCorps.Web, :view
+  use JaSerializer.PhoenixView
+
+  attributes [:slug, :inserted_at, :updated_at]
+
+  has_one :organization, serializer: CodeCorps.OrganizationView
+  has_one :user, serializer: CodeCorps.UserView
+end


### PR DESCRIPTION
Closes #38. Addresses most of #29.

This should be ready for a review now.

There are a lot of changes here, but to summarize:
- API endpoints for organizations and slugged routes
- auto creation of SluggedRoute when creating organization and user
- slug format validation
