### PR TITLE
Add CORS

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -41,3 +41,6 @@ config :code_corps, CodeCorps.Repo,
   hostname: System.get_env("DATABASE_POSTGRESQL_HOST") || "localhost",
   database: "code_corps_phoenix_dev",
   pool_size: 10
+
+# CORS allowed origins
+config :code_corps, allowed_origins: ["http://localhost:4200"]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -16,6 +16,14 @@ config :code_corps, CodeCorps.Endpoint,
   url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/manifest.json"
 
+# CORS allowed origins
+config :code_corps, allowed_origins: [
+  "http://codecorps.org",
+  "http://www.codecorps.org",
+  "https://codecorps.org",
+  "https://www.codecorps.org"
+]
+
 # Do not print debug messages in production
 config :logger, level: :info
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,3 +21,6 @@ config :code_corps, CodeCorps.Repo,
 # speed up password hashing
 config :comeonin, :bcrypt_log_rounds, 4
 config :comeonin, :pbkdf2_rounds, 1
+
+# CORS allowed origins
+config :code_corps, allowed_origins: ["http://localhost:4200"]

--- a/lib/code_corps/endpoint.ex
+++ b/lib/code_corps/endpoint.ex
@@ -38,6 +38,6 @@ defmodule CodeCorps.Endpoint do
     key: "_code_corps_key",
     signing_salt: "RJebPcfU"
 
-  plug Corsica, origins: "http://localhost:4200"
+  plug Corsica, origins: Application.get_env(:code_corps, :allowed_origins)
   plug CodeCorps.Router
 end

--- a/lib/code_corps/endpoint.ex
+++ b/lib/code_corps/endpoint.ex
@@ -38,5 +38,6 @@ defmodule CodeCorps.Endpoint do
     key: "_code_corps_key",
     signing_salt: "RJebPcfU"
 
+  plug Corsica, origins: "http://localhost:4200"
   plug CodeCorps.Router
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule CodeCorps.Mixfile do
   def application do
     [mod: {CodeCorps, []},
      applications: [:phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :logger,
-                    :gettext, :phoenix_ecto, :postgrex, :comeonin]]
+                    :gettext, :phoenix_ecto, :postgrex, :comeonin, :corsica]]
   end
 
   # Specifies which paths to compile per environment.
@@ -45,6 +45,7 @@ defmodule CodeCorps.Mixfile do
       {:mix_test_watch, "~> 0.2", only: :dev}, # Test watcher
       {:credo, "~> 0.4", only: [:dev, :test]}, # Code style suggestions
       {:inflex, "~> 1.7.0"},
+      {:corsica, "~> 0.4"}, # CORS
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,7 @@
   "bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "comeonin": {:hex, :comeonin, "2.5.2", "bbad773af30a7632a63053014d5cfebf6df2c1ad114167b4db02f05b5c60901b", [:mix, :make, :make], []},
   "connection": {:hex, :connection, "1.0.3", "3145f7416be3df248a4935f24e3221dc467c1e3a158d62015b35bd54da365786", [:mix], []},
+  "corsica": {:hex, :corsica, "0.5.0", "eb5b2fccc5bc4f31b8e2b77dd15f5f302aca5d63286c953e8e916f806056d50c", [:mix], [{:cowboy, ">= 1.0.0", [hex: :cowboy, optional: false]}, {:plug, ">= 0.9.0", [hex: :plug, optional: false]}]},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "credo": {:hex, :credo, "0.4.7", "1516ebd3c6099eff74ed0ef50637f0a43113c3f65338a9e1792efc03dff34855", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -5,4 +5,20 @@ defmodule CodeCorps.PageControllerTest do
     conn = get conn, "/"
     assert html_response(conn, 200) =~ "Welcome to Phoenix!"
   end
+
+  test "allows CORS from http://localhost:4200" do
+    conn = build_conn()
+      |> put_req_header("origin", "http://localhost:4200")
+      |> get("/")
+
+    assert "http://localhost:4200" in get_resp_header(conn, "access-control-allow-origin")
+  end
+
+  test "does not allow CORS for http://google.com" do
+    conn = build_conn()
+      |> put_req_header("origin", "http://google.com")
+      |> get("/")
+
+    refute "http://google.com" in get_resp_header(conn, "access-control-allow-origin")
+  end
 end


### PR DESCRIPTION
This adds CORS using `corsica` to be sure we can actually make requests to the server with our Ember application.

Testing inside the PageController test.
