### PR TITLE
[POST]: WIP update related data

### DIFF
--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -12,6 +12,7 @@ defmodule CodeCorps.PostController do
       where: c.project_id == ^project_id,
       select: c
     )
+    posts = Repo.preload(posts, [:project])
     render(conn, "index.json-api", data: posts)
   end
   def index(conn, _params) do
@@ -24,6 +25,7 @@ defmodule CodeCorps.PostController do
 
     case Repo.insert(changeset) do
       {:ok, post} ->
+        post = Repo.preload(post, [:project])
         conn
         |> put_status(:created)
         |> put_resp_header("location", post_path(conn, :show, post))
@@ -42,15 +44,22 @@ defmodule CodeCorps.PostController do
       where: c.project_id == ^project_id,
       select: c
     )
+    post = Repo.preload(post, [:project])
     render(conn, "show.json-api", data: post)
   end
   def show(conn, %{"id" => id}) do
-    post = Repo.get!(Post, id)
+    post = 
+      Post
+      |> preload([:project])
+      |> Repo.get!(id)
     render(conn, "show.json-api", data: post)
   end
 
   def update(conn, %{"id" => id, "data" => data = %{"type" => "post", "attributes" => _post_params}}) do
-    post = Repo.get!(Post, id)
+    post = 
+      Post
+      |> preload([:project])
+      |> Repo.get!(id)
     changeset = Post.changeset(post, Params.to_attributes(data))
 
     case Repo.update(changeset) do

--- a/web/models/post.ex
+++ b/web/models/post.ex
@@ -19,10 +19,11 @@ defmodule CodeCorps.Post do
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:title, :markdown, :post_type, :status])
+    |> cast(params, [:title, :markdown, :post_type, :status, :project_id])
     |> validate_required([:title, :markdown, :post_type, :status])
     |> validate_inclusion(:post_type, post_types)
     |> validate_inclusion(:status, statuses)
+    |> assoc_constraint(:project)
     |> MarkdownRenderer.render_markdown_to_html(:markdown, :body)
   end
 

--- a/web/views/post_view.ex
+++ b/web/views/post_view.ex
@@ -3,4 +3,6 @@ defmodule CodeCorps.PostView do
   use JaSerializer.PhoenixView
 
   attributes [:body, :markdown, :number, :post_type, :status, :title, :inserted_at, :updated_at]
+
+  has_one :project, serializer: CodeCorps.ProjectView
 end


### PR DESCRIPTION
Trying to get an initial update of related data (post -> project_id).  Noticed that `preview` uses `put_assoc` for updating the previews user.

Any thoughts @begedin on how to get the update working without `put_assoc`?  Also plan on adding more assertions for related data once we figure that out.

Failing line is right here: https://github.com/code-corps/code-corps-phoenix/pull/89/files#diff-8f3513cf21a0b7b4702df8db8016d51fR155
