### PR TITLE
Add role skills, tests for role, skill, role skill view

### DIFF
--- a/test/views/category_view_test.exs
+++ b/test/views/category_view_test.exs
@@ -1,8 +1,6 @@
 defmodule CodeCorps.CategoryViewTest do
   use CodeCorps.ConnCase, async: true
 
-  import CodeCorps.Factories
-
   alias CodeCorps.Repo
 
   # Bring render/3 and render_to_string/3 for testing custom views

--- a/test/views/organization_membership_view_test.exs
+++ b/test/views/organization_membership_view_test.exs
@@ -1,8 +1,6 @@
 defmodule CodeCorps.OrganizationMembershipViewTest do
   use CodeCorps.ConnCase, async: true
 
-  import CodeCorps.Factories
-
   alias CodeCorps.Repo
 
   # Bring render/3 and render_to_string/3 for testing custom views

--- a/test/views/organization_view_test.exs
+++ b/test/views/organization_view_test.exs
@@ -1,8 +1,6 @@
 defmodule CodeCorps.OrganizationViewTest do
   use CodeCorps.ConnCase, async: true
 
-  import CodeCorps.Factories
-
   alias CodeCorps.Repo
 
   # Bring render/3 and render_to_string/3 for testing custom views

--- a/test/views/project_view_test.exs
+++ b/test/views/project_view_test.exs
@@ -1,8 +1,6 @@
 defmodule CodeCorps.ProjectViewTest do
   use CodeCorps.ConnCase, async: true
 
-  import CodeCorps.Factories
-
   alias CodeCorps.Repo
 
   # Bring render/3 and render_to_string/3 for testing custom views

