### PR TITLE
Added user_roles migration, model, endpoint.

### DIFF
--- a/priv/repo/migrations/20160822011624_create_user_role.exs
+++ b/priv/repo/migrations/20160822011624_create_user_role.exs
@@ -1,0 +1,14 @@
+defmodule CodeCorps.Repo.Migrations.CreateUserRole do
+  use Ecto.Migration
+
+  def change do
+    create table(:user_roles) do
+      add :user_id, references(:users, on_delete: :nothing)
+      add :role_id, references(:roles, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:user_roles, [:user_id, :role_id], unique: true)
+  end
+end

--- a/test/controllers/organization_controller_test.exs
+++ b/test/controllers/organization_controller_test.exs
@@ -74,6 +74,7 @@ defmodule CodeCorps.OrganizationControllerTest do
     assert organization.id == slugged_route.organization_id
   end
 
+  @tag :requires_env
   test "uploads a icon to S3", %{conn: conn} do
     organization = insert_organization()
     icon_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -133,6 +133,7 @@ defmodule CodeCorps.ProjectControllerTest do
       assert project.organization_id == organization.id
     end
 
+    @tag :requires_env
     test "uploads a icon to S3", %{conn: conn} do
       project = insert_project()
       icon_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -126,6 +126,7 @@ defmodule CodeCorps.UserControllerTest do
       assert user.biography == "Just a test user"
     end
 
+    @tag :requires_env
     test "uploads a photo to S3", %{conn: conn} do
       user = insert_user()
       photo_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="

--- a/test/controllers/user_role_controller_test.exs
+++ b/test/controllers/user_role_controller_test.exs
@@ -1,0 +1,71 @@
+defmodule CodeCorps.UserRoleControllerTest do
+  use CodeCorps.ConnCase
+
+  alias CodeCorps.UserRole
+  alias CodeCorps.Repo
+
+  setup do
+    conn =
+      %{build_conn | host: "api."}
+      |> put_req_header("accept", "application/vnd.api+json")
+      |> put_req_header("content-type", "application/vnd.api+json")
+
+    {:ok, conn: conn}
+  end
+
+  defp attributes do
+    %{}
+  end
+
+  defp relationships(user, role) do
+    %{
+      user: %{data: %{id: user.id}},
+      role: %{data: %{id: role.id}}
+    }
+  end
+
+  test "creates and renders resource when data is valid", %{conn: conn} do
+    user = insert_user(%{email: "test-user@mail.com"})
+    role = insert_role(%{title: "test-role"})
+
+    conn = post conn, user_role_path(conn, :create), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "user-role",
+        "attributes" => attributes,
+        "relationships" => relationships(user, role)
+      }
+    }
+
+    json = json_response(conn, 201)
+
+    id = json["data"]["id"] |> String.to_integer
+    user_role = UserRole |> Repo.get!(id)
+
+    assert json["data"]["id"] == "#{user_role.id}"
+    assert json["data"]["type"] == "user-role"
+    assert json["data"]["relationships"]["user"]["data"]["id"] == "#{user.id}"
+    assert json["data"]["relationships"]["role"]["data"]["id"] == "#{role.id}"
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, user_role_path(conn, :create), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "user-role",
+        "attributes" => attributes,
+      }
+    }
+
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "deletes resource", %{conn: conn} do
+    role = insert_role(%{title: "test-role"})
+    user = insert_user(%{email: "test-user@mail.com"})
+    user_role = insert_user_role(%{user_id: user.id, role_id: role.id})
+    response = delete conn, user_role_path(conn, :delete, user_role)
+
+    assert response.status == 204
+  end
+end

--- a/test/models/organization_test.exs
+++ b/test/models/organization_test.exs
@@ -16,6 +16,7 @@ defmodule CodeCorps.OrganizationTest do
     refute changeset.valid?
   end
 
+  @tag :requires_env
   test "uploads base64icon data to aws" do
     # 1x1 black pixel gif
     icon_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="

