### PR TITLE
Add Coalesced ID filter support to organizations API

### DIFF
--- a/test/controllers/organization_controller_test.exs
+++ b/test/controllers/organization_controller_test.exs
@@ -26,6 +26,18 @@ defmodule CodeCorps.OrganizationControllerTest do
     assert json_response(conn, 200)["data"] == []
   end
 
+  test "filters resources on index", %{conn: conn} do
+    first_org = insert_organization(%{name: "Org A"})
+    second_org = insert_organization(%{name: "Org B"})
+    insert_organization(%{name: "Org C"})
+    conn = get conn, "organizations/?filter[id]=#{first_org.id},#{second_org.id}"
+    data = json_response(conn, 200)["data"]
+    [first_result, second_result | _] = data
+    assert length(data) == 2
+    assert first_result["id"] == "#{first_org.id}"
+    assert second_result["id"] == "#{second_org.id}"
+  end
+
   test "shows chosen resource", %{conn: conn} do
     organization = Repo.insert! %Organization{}
     conn = get conn, organization_path(conn, :show, organization)

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -24,10 +24,10 @@ defmodule CodeCorps.TestHelpers do
   end
 
   def insert_organization(attrs \\ %{}) do
-    changes = Map.merge(attrs, %{
+    changes = Map.merge(%{
       name: "Test organization",
       description: "Test description"
-    })
+    }, attrs)
 
     %Organization{}
     |> Organization.create_changeset(changes)

--- a/web/controllers/controller_helpers.ex
+++ b/web/controllers/controller_helpers.ex
@@ -1,0 +1,7 @@
+defmodule CodeCorps.ControllerHelpers do
+  def coalesce_id_string(string) do
+    string
+    |> String.split(",")
+    |> Enum.map(&String.to_integer(&1))
+  end
+end

--- a/web/controllers/skill_controller.ex
+++ b/web/controllers/skill_controller.ex
@@ -1,6 +1,8 @@
 defmodule CodeCorps.SkillController do
   use CodeCorps.Web, :controller
 
+  import CodeCorps.ControllerHelpers
+
   alias CodeCorps.Skill
   alias JaSerializer.Params
 
@@ -10,14 +12,12 @@ defmodule CodeCorps.SkillController do
     skills =
       case params do
         %{"filter" => %{"id" => id_list}} ->
-          ids = coalesce_id_string(id_list)
-          query = Skill |> where([p], p.id in ^ids)
-          Repo.all(query)
+          ids = id_list |> coalesce_id_string
+          Skill |> where([p], p.id in ^ids) |> Repo.all
         %{"query" => query} ->
-          text_query = Skill |> where([p], ilike(p.title, ^"%#{query}%"))
-          Repo.all(text_query)
+          Skill |> where([p], ilike(p.title, ^"%#{query}%")) |> Repo.all
         %{} ->
-          Repo.all(Skill)
+          Skill |> Repo.all
       end
     render(conn, "index.json-api", data: skills)
   end
@@ -43,7 +43,5 @@ defmodule CodeCorps.SkillController do
     render(conn, "show.json-api", data: skill)
   end
 
-  defp coalesce_id_string(string) do
-    String.split(string, ",") |> Enum.map(fn(n) -> String.to_integer(n) end)
-  end
+
 end


### PR DESCRIPTION
Closes #29 

I used logic similar to the one we have in `SkillController`. I also extracted `coalesce_id_string` into `CodeCorps.ControllerHelpers` using the example of `CodeCorps.ModelHelpers` 