--- a/test/views/role_skill_view_test.exs
+++ b/test/views/role_skill_view_test.exs
@@ -1,0 +1,40 @@
+defmodule CodeCorps.RoleSkillViewTest do
+  use CodeCorps.ConnCase, async: true
+
+  alias CodeCorps.Repo
+
+  # Bring render/3 and render_to_string/3 for testing custom views
+  import Phoenix.View
+
+  test "renders all attributes and relationships properly" do
+    role_skill = insert(:role_skill)
+
+    role_skill =
+      CodeCorps.RoleSkill
+      |> Repo.get(role_skill.id)
+      |> Repo.preload([:role, :skill])
+
+    rendered_json = render(CodeCorps.RoleSkillView, "show.json-api", data: role_skill)
+
+    expected_json = %{
+      data: %{
+        id: role_skill.id |> Integer.to_string,
+        type: "role-skill",
+        attributes: %{},
+        relationships: %{
+          "skill" => %{
+            data: %{id: role_skill.skill_id |> Integer.to_string, type: "skill"}
+          },
+          "role" => %{
+            data: %{id: role_skill.role_id |> Integer.to_string, type: "role"}
+          }
+        }
+      },
+      jsonapi: %{
+        version: "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+end

--- a/test/views/role_view_test.exs
+++ b/test/views/role_view_test.exs
@@ -1,0 +1,52 @@
+defmodule CodeCorps.RoleViewTest do
+  use CodeCorps.ConnCase, async: true
+
+  alias CodeCorps.Repo
+
+  # Bring render/3 and render_to_string/3 for testing custom views
+  import Phoenix.View
+
+  test "renders all attributes and relationships properly" do
+    role = insert(:role)
+    skill = insert(:skill)
+    role_skill = insert(:role_skill, role: role, skill: skill)
+
+    role =
+      CodeCorps.Role
+      |> Repo.get(role.id)
+      |> Repo.preload([:skills])
+
+    rendered_json =  render(CodeCorps.RoleView, "show.json-api", data: role)
+
+    expected_json = %{
+      data: %{
+        attributes: %{
+          "ability" => role.ability,
+          "inserted-at" => role.inserted_at,
+          "kind" => role.kind,
+          "name" => role.name,
+          "updated-at" => role.updated_at,
+        },
+        id: role.id |> Integer.to_string,
+        relationships: %{
+          "role-skills" => %{
+            data: [
+              %{id: role_skill.id |> Integer.to_string, type: "role-skill"}
+            ]
+          },
+          "skills" => %{
+            data: [
+              %{id: skill.id |> Integer.to_string, type: "skill"}
+            ]
+          }
+        },
+        type: "role",
+      },
+      jsonapi: %{
+        version: "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+end

--- a/test/views/skill_view_test.exs
+++ b/test/views/skill_view_test.exs
@@ -1,0 +1,53 @@
+defmodule CodeCorps.SkillViewTest do
+  use CodeCorps.ConnCase, async: true
+
+  import CodeCorps.Factories
+
+  alias CodeCorps.Repo
+
+  # Bring render/3 and render_to_string/3 for testing custom views
+  import Phoenix.View
+
+  test "renders all attributes and relationships properly" do
+    skill = insert(:skill)
+    role = insert(:role)
+    role_skill = insert(:role_skill, role: role, skill: skill)
+
+    skill =
+      CodeCorps.Skill
+      |> Repo.get(skill.id)
+      |> Repo.preload([:roles])
+
+    rendered_json =  render(CodeCorps.SkillView, "show.json-api", data: skill)
+
+    expected_json = %{
+      data: %{
+        attributes: %{
+          "description" => skill.description,
+          "inserted-at" => skill.inserted_at,
+          "title" => skill.title,
+          "updated-at" => skill.updated_at,
+        },
+        id: skill.id |> Integer.to_string,
+        relationships: %{
+          "role-skills" => %{
+            data: [
+              %{id: role_skill.id |> Integer.to_string, type: "role-skill"}
+            ]
+          },
+          "roles" => %{
+            data: [
+              %{id: role.id |> Integer.to_string, type: "role"}
+            ]
+          }
+        },
+        type: "skill",
+      },
+      jsonapi: %{
+        version: "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+end

--- a/test/views/user_category_view_test.exs
+++ b/test/views/user_category_view_test.exs
@@ -1,8 +1,6 @@
 defmodule CodeCorps.UserCategoryViewTest do
   use CodeCorps.ConnCase, async: true
 
-  import CodeCorps.Factories
-
   alias CodeCorps.Repo
 
   # Bring render/3 and render_to_string/3 for testing custom views

--- a/test/views/user_role_view_test.exs
+++ b/test/views/user_role_view_test.exs
@@ -1,8 +1,6 @@
 defmodule CodeCorps.UserRoleViewTest do
   use CodeCorps.ConnCase, async: true
 
-  import CodeCorps.Factories
-
   alias CodeCorps.Repo
 
   # Bring render/3 and render_to_string/3 for testing custom views

--- a/test/views/user_skill_view_test.exs
+++ b/test/views/user_skill_view_test.exs
@@ -1,8 +1,6 @@
 defmodule CodeCorps.UserSkillViewTest do
   use CodeCorps.ConnCase, async: true
 
-  import CodeCorps.Factories
-
   alias CodeCorps.Repo
 
   # Bring render/3 and render_to_string/3 for testing custom views

--- a/test/views/user_view_test.exs
+++ b/test/views/user_view_test.exs
@@ -1,8 +1,6 @@
 defmodule CodeCorps.UserViewTest do
   use CodeCorps.ConnCase, async: true
 
-  import CodeCorps.Factories
-
   alias CodeCorps.Repo
 
   # Bring render/3 and render_to_string/3 for testing custom views

--- a/web/controllers/role_controller.ex
+++ b/web/controllers/role_controller.ex
@@ -7,7 +7,10 @@ defmodule CodeCorps.RoleController do
   plug :scrub_params, "data" when action in [:create]
 
   def index(conn, _params) do
-    roles = Repo.all(Role)
+    roles =
+      Role
+      |> Repo.all
+      |> Repo.preload([:skills])
     render(conn, "index.json-api", data: roles)
   end
 
@@ -16,6 +19,8 @@ defmodule CodeCorps.RoleController do
 
     case Repo.insert(changeset) do
       {:ok, role} ->
+        role = Repo.preload(role, [:skills])
+
         conn
         |> put_status(:created)
         |> put_resp_header("location", role_path(conn, :show, role))

--- a/web/controllers/skill_controller.ex
+++ b/web/controllers/skill_controller.ex
@@ -11,6 +11,7 @@ defmodule CodeCorps.SkillController do
       Skill
       |> Skill.index_filters(params)
       |> Repo.all
+      |> Repo.preload([:roles])
 
     render(conn, "index.json-api", data: skills)
   end
@@ -20,6 +21,8 @@ defmodule CodeCorps.SkillController do
 
     case Repo.insert(changeset) do
       {:ok, skill} ->
+        skill = Repo.preload(skill, [:roles])
+
         conn
         |> put_status(:created)
         |> put_resp_header("location", skill_path(conn, :show, skill))
@@ -32,7 +35,10 @@ defmodule CodeCorps.SkillController do
   end
 
   def show(conn, %{"id" => id}) do
-    skill = Repo.get!(Skill, id)
+    skill =
+      Skill
+      |> Repo.get!(id)
+      |> Repo.preload([:roles])
     render(conn, "show.json-api", data: skill)
   end
 end

--- a/web/models/role.ex
+++ b/web/models/role.ex
@@ -6,6 +6,9 @@ defmodule CodeCorps.Role do
     field :ability, :string
     field :kind, :string
 
+    has_many :role_skills, CodeCorps.RoleSkill
+    has_many :skills, through: [:role_skills, :skill]
+
     timestamps()
   end
 

--- a/web/models/skill.ex
+++ b/web/models/skill.ex
@@ -8,6 +8,9 @@ defmodule CodeCorps.Skill do
     field :description, :string
     field :original_row, :integer
 
+    has_many :role_skills, CodeCorps.RoleSkill
+    has_many :roles, through: [:role_skills, :role]
+
     timestamps()
   end
 

--- a/web/views/role_view.ex
+++ b/web/views/role_view.ex
@@ -3,4 +3,7 @@ defmodule CodeCorps.RoleView do
   use JaSerializer.PhoenixView
 
   attributes [:name, :ability, :kind, :inserted_at, :updated_at]
+
+  has_many :role_skills, serializer: CodeCorps.RoleSkillView
+  has_many :skills, serializer: CodeCorps.SkillView
 end

--- a/web/views/skill_view.ex
+++ b/web/views/skill_view.ex
@@ -3,4 +3,7 @@ defmodule CodeCorps.SkillView do
   use JaSerializer.PhoenixView
 
   attributes [:title, :description, :inserted_at, :updated_at]
+
+  has_many :role_skills, serializer: CodeCorps.RoleSkillView
+  has_many :roles, serializer: CodeCorps.RoleView
 end


### PR DESCRIPTION
Closes #111.

Adds `has_many` and `belongs_to` for `RoleSkill`, `Role`, and `Skill` to set up relationships. Also adds view tests to be sure they're working appropriately.

Removes some unnecessary calls to `import CodeCorps.Factories` already imported by `ConnCase`.
