### PR TITLE
Add has many project categories projects to category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /db
 /deps
 /*.ez
+/tmp
 
 # Generated on crash by the VM
 erl_crash.dump
@@ -22,3 +23,6 @@ erl_crash.dump
 # secrets file as long as you replace its contents by environment
 # variables.
 /config/prod.secret.exs
+
+# Secret
+.env

--- a/test/controllers/category_controller_test.exs
+++ b/test/controllers/category_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule CodeCorps.CategoryControllerTest do
   use CodeCorps.ConnCase
 
+  import CodeCorps.Factories
+
   alias CodeCorps.Category
 
   @valid_attrs %{description: "You want to improve software tools and infrastructure.", name: "Technology"}
@@ -22,12 +24,7 @@ defmodule CodeCorps.CategoryControllerTest do
   end
 
   defp build_payload(attributes) do
-    %{
-      "data" => %{
-        "type" => "category",
-        "attributes" => attributes
-      }
-    }
+    %{ "data" => %{"type" => "category", "attributes" => attributes}}
   end
 
   test "lists all entries on index", %{conn: conn} do
@@ -36,18 +33,17 @@ defmodule CodeCorps.CategoryControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    changeset = Category.create_changeset(%Category{}, @valid_attrs)
-    category = Repo.insert!(changeset)
-    conn = get conn, category_path(conn, :show, category)
-    assert json_response(conn, 200)["data"] == %{
-      "id" => "#{category.id}",
-      "type" => "category",
-      "attributes" => %{
-        "name" => category.name,
-        "slug" => category.slug,
-        "description" => category.description
-      }
-    }
+    category = insert(:category)
+
+    path = conn |> category_path(:show, category)
+    data = conn |> get(path) |> json_response(200) |> Map.get("data")
+
+    assert data["id"] == category.id |> Integer.to_string
+    assert data["type"] == "category"
+
+    assert data["attributes"]["name"] == category.name
+    assert data["attributes"]["slug"] == category.slug
+    assert data["attributes"]["description"] == category.description
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do
@@ -71,8 +67,7 @@ defmodule CodeCorps.CategoryControllerTest do
   end
 
   test "updates and renders chosen resource when data is valid", %{conn: conn} do
-    changeset = Category.create_changeset(%Category{}, @valid_attrs)
-    category = Repo.insert!(changeset)
+    category = insert(:category)
     updated_attrs = %{@valid_attrs | description: "New Description"}
     conn = put conn, category_path(conn, :update, category), build_payload(category.id, updated_attrs)
 
@@ -81,8 +76,7 @@ defmodule CodeCorps.CategoryControllerTest do
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    changeset = Category.create_changeset(%Category{}, @valid_attrs)
-    category = Repo.insert!(changeset)
+    category = insert(:category)
     conn = put conn, category_path(conn, :update, category), build_payload(category.id, @invalid_attrs)
     assert json_response(conn, 422)["errors"] != %{}
   end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -35,7 +35,8 @@ defmodule CodeCorps.Factories do
   def category_factory do
     %CodeCorps.Category{
       name: sequence(:name, &"Category #{&1}"),
-      slug: sequence(:slug, &"category_#{&1}")
+      slug: sequence(:slug, &"category_#{&1}"),
+      description: sequence(:description, &"A description for category #{&1}"),
     }
   end
 

--- a/test/views/category_view_test.exs
+++ b/test/views/category_view_test.exs
@@ -1,0 +1,50 @@
+defmodule CodeCorps.CategoryViewTest do
+  use CodeCorps.ConnCase, async: true
+
+  import CodeCorps.Factories
+
+  alias CodeCorps.Repo
+
+  # Bring render/3 and render_to_string/3 for testing custom views
+  import Phoenix.View
+
+  test "renders all attributes and relationships properly" do
+    project_category = insert(:project_category)
+
+    category =
+      CodeCorps.Category
+      |> Repo.get(project_category.category_id)
+      |> CodeCorps.Repo.preload([:project_categories, :projects])
+
+    rendered_json =  render(CodeCorps.CategoryView, "show.json-api", data: category)
+
+    expected_json = %{
+      data: %{
+        attributes: %{
+          "description" => category.description,
+          "name" => category.name,
+          "slug" => category.slug
+        },
+        id: category.id |> Integer.to_string,
+        relationships: %{
+          "project-categories" => %{
+            data: [
+              %{id: project_category.id |> Integer.to_string, type: "project-category"}
+            ]
+          },
+          "projects" => %{
+            data: [
+              %{id: project_category.project_id |> Integer.to_string, type: "project"}
+            ]
+          }
+        },
+        type: "category",
+      },
+      jsonapi: %{
+        version: "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+end

--- a/web/controllers/category_controller.ex
+++ b/web/controllers/category_controller.ex
@@ -14,6 +14,10 @@ defmodule CodeCorps.CategoryController do
 
     case Repo.insert(changeset) do
       {:ok, category} ->
+        category =
+          category
+          |> Repo.preload([:projects])
+
         conn
         |> put_status(:created)
         |> put_resp_header("location", category_path(conn, :show, category))
@@ -26,13 +30,20 @@ defmodule CodeCorps.CategoryController do
   end
 
   def show(conn, %{"id" => id}) do
-    category = Repo.get!(Category, id)
+    category =
+      Category
+      |> preload([:projects])
+      |> Repo.get!(id)
+
     render(conn, "show.json-api", data: category)
   end
 
   def update(conn, %{"id" => id, "data" => data = %{"type" => "category", "attributes" => _category_params}}) do
-    category = Repo.get!(Category, id)
-    changeset = Category.changeset(category, Params.to_attributes(data))
+    changeset =
+      Category
+      |> preload([:projects])
+      |> Repo.get!(id)
+      |> Category.changeset(Params.to_attributes(data))
 
     case Repo.update(changeset) do
       {:ok, category} ->

--- a/web/models/category.ex
+++ b/web/models/category.ex
@@ -12,6 +12,9 @@ defmodule CodeCorps.Category do
     field :slug, :string
     field :description, :string
 
+    has_many :project_categories, CodeCorps.ProjectCategory
+    has_many :projects, through: [:project_categories, :project]
+
     timestamps()
   end
 

--- a/web/views/category_view.ex
+++ b/web/views/category_view.ex
@@ -3,4 +3,7 @@ defmodule CodeCorps.CategoryView do
   use JaSerializer.PhoenixView
 
   attributes [:name, :slug, :description]
+
+  has_many :project_categories, serializer: CodeCorps.ProjectCategoryView
+  has_many :projects, serializer: CodeCorps.ProjectView
 end


### PR DESCRIPTION
Note: This branches off of #105. I wanted to make that PR as mergeable as possible, so I decided to submit this separately.

This adds the following relationships to the category model:

``` Elixir
has_many :project_categories, CodeCorps.ProjectCategory
has_many :projects, through: [:project_categories, :project]
```

It also adds a `preload` statement for both relationships on all `CategoryController` endpoints.

Finally, it adds our first `ViewTest` that tests an actual JSON API resource view, so it should serve as a template for others, meaning extra focus on that part while reviewing.

The reason I submitted this separately is because we're preloading two layers of a `has_many` relationship here, which I'm not sure we actually need. I think we might do, but I'm not sure. Any ideas are welcome here.

Please do focus on https://github.com/code-corps/code-corps-phoenix/pull/106/commits/58129cfe26cfef78a31d50dc337d32694d4740b0 while reviewing. The first commit is just what's already in PR #105 
