### PR TITLE
Update icon URLs to not use relative paths

### DIFF
--- a/web/uploaders/organization_icon.ex
+++ b/web/uploaders/organization_icon.ex
@@ -35,7 +35,7 @@ defmodule CodeCorps.OrganizationIcon do
 
   # Provide a default URL if there hasn't been a file uploaded
   def default_url(version, _) do
-    "/icons/organization_default_#{version}.png"
+    "#{Application.get_env(:arc, :asset_host)}/icons/organization_default_#{version}.png"
   end
 
   # Specify custom headers for s3 objects

--- a/web/uploaders/project_icon.ex
+++ b/web/uploaders/project_icon.ex
@@ -35,7 +35,7 @@ defmodule CodeCorps.ProjectIcon do
 
   # Provide a default URL if there hasn't been a file uploaded
   def default_url(version, _) do
-    "/icons/project_default_#{version}.png"
+    "#{Application.get_env(:arc, :asset_host)}/icons/project_default_#{version}.png"
   end
 
   # Specify custom headers for s3 objects

--- a/web/uploaders/user_photo.ex
+++ b/web/uploaders/user_photo.ex
@@ -35,7 +35,7 @@ defmodule CodeCorps.UserPhoto do
 
   # Provide a default URL if there hasn't been a file uploaded
   def default_url(version, _) do
-    "/icons/user_default_#{version}.png"
+    "#{Application.get_env(:arc, :asset_host)}/icons/user_default_#{version}.png"
   end
 
   # Specify custom headers for s3 objects


### PR DESCRIPTION
This PR updates icon URLs to not use relative paths. Maybe could use regression tests, but probably not a huge deal.
