### PR TITLE
Add deserializer for JSON API requests

### DIFF
--- a/web/router.ex
+++ b/web/router.ex
@@ -13,6 +13,7 @@ defmodule CodeCorps.Router do
     plug :accepts, ["json-api", "json"]
     plug Guardian.Plug.VerifyHeader
     plug Guardian.Plug.LoadResource
+    plug JaSerializer.Deserializer
   end
 
   scope "/", CodeCorps do


### PR DESCRIPTION
Very simple.

This adds deserialization to take something like `first-name` in the JSON attributes hash keys and turn it into `first_name` for use in Phoenix itself.

Not sure how to test, or if it's really necessary right now.
