### PR TITLE
Add roles for organization membership

### DIFF
--- a/test/models/organization_membership_test.exs
+++ b/test/models/organization_membership_test.exs
@@ -59,4 +59,36 @@ defmodule CodeCorps.OrganizationMembershipTest do
       assert changeset.errors[:member] == {"does not exist", []}
     end
   end
+
+  describe "role validation" do
+    test "includes pending" do
+      attrs = Map.merge(@valid_attrs, %{role: "pending"})
+      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "includes contributor" do
+      attrs = Map.merge(@valid_attrs, %{role: "contributor"})
+      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "includes admin" do
+      attrs = Map.merge(@valid_attrs, %{role: "admin"})
+      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "includes owner" do
+      attrs = Map.merge(@valid_attrs, %{role: "owner"})
+      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "does not include invalid values" do
+      attrs = Map.merge(@valid_attrs, %{role: "invalid"})
+      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
+      refute changeset.valid?
+    end
+  end
 end

--- a/web/controllers/project_category_controller.ex
+++ b/web/controllers/project_category_controller.ex
@@ -1,8 +1,6 @@
 defmodule CodeCorps.ProjectCategoryController do
   use CodeCorps.Web, :controller
 
-  import CodeCorps.ControllerHelpers
-
   alias JaSerializer.Params
   alias CodeCorps.ProjectCategory
 

--- a/web/models/organization_membership.ex
+++ b/web/models/organization_membership.ex
@@ -18,12 +18,23 @@ defmodule CodeCorps.OrganizationMembership do
   end
 
   @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:role])
+    |> validate_required([:role])
+    |> validate_inclusion(:role, roles)
+  end
+
+  @doc """
   Builds a changeset based on the `struct` and `params`, for creating a record.
   """
   def create_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:member_id, :organization_id, :role])
-    |> validate_required([:member_id, :organization_id, :role])
+    |> changeset(params)
+    |> cast(params, [:member_id, :organization_id])
+    |> validate_required([:member_id, :organization_id])
     |> assoc_constraint(:member)
     |> assoc_constraint(:organization)
   end
@@ -33,8 +44,10 @@ defmodule CodeCorps.OrganizationMembership do
   """
   def update_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:role])
-    |> validate_required([:role])
+    |> changeset(params)
   end
 
+  defp roles do
+    ~w{ pending contributor admin owner }
+  end
 end


### PR DESCRIPTION
Part of #26.

This adds missing roles and role validation with tests.

Also minor removal of an unused `import` in an unrelated file that was bothering me.