--- a/test/models/project_test.exs
+++ b/test/models/project_test.exs
@@ -39,6 +39,7 @@ defmodule CodeCorps.ProjectTest do
     refute changeset.valid?
   end
 
+  @tag :requires_env
   test "uploads base64icon data to aws" do
     # 1x1 black pixel gif
     icon_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="

--- a/test/models/user_role_test.exs
+++ b/test/models/user_role_test.exs
@@ -1,0 +1,57 @@
+defmodule CodeCorps.UserRoleTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.UserRole
+
+  test "valid_changeset_is_valid" do
+    user_id = insert_user().id
+    role_id = insert_role().id
+
+    changeset = UserRole.changeset(%UserRole{}, %{user_id: user_id, role_id: role_id})
+    assert changeset.valid?
+  end
+
+  test "changeset requires user_id" do
+    role_id = insert_role().id
+
+    changeset = UserRole.changeset(%UserRole{}, %{role_id: role_id})
+
+    refute changeset.valid?
+    assert changeset.errors[:user_id] == {"can't be blank", []}
+  end
+
+  test "changeset requires role_id" do
+    user_id = insert_user().id
+
+    changeset = UserRole.changeset(%UserRole{}, %{user_id: user_id})
+
+    refute changeset.valid?
+    assert changeset.errors[:role_id] == {"can't be blank", []}
+  end
+
+  test "changeset requires id of actual user" do
+    user_id = -1
+    role_id = insert_role().id
+
+    { result, changeset } =
+      UserRole.changeset(%UserRole{}, %{user_id: user_id, role_id: role_id})
+      |> Repo.insert
+
+    assert result == :error
+    refute changeset.valid?
+    assert changeset.errors[:user] == {"does not exist", []}
+  end
+
+  test "changeset requires id of actual role" do
+    user_id = insert_user().id
+    role_id = -1
+
+    { result, changeset } =
+      UserRole.changeset(%UserRole{}, %{user_id: user_id, role_id: role_id})
+      |> Repo.insert
+
+    assert result == :error
+    refute changeset.valid?
+    assert changeset.errors[:role] == {"does not exist", []}
+  end
+end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -98,6 +98,7 @@ defmodule CodeCorps.UserTest do
       refute Map.has_key?(changeset.changes, :website)
     end
 
+    @tag :requires_env
     test "uploads base64photo data to aws" do
       # 1x1 black pixel gif
       photo_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -10,6 +10,21 @@ defmodule CodeCorps.Factories do
     }
   end
 
