### PR TITLE
Add seeds and fix bug in ProjectController

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,5 +1,75 @@
 alias CodeCorps.Repo
 alias CodeCorps.Category
+alias CodeCorps.Organization
+alias CodeCorps.Project
+alias CodeCorps.User
+
+# Users
+
+users = [
+  %{
+    username: "adminstrator",
+    email: "admin@example.org",
+    password: "password",
+    admin: true
+  },
+  %{
+    username: "testuser",
+    email: "test@example.org",
+    password: "test",
+    admin: false
+  },
+]
+
+cond do
+  Repo.all(User) != [] ->
+    IO.puts "Users detected, aborting user seed."
+  true ->
+    Enum.each(users, fn user ->
+      User.registration_changeset(%User{}, user)
+      |> Repo.insert!
+    end)
+end
+
+# Organizations
+
+organizations = [
+  %{
+    name: "Code Corps"
+  },
+]
+
+cond do
+  Repo.all(Organization) != [] ->
+    IO.puts "Organizations detected, aborting organization seed."
+  true ->
+    Enum.each(organizations, fn organization ->
+      Organization.create_changeset(%Organization{}, organization)
+      |> Repo.insert!
+    end)
+end
+
+# Projects
+
+projects = [
+  %{
+    title: "Code Corps",
+    description: "A basic project for use in development",
+    organization_id: 1
+  },
+]
+
+cond do
+  Repo.all(Project) != [] ->
+    IO.puts "Projects detected, aborting project seed."
+  true ->
+    Enum.each(projects, fn project ->
+      Project.changeset(%Project{}, project)
+      |> Repo.insert!
+    end)
+end
+
+# Categories
 
 categories = [
   %{

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -23,6 +23,7 @@ defmodule CodeCorps.ProjectController do
     projects =
       Project
       |> Repo.all
+      |> Repo.preload([:organization])
     render(conn, "index.json-api", data: projects)
   end
 


### PR DESCRIPTION
This adds seeds for users, organizations, and projects.

There was also a bug with the index action on projects where the organizations were not properly preloaded.

This PR now makes the Phoenix app as compatible with the Ember app as we can be, given missing `state` for user onboarding, missing images, missing posts, etc.
