### PR TITLE
Added unique_constraint to Category slug and test

### DIFF
--- a/test/models/category_test.exs
+++ b/test/models/category_test.exs
@@ -6,24 +6,39 @@ defmodule CodeCorps.CategoryTest do
   @valid_attrs %{description: "You want to improve software tools and infrastructure.", name: "Technology", slug: "technology"}
   @invalid_attrs %{}
 
-  test "changeset with valid attributes" do
-    changeset = Category.changeset(%Category{}, @valid_attrs)
-    assert changeset.valid?
+  describe "changeset" do
+    test "with valid attributes" do
+      changeset = Category.changeset(%Category{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "with invalid attributes" do
+      changeset = Category.changeset(%Category{}, @invalid_attrs)
+      refute changeset.valid?
+    end
   end
 
-  test "changeset with invalid attributes" do
-    changeset = Category.changeset(%Category{}, @invalid_attrs)
-    refute changeset.valid?
+  describe "create_changeset" do
+    test "with valid attributes" do
+      changeset = Category.create_changeset(%Category{}, @valid_attrs)
+      assert changeset.valid?
+      assert changeset.changes.slug == "technology"
+    end
+
+    test "with invalid attributes" do
+      changeset = Category.create_changeset(%Category{}, @invalid_attrs)
+      refute changeset.valid?
+    end
+
+    test "does not allow duplicate slugs, regardless of case" do
+      category_1_attrs = %{name: "Technology", slug: "technology", description: "Description"}
+      category_2_attrs = %{name: "technology", slug: "TECHNOLOGY", description: "Description"}
+      insert_category(category_1_attrs)
+      changeset = Category.create_changeset(%Category{}, category_2_attrs)
+      {:error, changeset} = Repo.insert(changeset)
+      refute changeset.valid?
+      assert changeset.errors[:slug] == {"has already been taken", []}
+    end
   end
 
-  test "create changeset with valid attributes" do
-    changeset = Category.create_changeset(%Category{}, @valid_attrs)
-    assert changeset.valid?
-    assert changeset.changes.slug == "technology"
-  end
-
-  test "create changeset with invalid attributes" do
-    changeset = Category.create_changeset(%Category{}, @invalid_attrs)
-    refute changeset.valid?
-  end
 end

--- a/web/models/category.ex
+++ b/web/models/category.ex
@@ -35,5 +35,6 @@ defmodule CodeCorps.Category do
     |> changeset(params)
     |> generate_slug(:name, :slug)
     |> validate_required([:slug])
+    |> unique_constraint(:slug, name: :index_categories_on_slug)
   end
 end


### PR DESCRIPTION
Closes #127.

Adds `unique_constraint` to `Category` `slug` with a test; minor reordering of tests in `describe` blocks.