+  def user_role_factory do
+    %CodeCorps.UserRole{
+      user: build(:user),
+      role: build(:role)
+    }
+  end
+
+  def role_factory do
+    %CodeCorps.Role{
+      name: sequence(:name, &"Role #{&1}"),
+      ability: sequence(:ability, &"Ability for role #{&1}"),
+      kind: sequence(:kind, &"Kind for role #{&1}")
+    }
+  end
+
   def organization_factory do
     %CodeCorps.Organization{
       name: sequence(:username, &"Organization #{&1}"),

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -5,6 +5,7 @@ defmodule CodeCorps.TestHelpers do
   alias CodeCorps.Project
   alias CodeCorps.Repo
   alias CodeCorps.Role
+  alias CodeCorps.UserRole
   alias CodeCorps.RoleSkill
   alias CodeCorps.Skill
   alias CodeCorps.User
@@ -62,6 +63,12 @@ defmodule CodeCorps.TestHelpers do
 
     %Project{}
     |> Project.changeset(changes)
+    |> Repo.insert!
+  end
+
+  def insert_user_role(attrs \\ %{}) do
+    %UserRole{}
+    |> UserRole.changeset(attrs)
     |> Repo.insert!
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,9 @@
 # Needs to be called before ExUnit.start
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 
+# By default, exclude S3 tests
+# To run S3 tests, run `mix test --include requires_env`
+ExUnit.configure exclude: [:requires_env]
 ExUnit.start
 
 Ecto.Adapters.SQL.Sandbox.mode(CodeCorps.Repo, :manual)

--- a/test/views/user_role_view_test.exs
+++ b/test/views/user_role_view_test.exs
@@ -1,0 +1,42 @@
+defmodule CodeCorps.UserRoleViewTest do
+  use CodeCorps.ConnCase, async: true
+
+  import CodeCorps.Factories
+
+  alias CodeCorps.Repo
+
+  # Bring render/3 and render_to_string/3 for testing custom views
+  import Phoenix.View
+
+  test "renders all attributes and relationships properly" do
+    db_user_role = insert(:user_role)
+
+    user_role =
+      CodeCorps.UserRole
+      |> Repo.get(db_user_role.id)
+      |> Repo.preload([:user, :role])
+
+    rendered_json = render(CodeCorps.UserRoleView, "show.json-api", data: user_role)
+
+    expected_json = %{
+      data: %{
+        id: user_role.id |> Integer.to_string,
+        type: "user-role",
+        attributes: %{},
+        relationships: %{
+          "role" => %{
+            data: %{id: user_role.role_id |> Integer.to_string, type: "role"}
+          },
+          "user" => %{
+            data: %{id: user_role.user_id |> Integer.to_string, type: "user"}
+          }
+        }
+      },
+      jsonapi: %{
+        version: "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+end

--- a/test/views/user_view_test.exs
+++ b/test/views/user_view_test.exs
@@ -1,0 +1,56 @@
+defmodule CodeCorps.UserViewTest do
+  use CodeCorps.ConnCase, async: true
+
+  import CodeCorps.Factories
+
+  alias CodeCorps.Repo
+
+  # Bring render/3 and render_to_string/3 for testing custom views
+  import Phoenix.View
+
+  test "renders all attributes and relationships properly" do
+    user_role = insert(:user_role)
+
+    user =
+      CodeCorps.User
+      |> Repo.get(user_role.user_id)
+      |> CodeCorps.Repo.preload([:slugged_route, :roles])
+
+    rendered_json =  render(CodeCorps.UserView, "show.json-api", data: user)
+
+    expected_json = %{
+      data: %{
+        id: user.id |> Integer.to_string,
+        type: "user",
+        attributes: %{
+          "username" => user.username,
+          "email" => user.email,
+          "photo-large-url" => CodeCorps.UserPhoto.url({user.photo, user}, :large),
+          "photo-thumb-url" => CodeCorps.UserPhoto.url({user.photo, user}, :thumb),
+          "inserted-at" => user.inserted_at,
+          "updated-at" => user.updated_at
+        },
+        relationships: %{
+          "roles" => %{
+            data: [
+              %{id: user_role.role_id |> Integer.to_string, type: "role"}
+            ]
+          },
+          "slugged-route" => %{
+            data: nil
+          },
+          "user-roles" => %{
+            data: [
+              %{id: user_role.id |> Integer.to_string, type: "user-role"}
+            ]
+          }
+        }
+      },
+      jsonapi: %{
+        version: "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -14,12 +14,12 @@ defmodule CodeCorps.UserController do
         %{"filter" => %{"id" => id_list}} ->
           ids = id_list |> coalesce_id_string
           User
-          |> preload([:slugged_route])
+          |> preload([:slugged_route, :roles])
           |> where([p], p.id in ^ids)
           |> Repo.all
         %{} ->
           User
-          |> preload([:slugged_route])
+          |> preload([:slugged_route, :roles])
           |> Repo.all
       end
 
@@ -31,7 +31,7 @@ defmodule CodeCorps.UserController do
 
     case Repo.insert(changeset) do
       {:ok, user} ->
-        user = Repo.preload(user, [:slugged_route])
+        user = Repo.preload(user, [:slugged_route, :roles])
 
         conn
         |> put_status(:created)
@@ -47,7 +47,7 @@ defmodule CodeCorps.UserController do
   def show(conn, %{"id" => id}) do
     user =
       User
-      |> preload([:slugged_route])
+      |> preload([:slugged_route, :roles])
       |> Repo.get!(id)
   render(conn, "show.json-api", data: user)
   end
@@ -55,7 +55,7 @@ defmodule CodeCorps.UserController do
   def update(conn, %{"id" => id, "data" => data = %{"type" => "user", "attributes" => _user_params}}) do
     user =
       User
-      |> preload([:slugged_route])
+      |> preload([:slugged_route, :roles])
       |> Repo.get!(id)
 
     changeset = User.update_changeset(user, Params.to_attributes(data))

--- a/web/controllers/user_role_controller.ex
+++ b/web/controllers/user_role_controller.ex
@@ -1,0 +1,26 @@
+defmodule CodeCorps.UserRoleController do
+  use CodeCorps.Web, :controller
+
+  alias CodeCorps.UserRole
+  alias JaSerializer.Params
+
+  def create(conn, %{"data" => data = %{"type" => "user-role"}}) do
+    changeset = UserRole.changeset(%UserRole{}, Params.to_attributes(data))
+
+    case Repo.insert(changeset) do
+      {:ok, user_role} ->
+        conn
+        |> put_status(:created)
+        |> render("show.json-api", data: user_role |> Repo.preload([:user, :role]))
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    UserRole |> Repo.get!(id) |> Repo.delete!
+    conn |> send_resp(:no_content, "")
+  end
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -28,6 +28,9 @@ defmodule CodeCorps.User do
 
     has_one :slugged_route, SluggedRoute
 
+    has_many :user_roles, CodeCorps.UserRole
+    has_many :roles, through: [:user_roles, :role]
+
     timestamps()
   end
 

--- a/web/models/user_role.ex
+++ b/web/models/user_role.ex
@@ -1,0 +1,22 @@
+defmodule CodeCorps.UserRole do
+  use CodeCorps.Web, :model
+
+  schema "user_roles" do
+    belongs_to :user, CodeCorps.User
+    belongs_to :role, CodeCorps.Role
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:user_id, :role_id])
+    |> validate_required([:user_id, :role_id])
+    |> assoc_constraint(:user)
+    |> assoc_constraint(:role)
+    |> unique_constraint(:user_id, name: :index_projects_on_user_id_role_id)
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -57,6 +57,7 @@ defmodule CodeCorps.Router do
     get "/users/username_available", UserController, :username_available
     resources "/users", UserController, only: [:index, :show, :create, :update]
 
+    resources "/user-roles", UserRoleController, only: [:create, :delete]
     resources "/user-skills", UserSkillController, only: [:index, :show, :create, :delete]
     resources "/role-skills", RoleSkillController, only: [:index, :show, :create, :delete]
 

--- a/web/views/user_role_view.ex
+++ b/web/views/user_role_view.ex
@@ -1,0 +1,7 @@
+defmodule CodeCorps.UserRoleView do
+  use CodeCorps.Web, :view
+  use JaSerializer.PhoenixView
+
+  has_one :user, serializer: CodeCorps.UserView
+  has_one :role, serializer: CodeCorps.RoleView
+end

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -6,6 +6,9 @@ defmodule CodeCorps.UserView do
 
   has_one :slugged_route, serializer: CodeCorps.SluggedRouteView
 
+  has_many :user_roles, serializer: CodeCorps.UserRoleView
+  has_many :roles, serializer: CodeCorps.RoleView
+
   def photo_large_url(user, _conn) do
     CodeCorps.UserPhoto.url({user.photo, user}, :large)
   end


### PR DESCRIPTION
Also added a tag to add to all endpoints that require interaction with AWS S3 that are ignored in tests by default.

To run all tests, including those which interface with S3, run `mix test --include s3`

Endpoint issue: #40
Contributes to #109 (exclude tests that rely on ENV vars)
