### PR TITLE
Spike canary

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,6 +38,10 @@ config :guardian, Guardian,
   secret_key: System.get_env("GUARDIAN_SECRET_KEY"),
   serializer: CodeCorps.GuardianSerializer
 
+config :canary, repo: CodeCorps.Repo
+config :canary, unauthorized_handler: {CodeCorps.AuthenticationHelpers, :handle_unauthorized}
+config :canary, not_found_handler: {CodeCorps.AuthenticationHelpers, :handle_not_found}
+
 # Configures ex_aws with credentials
 config :ex_aws,
   access_key_id: [System.get_env("AWS_ACCESS_KEY_ID"), :instance_role],

--- a/mix.exs
+++ b/mix.exs
@@ -69,6 +69,7 @@ defmodule CodeCorps.Mixfile do
       {:ex_aws, "~> 0.4.10"}, # Amazon AWS
       {:httpoison, "~> 0.7"},
       {:poison, "~> 1.2"},
+      {:canary, "~> 0.14.2"}, # Authorization
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,8 @@
   "arc_ecto": {:hex, :arc_ecto, "0.4.3", "f4383780f7bacee22e700a92783b562b5ec9f65a828c48b0daed7389eb441e13", [:mix], [{:arc, "~> 0.5.3", [hex: :arc, optional: false]}, {:ecto, "~> 2.0", [hex: :ecto, optional: false]}]},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], []},
   "bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
+  "canada": {:hex, :canada, "1.0.1", "da96d0ff101a0c2a6cc7b07d92b8884ff6508f058781d3679999416feacf41c5", [:mix], []},
+  "canary": {:hex, :canary, "0.14.2", "fa5f66db9d35a19ead19364a28d790bdc28f3cfb449978fa4e2c88f0d1c9d161", [:mix], [{:canada, "~> 1.0.0", [hex: :canada, optional: false]}, {:ecto, ">= 1.1.0", [hex: :ecto, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "comeonin": {:hex, :comeonin, "2.5.2", "bbad773af30a7632a63053014d5cfebf6df2c1ad114167b4db02f05b5c60901b", [:mix, :make, :make], []},
   "connection": {:hex, :connection, "1.0.3", "3145f7416be3df248a4935f24e3221dc467c1e3a158d62015b35bd54da365786", [:mix], []},

--- a/priv/repo/migrations/20160830081224_add_admin_to_user.exs
+++ b/priv/repo/migrations/20160830081224_add_admin_to_user.exs
@@ -1,0 +1,9 @@
+defmodule CodeCorps.Repo.Migrations.AddAdminToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :admin, :boolean, null: false, default: false
+    end
+  end
+end

--- a/test/controllers/category_controller_test.exs
+++ b/test/controllers/category_controller_test.exs
@@ -1,19 +1,10 @@
 defmodule CodeCorps.CategoryControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.Category
 
   @valid_attrs %{description: "You want to improve software tools and infrastructure.", name: "Technology"}
   @invalid_attrs %{name: nil}
-
-  setup do
-    conn =
-      %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
-
-    {:ok, conn: conn}
-  end
 
   defp build_payload(id, attributes, relationships \\ %{}) do
     build_payload(attributes)
@@ -30,52 +21,86 @@ defmodule CodeCorps.CategoryControllerTest do
     assert json_response(conn, 200)["data"] == []
   end
 
-  test "shows chosen resource", %{conn: conn} do
-    category = insert(:category)
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      category = insert(:category)
 
-    path = conn |> category_path(:show, category)
-    data = conn |> get(path) |> json_response(200) |> Map.get("data")
+      path = conn |> category_path(:show, category)
+      data = conn |> get(path) |> json_response(200) |> Map.get("data")
 
-    assert data["id"] == category.id |> Integer.to_string
-    assert data["type"] == "category"
+      assert data["id"] == category.id |> Integer.to_string
+      assert data["type"] == "category"
 
-    assert data["attributes"]["name"] == category.name
-    assert data["attributes"]["slug"] == category.slug
-    assert data["attributes"]["description"] == category.description
-  end
+      assert data["attributes"]["name"] == category.name
+      assert data["attributes"]["slug"] == category.slug
+      assert data["attributes"]["description"] == category.description
+    end
 
-  test "renders page not found when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, category_path(conn, :show, -1)
+    test "renders page not found when id is nonexistent", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get conn, category_path(conn, :show, -1)
+      end
     end
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    conn = post conn, category_path(conn, :create), build_payload(@valid_attrs)
-    response = json_response(conn, 201)
+  describe "create" do
+    @tag authenticated: :admin
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      conn = post conn, category_path(conn, :create), build_payload(@valid_attrs)
+      response = json_response(conn, 201)
 
-    assert response["data"]["id"]
-    assert response["data"]["attributes"]["slug"] == "technology"
-    assert Repo.get_by(Category, @valid_attrs)
+      assert response["data"]["id"]
+      assert response["data"]["attributes"]["slug"] == "technology"
+      assert Repo.get_by(Category, @valid_attrs)
+    end
+
+    @tag authenticated: :admin
+    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+      conn = post conn, category_path(conn, :create), build_payload(@invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "does not create resource and renders 401 when not authenticated", %{conn: conn} do
+      conn = post conn, category_path(conn, :create), build_payload(@valid_attrs)
+      assert json_response(conn, 401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      conn = post conn, category_path(conn, :create), build_payload(@valid_attrs)
+      assert json_response(conn, 401)
+    end
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, category_path(conn, :create), build_payload(@invalid_attrs)
-    assert json_response(conn, 422)["errors"] != %{}
-  end
+  describe "update" do
+    @tag authenticated: :admin
+    test "updates and renders chosen resource when data is valid", %{conn: conn} do
+      category = insert(:category)
+      updated_attrs = %{@valid_attrs | description: "New Description"}
+      conn = put conn, category_path(conn, :update, category), build_payload(category.id, updated_attrs)
 
-  test "updates and renders chosen resource when data is valid", %{conn: conn} do
-    category = insert(:category)
-    updated_attrs = %{@valid_attrs | description: "New Description"}
-    conn = put conn, category_path(conn, :update, category), build_payload(category.id, updated_attrs)
+      assert json_response(conn, 200)["data"]["id"] == "#{category.id}"
+      assert Repo.get_by(Category, updated_attrs)
+    end
 
-    assert json_response(conn, 200)["data"]["id"] == "#{category.id}"
-    assert Repo.get_by(Category, updated_attrs)
-  end
+    @tag authenticated: :admin
+    test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+      category = insert(:category)
+      conn = put conn, category_path(conn, :update, category), build_payload(category.id, @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
 
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    category = insert(:category)
-    conn = put conn, category_path(conn, :update, category), build_payload(category.id, @invalid_attrs)
-    assert json_response(conn, 422)["errors"] != %{}
+    test "does not update resource and renders 401 when not authenticated", %{conn: conn} do
+      category = insert(:category)
+      conn = put conn, category_path(conn, :update, category), build_payload(category.id, @invalid_attrs)
+      assert json_response(conn, 401)
+    end
+
+    @tag :authenticated
+    test "does not update resource and renders 401 when not authorized", %{conn: conn} do
+      category = insert(:category)
+      conn = put conn, category_path(conn, :update, category), build_payload(category.id, @invalid_attrs)
+      assert json_response(conn, 401)
+    end
   end
 end

--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule CodeCorps.CommentControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.Comment
   alias CodeCorps.Repo
@@ -7,16 +7,15 @@ defmodule CodeCorps.CommentControllerTest do
   @valid_attrs %{markdown: "I love elixir!"}
   @invalid_attrs %{markdown: ""}
 
-  setup do
-    conn =
-      %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
-
-    {:ok, conn: conn}
+  defp build_payload, do: %{ "data" => %{"type" => "comment"}}
+  defp put_id(payload, id), do: payload |> put_in(["data", "id"], id)
+  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
+  defp put_relationships(payload, user, post) do
+    relationships = build_relationships(user, post)
+    payload |> put_in(["data", "relationships"], relationships)
   end
 
-  defp relationships(user, post) do
+  defp build_relationships(user, post) do
     %{
       user: %{data: %{id: user.id}},
       post: %{data: %{id: post.id}}
@@ -24,92 +23,138 @@ defmodule CodeCorps.CommentControllerTest do
   end
 
   test "lists all entries on index", %{conn: conn} do
-    conn = get conn, comment_path(conn, :index)
+    path = conn |> comment_path(:index)
+    conn = conn |> get(path)
     assert json_response(conn, 200)["data"] == []
   end
 
-  test "shows chosen resource", %{conn: conn} do
-    user = insert(:user)
-    project = insert(:project)
-    post = insert(:post, project: project, user: user)
-    comment = insert(:comment, post: post, user: user)
-    conn = get conn, comment_path(conn, :show, comment)
-    data = json_response(conn, 200)["data"]
-    assert data["id"] == "#{comment.id}"
-    assert data["type"] == "comment"
-    assert data["attributes"]["body"] == comment.body
-    assert data["attributes"]["markdown"] == comment.markdown
-    assert data["relationships"]["user"]["data"]["id"] == "#{comment.user_id}"
-    assert data["relationships"]["post"]["data"]["id"] == "#{comment.post_id}"
-  end
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      comment = insert(:comment)
 
-  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, comment_path(conn, :show, -1)
+      path = conn |> comment_path(:show, comment)
+      conn = conn |> get(path)
+
+      data = json_response(conn, 200)["data"]
+
+      assert data["id"] == "#{comment.id}"
+      assert data["type"] == "comment"
+      assert data["attributes"]["body"] == comment.body
+      assert data["attributes"]["markdown"] == comment.markdown
+      assert data["relationships"]["user"]["data"]["id"] == "#{comment.user_id}"
+      assert data["relationships"]["post"]["data"]["id"] == "#{comment.post_id}"
+    end
+
+    test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get conn, comment_path(conn, :show, -1)
+      end
     end
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    user = insert(:user)
-    project = insert(:project)
-    post = insert(:post, project: project, user: user)
-    conn = post conn, comment_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "comment",
-        "attributes" => @valid_attrs,
-        "relationships" => relationships(user, post)
-      }
-    }
+  describe "create" do
+    @tag :authenticated
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      user = insert(:user)
+      post = insert(:post, user: user)
 
-    assert json_response(conn, 201)["data"]["id"]
-    assert Repo.get_by(Comment, @valid_attrs)
+      payload =
+        build_payload
+        |> put_attributes(@valid_attrs)
+        |> put_relationships(user, post)
+
+      path = conn |> comment_path(:create)
+      conn = conn |> post(path, payload)
+
+      assert json_response(conn, 201)["data"]["id"]
+      assert Repo.get_by(Comment, @valid_attrs)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+      payload = build_payload |> put_attributes(@invalid_attrs)
+
+      path = conn |> comment_path(:create)
+      conn = conn |> post(path, payload)
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "does not create resource and renders 401 when not authenticated", %{conn: conn} do
+      user = insert(:user)
+      post = insert(:post, user: user)
+
+      payload =
+        build_payload
+        |> put_attributes(@valid_attrs)
+        |> put_relationships(user, post)
+
+      path = conn |> comment_path(:create)
+      conn = conn |> post(path, payload)
+
+      assert json_response(conn, 401)
+    end
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, comment_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "comment",
-        "attributes" => @invalid_attrs,
-      }
-    }
+  describe "update" do
+    @tag :authenticated
+    test "updates and renders chosen resource when data is valid", %{conn: conn, current_user: current_user} do
+      comment = insert(:comment, user: current_user)
 
-    assert json_response(conn, 422)["errors"] != %{}
-  end
+      payload =
+        build_payload
+        |> put_id(comment.id)
+        |> put_attributes(@valid_attrs)
 
-  test "updates and renders chosen resource when data is valid", %{conn: conn} do
-    user = insert(:user)
-    project = insert(:project)
-    post = insert(:post, project: project, user: user)
-    comment = insert(:comment, post: post, user: user)
-    conn = put conn, comment_path(conn, :update, comment), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "comment",
-        "id" => comment.id,
-        "attributes" => @valid_attrs,
-      }
-    }
+      path = conn |> comment_path(:update, comment)
+      conn = conn |> put(path, payload)
 
-    assert json_response(conn, 200)["data"]["id"]
-    assert Repo.get_by(Comment, @valid_attrs)
-  end
+      assert json_response(conn, 200)["data"]["id"]
+      assert Repo.get_by(Comment, @valid_attrs)
+    end
 
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    user = insert(:user)
-    project = insert(:project)
-    post = insert(:post, project: project, user: user)
-    comment = insert(:comment, post: post, user: user)
-    conn = put conn, comment_path(conn, :update, comment), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "comment",
-        "id" => comment.id,
-        "attributes" => @invalid_attrs,
-      }
-    }
+    @tag :authenticated
+    test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, current_user: current_user} do
+      comment = insert(:comment, user: current_user)
 
-    assert json_response(conn, 422)["errors"] != %{}
+      payload =
+        build_payload
+        |> put_id(comment.id)
+        |> put_attributes(@invalid_attrs)
+
+      path = conn |> comment_path(:update, comment)
+      conn = conn |> put(path, payload)
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "does not update resource and renders 401 when not authenticated", %{conn: conn} do
+      comment = insert(:comment)
+
+      payload =
+        build_payload
+        |> put_id(comment.id)
+        |> put_attributes(@valid_attrs)
+
+      path = conn |> comment_path(:update, comment)
+      conn = conn |> put(path, payload)
+
+      assert json_response(conn, 401)
+    end
+
+    @tag :authenticated
+    test "does not update resource and renders 401 when not authorized", %{conn: conn} do
+      comment = insert(:comment)
+
+      payload =
+        build_payload
+        |> put_id(comment.id)
+        |> put_attributes(@valid_attrs)
+
+      path = conn |> comment_path(:update, comment)
+      conn = conn |> put(path, payload)
+
+      assert json_response(conn, 401)
+    end
   end
 end

--- a/test/controllers/organization_controller_test.exs
+++ b/test/controllers/organization_controller_test.exs
@@ -1,144 +1,209 @@
 defmodule CodeCorps.OrganizationControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.Organization
   alias CodeCorps.Repo
   alias CodeCorps.SluggedRoute
 
   @valid_attrs %{description: "Build a better future.", name: "Code Corps"}
-  @invalid_attrs %{}
+  @invalid_attrs %{name: ""}
 
-  setup do
-    conn =
-      %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
+  defp build_payload, do: %{ "data" => %{"type" => "organization"}}
+  defp put_id(payload, id), do: payload |> put_in(["data", "id"], id)
+  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
 
-    {:ok, conn: conn}
-  end
+  describe "index" do
+    test "lists all entries on index", %{conn: conn} do
+      path = conn |> organization_path(:index)
+      conn = conn |> get(path)
 
-  defp relationships do
-    %{}
-  end
+      assert json_response(conn, 200)["data"] == []
+    end
 
-  test "lists all entries on index", %{conn: conn} do
-    conn = get conn, organization_path(conn, :index)
-    assert json_response(conn, 200)["data"] == []
-  end
+    test "filters resources on index", %{conn: conn} do
+      first_org = insert(:organization, name: "Org A")
+      second_org = insert(:organization, name: "Org B")
+      insert(:organization, name: "Org C")
 
-  test "filters resources on index", %{conn: conn} do
-    first_org = insert(:organization, name: "Org A")
-    second_org = insert(:organization, name: "Org B")
-    insert(:organization, name: "Org C")
-    conn = get conn, "organizations/?filter[id]=#{first_org.id},#{second_org.id}"
-    data = json_response(conn, 200)["data"]
-    [first_result, second_result | _] = data
-    assert length(data) == 2
-    assert first_result["id"] == "#{first_org.id}"
-    assert second_result["id"] == "#{second_org.id}"
-  end
+      path = "organizations/?filter[id]=#{first_org.id},#{second_org.id}"
+      conn = conn |> get(path)
 
-  test "shows chosen resource", %{conn: conn} do
-    organization = Repo.insert! %Organization{}
-    conn = get conn, organization_path(conn, :show, organization)
-    data = json_response(conn, 200)["data"]
-    assert data["id"] == "#{organization.id}"
-    assert data["type"] == "organization"
-    assert data["attributes"]["name"] == organization.name
-    assert data["attributes"]["description"] == organization.description
-    assert data["attributes"]["slug"] == organization.slug
-  end
+      data = json_response(conn, 200)["data"]
 
-  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, user_path(conn, :show, -1)
+      [first_result, second_result | _] = data
+      assert length(data) == 2
+      assert first_result["id"] == "#{first_org.id}"
+      assert second_result["id"] == "#{second_org.id}"
     end
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    conn = post conn, organization_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "organization",
-        "attributes" => @valid_attrs,
-        "relationships" => relationships
-      }
-    }
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      organization = insert(:organization)
 
-    organization_id = json_response(conn, 201)["data"]["id"]
-    assert organization_id
-    organization = Repo.get_by(Organization, @valid_attrs)
-    assert organization
-    slugged_route = Repo.get_by(SluggedRoute, slug: "code-corps")
-    assert slugged_route
-    assert organization.id == slugged_route.organization_id
+      path = conn |> organization_path(:show, organization)
+      conn = conn |> get(path)
+
+      data = json_response(conn, 200)["data"]
+
+      assert data["id"] == "#{organization.id}"
+      assert data["type"] == "organization"
+      assert data["attributes"]["name"] == organization.name
+      assert data["attributes"]["description"] == organization.description
+      assert data["attributes"]["slug"] == organization.slug
+    end
+
+    test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        path = conn |> organization_path(:show, -1)
+        conn |> get(path)
+      end
+    end
   end
 
-  @tag :requires_env
-  test "uploads a icon to S3", %{conn: conn} do
-    organization = insert(:organization)
-    icon_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="
-    attrs = Map.put(@valid_attrs, :base64_icon_data, icon_data)
-    conn = put conn, organization_path(conn, :update, organization), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "organization",
-        "id" => organization.id,
-        "attributes" => attrs
-      }
-    }
+  describe "create" do
+    @tag authenticated: :admin
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      payload =
+        build_payload
+        |> put_attributes(@valid_attrs)
 
-    data = json_response(conn, 200)["data"]
-    large_url = data["attributes"]["icon-large-url"]
-    assert large_url
-    assert String.contains? large_url, "/organizations/#{organization.id}/large"
-    thumb_url = data["attributes"]["icon-thumb-url"]
-    assert thumb_url
-    assert String.contains? thumb_url, "/organizations/#{organization.id}/thumb"
+      path = conn |> organization_path(:create)
+      conn = conn |> post(path, payload)
+
+      organization_id = json_response(conn, 201)["data"]["id"]
+      assert organization_id
+      organization = Repo.get_by(Organization, @valid_attrs)
+      assert organization
+      slugged_route = Repo.get_by(SluggedRoute, slug: "code-corps")
+      assert slugged_route
+      assert organization.id == slugged_route.organization_id
+    end
+
+    @tag authenticated: :admin
+    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+      payload =
+        build_payload
+        |> put_attributes(@invalid_attrs)
+
+      path = conn |> organization_path(:create)
+      conn = conn |> post(path, payload)
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "does not create resource and renders 401 when not authenticated", %{conn: conn} do
+      payload =
+        build_payload
+        |> put_attributes(@invalid_attrs)
+
+      path = conn |> organization_path(:create)
+      conn = conn |> post(path, payload)
+
+      assert json_response(conn, 401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      payload =
+        build_payload
+        |> put_attributes(@invalid_attrs)
+
+      path = conn |> organization_path(:create)
+      conn = conn |> post(path, payload)
+
+      assert json_response(conn, 401)
+    end
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, organization_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "organization",
-        "attributes" => @invalid_attrs,
-        "relationships" => relationships
-      }
-    }
+  describe "update" do
+    @tag :authenticated
+    test "updates and renders chosen resource when data is valid", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      insert(:organization_membership, organization: organization, member: current_user, role: "admin")
 
-    assert json_response(conn, 422)["errors"] != %{}
+      payload =
+        build_payload
+        |> put_id(organization)
+        |> put_attributes(@valid_attrs)
+
+      path = conn |> organization_path(:update, organization)
+      conn = conn |> put(path, payload)
+
+      assert json_response(conn, 200)["data"]["id"]
+      assert Repo.get_by(Organization, @valid_attrs)
+    end
+
+    @tag :authenticated
+    test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      insert(:organization_membership, organization: organization, member: current_user, role: "admin")
+
+      payload =
+        build_payload
+        |> put_id(organization)
+        |> put_attributes(@invalid_attrs)
+
+      path = conn |> organization_path(:update, organization)
+      conn = conn |> put(path, payload)
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "does not update resource and renders 401 when not authenticated", %{conn: conn} do
+      organization = insert(:organization)
+
+      payload =
+        build_payload
+        |> put_id(organization)
+        |> put_attributes(@invalid_attrs)
+
+      path = conn |> organization_path(:update, organization)
+      conn = conn |> put(path, payload)
+
+      assert json_response(conn, 401)
+    end
+
+    @tag :authenticated
+    test "does not update resource and renders 401 when not authorized", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      insert(:organization_membership, organization: organization, member: current_user, role: "member")
+
+      payload =
+        build_payload
+        |> put_id(organization)
+        |> put_attributes(@invalid_attrs)
+
+      path = conn |> organization_path(:update, organization)
+      conn = conn |> put(path, payload)
+
+      assert json_response(conn, 401)
+    end
+
+    @tag :requires_env
+    @tag :authenticated
+    test "uploads a icon to S3", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      insert(:organization_membership, organization: organization, member: current_user, role: "admin")
+
+      icon_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="
+      attrs = Map.put(@valid_attrs, :base64_icon_data, icon_data)
+
+      payload =
+        build_payload
+        |> put_id(organization)
+        |> put_attributes(attrs)
+
+      path = conn |> organization_path(:update, organization)
+      conn = conn |> put(path, payload)
+
+      data = json_response(conn, 200)["data"]
+      large_url = data["attributes"]["icon-large-url"]
+      assert large_url
+      assert String.contains? large_url, "/organizations/#{organization.id}/large"
+      thumb_url = data["attributes"]["icon-thumb-url"]
+      assert thumb_url
+      assert String.contains? thumb_url, "/organizations/#{organization.id}/thumb"
+    end
   end
-
-  test "updates and renders chosen resource when data is valid", %{conn: conn} do
-    organization = Repo.insert! %Organization{}
-    conn = put conn, organization_path(conn, :update, organization), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "organization",
-        "id" => organization.id,
-        "attributes" => @valid_attrs,
-        "relationships" => relationships
-      }
-    }
-
-    assert json_response(conn, 200)["data"]["id"]
-    assert Repo.get_by(Organization, @valid_attrs)
-  end
-
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    organization = Repo.insert! %Organization{}
-    conn = put conn, organization_path(conn, :update, organization), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "organization",
-        "id" => organization.id,
-        "attributes" => @invalid_attrs,
-        "relationships" => relationships
-      }
-    }
-
-    assert json_response(conn, 422)["errors"] != %{}
-  end
-
 end

--- a/test/controllers/organization_memberships_controller_test.exs
+++ b/test/controllers/organization_memberships_controller_test.exs
@@ -1,17 +1,26 @@
 defmodule CodeCorps.OrganizationMembershipControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.OrganizationMembership
   alias CodeCorps.Organization
   alias CodeCorps.User
 
-  setup do
-    conn =
-      %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
+  @valid_attrs %{role: "admin"}
+  @invalid_attrs %{role: "invalid_role"}
 
-    {:ok, conn: conn}
+  defp build_payload, do: %{ "data" => %{"type" => "organization-membership"}}
+  defp put_id(payload, id), do: payload |> put_in(["data", "id"], id)
+  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
+  defp put_relationships(payload, organization, member) do
+    relationships = build_relationships(organization, member)
+    payload |> put_in(["data", "relationships"], relationships)
+  end
+
+  defp build_relationships(organization, member) do
+    %{
+      organization: %{data: %{id: organization.id}},
+      member: %{data: %{id: member.id}}
+    }
   end
 
   describe "index" do
@@ -121,124 +130,188 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
     end
   end
 
-  test "shows chosen resource", %{conn: conn} do
-    membership = insert(:organization_membership, role: "admin")
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      membership = insert(:organization_membership, role: "admin")
 
-    path = conn |> organization_membership_path(:show, membership)
+      path = conn |> organization_membership_path(:show, membership)
 
-    data = conn |> get(path) |> json_response(200) |> Map.get("data")
+      data = conn |> get(path) |> json_response(200) |> Map.get("data")
 
-    assert data["id"] == "#{membership.id}"
-    assert data["type"] == "organization-membership"
+      assert data["id"] == "#{membership.id}"
+      assert data["type"] == "organization-membership"
 
-    assert data["attributes"]["role"] == "admin"
-    assert data["relationships"]["organization"]["data"]["id"] |> String.to_integer == membership.organization_id
-    assert data["relationships"]["member"]["data"]["id"] |> String.to_integer == membership.member_id
-  end
+      assert data["attributes"]["role"] == "admin"
+      assert data["relationships"]["organization"]["data"]["id"] |> String.to_integer == membership.organization_id
+      assert data["relationships"]["member"]["data"]["id"] |> String.to_integer == membership.member_id
+    end
 
-  test "renders page not found when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, organization_membership_path(conn, :show, -1)
+    test "renders page not found when id is nonexistent", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        path = conn |> organization_membership_path(:show, -1)
+        conn |> get(path)
+      end
     end
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    attrs = %{ role: "admin" }
-    organization = insert(:organization)
-    member = insert(:user)
+  describe "create" do
+    @tag :authenticated
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      organization = insert(:organization)
+      member = insert(:user)
 
-    relationships = %{
-      organization: %{data: %{id: organization.id}},
-      member: %{data: %{id: member.id}}
-    }
+      payload =
+        build_payload
+        |> put_attributes(@valid_attrs)
+        |> put_relationships(organization, member)
 
-    params = %{
-      "meta" => %{},
-      "data" => %{"type" => "organization-membership", "attributes" => attrs, "relationships" => relationships}
-    }
+      path = conn |> organization_membership_path(:create)
+      data = conn |> post(path, payload) |> json_response(201) |> Map.get("data")
 
-    path = conn |> organization_membership_path(:create)
+      id = data["id"]
+      assert data["attributes"]["role"] == "admin"
+      assert data["relationships"]["organization"]["data"]["id"] |> String.to_integer == organization.id
+      assert data["relationships"]["member"]["data"]["id"] |> String.to_integer == member.id
 
-    data = conn |> post(path, params) |> json_response(201) |> Map.get("data")
+      membership = OrganizationMembership |> Repo.get(id)
+      assert membership
+      assert membership.role == "admin"
+      assert membership.organization_id == organization.id
+      assert membership.member_id == member.id
+    end
 
-    id = data["id"]
-    assert data["attributes"]["role"] == "admin"
-    assert data["relationships"]["organization"]["data"]["id"] |> String.to_integer == organization.id
-    assert data["relationships"]["member"]["data"]["id"] |> String.to_integer == member.id
+    @tag :authenticated
+    test "does not create resource and renders 422 when data is invalid", %{conn: conn} do
+      organization = insert(:organization)
+      member = insert(:user)
 
-    membership = OrganizationMembership |> Repo.get(id)
-    assert membership
-    assert membership.role == "admin"
-    assert membership.organization_id == organization.id
-    assert membership.member_id == member.id
+      payload =
+        build_payload
+        |> put_attributes(@invalid_attrs)
+        |> put_relationships(organization, member)
+
+      path = conn |> organization_membership_path(:create)
+      data = conn |> post(path, payload) |> json_response(422)
+
+      assert data["errors"] != %{}
+    end
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    params = %{"meta" => %{}, "data" => %{"type" => "organization-membership", "attributes" => %{}}}
-    path = conn |> organization_membership_path(:create)
+  describe "update" do
+    @tag :authenticated
+    test "updates and renders resource when data is valid", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      membership = insert(:organization_membership, organization: organization)
+      insert(:organization_membership, organization: organization, member: current_user, role: "owner")
 
-    data = conn |> post(path, params) |> json_response(422)
-    assert data["errors"] != %{}
-  end
+      payload =
+        build_payload
+        |> put_id(membership.id)
+        |> put_attributes(@valid_attrs)
 
-  test "updates and renders resource when data is valid", %{conn: conn} do
-    membership = insert(:organization_membership)
+      path = conn |> organization_membership_path(:update, membership)
+      data = conn |> put(path, payload) |> json_response(200) |> Map.get("data")
 
-    params = %{
-      "meta" => %{},
-      "data" => %{
-        "id" => membership.id,
-        "type" => "organization-membership",
-        "attributes" => %{"role" => "admin"}
-      }
-    }
+      id = data["id"]
+      assert data["attributes"]["role"] == "admin"
+      assert data["relationships"]["organization"]["data"]["id"] |> String.to_integer == membership.organization_id
+      assert data["relationships"]["member"]["data"]["id"] |> String.to_integer == membership.member_id
 
-    path = conn |> organization_membership_path(:update, membership)
+      membership = OrganizationMembership |> Repo.get(id)
+      assert membership
+      assert membership.role == "admin"
+      assert membership.organization_id == membership.organization_id
+      assert membership.member_id == membership.member_id
+    end
 
-    data = conn |> put(path, params) |> json_response(200) |> Map.get("data")
+    @tag :authenticated
+    test "doesnt't update and renders 422 when data is invalid", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      membership = insert(:organization_membership, organization: organization)
+      insert(:organization_membership, organization: organization, member: current_user, role: "owner")
 
-    id = data["id"]
-    assert data["attributes"]["role"] == "admin"
-    assert data["relationships"]["organization"]["data"]["id"] |> String.to_integer == membership.organization_id
-    assert data["relationships"]["member"]["data"]["id"] |> String.to_integer == membership.member_id
+      payload =
+        build_payload
+        |> put_id(membership.id)
+        |> put_attributes(@invalid_attrs)
 
-    membership = OrganizationMembership |> Repo.get(id)
-    assert membership
-    assert membership.role == "admin"
-    assert membership.organization_id == membership.organization_id
-    assert membership.member_id == membership.member_id
-  end
+      path = conn |> organization_membership_path(:update, membership)
+      conn = conn |> put(path, payload)
 
-  test "renders page not found when id is nonexistent on update", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      params = %{
-        "meta" => %{},
-        "data" => %{
-          "id" => -1,
-          "type" => "organization-membership",
-          "attributes" => %{"role" => "admin"}
-        }
-      }
+      assert conn |> json_response(422)
+    end
+
+    test "doesnt't update and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> organization_membership_path(:update, "id doesn't matter")
+      conn = conn |> put(path)
+
+      assert conn |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "doesnt't update and renders 401 when not authorized", %{conn: conn} do
+      membership = insert(:organization_membership)
+
+      payload =
+        build_payload
+        |> put_id(membership.id)
+        |> put_attributes(@valid_attrs)
+
+      path = conn |> organization_membership_path(:update, membership)
+      conn = conn |> put(path, payload)
+
+      assert conn |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders page not found when id is nonexistent on update", %{conn: conn} do
       path = conn |> organization_membership_path(:update, -1)
-      conn |> put(path, params)
+      assert conn |> put(path) |> json_response(:not_found)
     end
   end
 
-  test "deletes resource", %{conn: conn} do
-    membership = insert(:organization_membership, role: "admin")
+  describe "delete" do
+    @tag :authenticated
+    test "deletes resource", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      membership = insert(:organization_membership, organization: organization)
+      insert(:organization_membership, organization: organization, member: current_user, role: "owner")
 
-    path = conn |> organization_membership_path(:delete, membership)
+      path = conn |> organization_membership_path(:delete, membership)
 
-    assert conn |> delete(path) |> response(204)
+      assert conn |> delete(path) |> response(204)
 
-    refute Repo.get(OrganizationMembership, membership.id)
-    assert Repo.get(Organization, membership.organization_id)
-    assert Repo.get(User, membership.member_id)
-  end
+      refute Repo.get(OrganizationMembership, membership.id)
+      assert Repo.get(Organization, membership.organization_id)
+      assert Repo.get(User, membership.member_id)
+    end
 
-  test "renders page not found when id is nonexistent on delete", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      delete conn, organization_membership_path(conn, :delete, -1)
+    test "doesnt't delete and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> organization_membership_path(:delete, "id doesn't matter")
+      conn = conn |> delete(path)
+
+      assert conn |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "doesnt't delete and renders 401 when not authorized", %{conn: conn} do
+      membership = insert(:organization_membership)
+
+      payload =
+        build_payload
+        |> put_id(membership.id)
+        |> put_attributes(@valid_attrs)
+
+      path = conn |> organization_membership_path(:delete, membership)
+      conn = conn |> delete(path, payload)
+
+      assert conn |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders page not found when id is nonexistent on delete", %{conn: conn} do
+      path = conn |> organization_membership_path(:delete, -1)
+      assert conn |> delete(path) |> json_response(:not_found)
     end
   end
 end

--- a/test/controllers/project_category_controller_test.exs
+++ b/test/controllers/project_category_controller_test.exs
@@ -1,23 +1,19 @@
 defmodule CodeCorps.ProjectCategoryControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.Category
   alias CodeCorps.Project
   alias CodeCorps.ProjectCategory
   alias CodeCorps.Repo
 
-  setup do
-    conn =
-      %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
+  @attrs %{}
 
-    {:ok, conn: conn}
+  defp build_payload, do: %{ "data" => %{"type" => "project-category", "attributes" => %{}}}
+  defp put_relationships(payload, project, category) do
+    relationships = build_relationships(project, category)
+    payload |> put_in(["data", "relationships"], relationships)
   end
 
-  @attributes %{}
-
-  defp build_relationships(nil, nil), do: %{}
   defp build_relationships(project, category) do
     %{
       project: %{data: %{id: project.id}},
@@ -25,62 +21,83 @@ defmodule CodeCorps.ProjectCategoryControllerTest do
     }
   end
 
-  defp build_payload(), do: build_payload(nil, nil)
-  defp build_payload(project, category) do
-    relationships = build_relationships(project, category)
-    %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "project-category",
-        "attributes" => %{},
-        "relationships" => relationships
-      }
-    }
+  describe "create" do
+    @tag authenticated: :admin
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      category = insert(:category)
+      project = insert(:project)
+
+      payload = build_payload |> put_relationships(project, category)
+
+      path = conn |> project_category_path(:create)
+      data = conn |> post(path, payload) |> json_response(201) |> Map.get("data")
+
+      id = data["id"]
+      assert data["relationships"]["project"]["data"]["id"] |> String.to_integer == project.id
+      assert data["relationships"]["category"]["data"]["id"] |> String.to_integer == category.id
+
+      project_category = ProjectCategory |> Repo.get(id)
+      assert project_category
+      assert project_category.project_id == project.id
+      assert project_category.category_id == category.id
+    end
+
+    @tag authenticated: :admin
+    test "does not create resource and renders 422 when data is invalid", %{conn: conn} do
+      payload = build_payload()
+
+      path = conn |> project_category_path(:create)
+      data = conn |> post(path, payload) |> json_response(422)
+      assert data["errors"] != %{}
+    end
+
+    test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
+      payload = build_payload()
+
+      path = conn |> project_category_path(:create)
+      assert conn |> post(path, payload) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      payload = build_payload()
+
+      path = conn |> project_category_path(:create)
+      assert conn |> post(path, payload) |> json_response(401)
+    end
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    category = insert(:category)
-    project = insert(:project)
+  describe "delete" do
+    @tag authenticated: :admin
+    test "deletes resource", %{conn: conn} do
+      project_category = insert(:project_category)
 
-    payload = build_payload(project, category)
+      path = conn |> project_category_path(:delete, project_category)
 
-    path = conn |> project_category_path(:create)
+      assert conn |> delete(path) |> response(204)
 
-    data = conn |> post(path, payload) |> json_response(201) |> Map.get("data")
+      refute Repo.get(ProjectCategory, project_category.id)
+      assert Repo.get(Project, project_category.project_id)
+      assert Repo.get(Category, project_category.category_id)
+    end
 
-    id = data["id"]
-    assert data["relationships"]["project"]["data"]["id"] |> String.to_integer == project.id
-    assert data["relationships"]["category"]["data"]["id"] |> String.to_integer == category.id
+    test "does not delete resource and renders 401 when unauthenticated", %{conn: conn} do
+      project_category = insert(:project_category)
+      path = conn |> project_category_path(:delete, project_category)
+      assert conn |> delete(path) |> json_response(401)
+    end
 
-    project_category = ProjectCategory |> Repo.get(id)
-    assert project_category
-    assert project_category.project_id == project.id
-    assert project_category.category_id == category.id
-  end
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      project_category = insert(:project_category)
+      path = conn |> project_category_path(:delete, project_category)
+      assert conn |> delete(path) |> json_response(401)
+    end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    payload = build_payload()
-
-    path = conn |> project_category_path(:create)
-    data = conn |> post(path, payload) |> json_response(422)
-    assert data["errors"] != %{}
-  end
-
-  test "deletes resource", %{conn: conn} do
-    project_category = insert(:project_category)
-
-    path = conn |> project_category_path(:delete, project_category)
-
-    assert conn |> delete(path) |> response(204)
-
-    refute Repo.get(ProjectCategory, project_category.id)
-    assert Repo.get(Project, project_category.project_id)
-    assert Repo.get(Category, project_category.category_id)
-  end
-
-  test "renders page not found when id is nonexistent on delete", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      delete conn, project_category_path(conn, :delete, -1)
+    @tag :authenticated
+    test "renders page not found when id is nonexistent on delete", %{conn: conn} do
+      path = conn |> project_category_path(:delete, -1)
+      assert conn |> delete(path) |> json_response(404)
     end
   end
 end

--- a/test/controllers/project_skill_controller_test.exs
+++ b/test/controllers/project_skill_controller_test.exs
@@ -1,132 +1,152 @@
 defmodule CodeCorps.ProjectSkillControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.ProjectSkill
   alias CodeCorps.Repo
 
-  setup do
-    conn = %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
+  @attrs %{}
 
-    {:ok, conn: conn}
+  defp build_payload, do: %{ "data" => %{"type" => "project-skill", "attributes" => %{}}}
+  defp put_relationships(payload, project, skill) do
+    relationships = build_relationships(project, skill)
+    payload |> put_in(["data", "relationships"], relationships)
   end
 
-  defp relationships(project, skill) do
+  defp build_relationships(project, skill) do
     %{
-      "project" => %{
-        "data" => %{
-          "type" => "project",
-          "id" => project.id
-        }
-      },
-      "skill" => %{
-        "data" => %{
-          "type" => "skill",
-          "id" => skill.id
-        }
-      },
+      project: %{data: %{id: project.id}},
+      skill: %{data: %{id: skill.id}}
     }
   end
 
-  test "lists all entries on index", %{conn: conn} do
-    conn = get conn, project_skill_path(conn, :index)
-    assert json_response(conn, 200)["data"] == []
-  end
+  describe "index" do
+    test "lists all entries on index", %{conn: conn} do
+      conn = get conn, project_skill_path(conn, :index)
+      assert json_response(conn, 200)["data"] == []
+    end
 
-  test "filters resources on index", %{conn: conn} do
-    elixir = insert(:skill, title: "Elixir")
-    phoenix = insert(:skill, title: "Phoenix")
-    rails = insert(:skill, title: "Rails")
+    test "filters resources on index", %{conn: conn} do
+      elixir = insert(:skill, title: "Elixir")
+      phoenix = insert(:skill, title: "Phoenix")
+      rails = insert(:skill, title: "Rails")
 
-    project = insert(:project)
-    project_skill_1 = insert(:project_skill, project: project, skill: elixir)
-    project_skill_2 = insert(:project_skill, project: project, skill: phoenix)
-    insert(:project_skill, project: project, skill: rails)
-    conn = get conn, "project-skills/?filter[id]=#{project_skill_1.id},#{project_skill_2.id}"
-    data = json_response(conn, 200)["data"]
-    [first_result, second_result | _] = data
-    assert length(data) == 2
-    assert first_result["id"] == "#{project_skill_1.id}"
-    assert first_result["relationships"]["project"]["data"]["id"] == "#{project.id}"
-    assert first_result["relationships"]["project"]["data"]["type"] == "project"
-    assert first_result["relationships"]["skill"]["data"]["id"] == "#{elixir.id}"
-    assert first_result["relationships"]["skill"]["data"]["type"] == "skill"
-    assert second_result["id"] == "#{project_skill_2.id}"
-    assert second_result["relationships"]["project"]["data"]["id"] == "#{project.id}"
-    assert second_result["relationships"]["project"]["data"]["type"] == "project"
-    assert second_result["relationships"]["skill"]["data"]["id"] == "#{phoenix.id}"
-    assert second_result["relationships"]["skill"]["data"]["type"] == "skill"
-  end
+      project = insert(:project)
+      project_skill_1 = insert(:project_skill, project: project, skill: elixir)
+      project_skill_2 = insert(:project_skill, project: project, skill: phoenix)
+      insert(:project_skill, project: project, skill: rails)
+      json =
+        conn
+        |> get("project-skills/?filter[id]=#{project_skill_1.id},#{project_skill_2.id}")
+        |> json_response(200)
+      data = json["data"]
+      assert length(data) == 2
+      [first_result, second_result | _] = data
 
-  test "shows chosen resource", %{conn: conn} do
-    skill = insert(:skill)
-    project = insert(:project)
-    project_skill = insert(:project_skill, project: project, skill: skill)
-    conn = get conn, project_skill_path(conn, :show, project_skill)
-    data = json_response(conn, 200)["data"]
-    assert data["id"] == "#{project_skill.id}"
-    assert data["type"] == "project-skill"
-    assert data["attributes"] == %{}
-    assert data["relationships"]["project"]["data"]["id"] == "#{project.id}"
-    assert data["relationships"]["project"]["data"]["type"] == "project"
-    assert data["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
-    assert data["relationships"]["skill"]["data"]["type"] == "skill"
-  end
+      assert first_result["id"] == "#{project_skill_1.id}"
+      assert first_result["relationships"]["project"]["data"]["id"] == "#{project.id}"
+      assert first_result["relationships"]["project"]["data"]["type"] == "project"
+      assert first_result["relationships"]["skill"]["data"]["id"] == "#{elixir.id}"
+      assert first_result["relationships"]["skill"]["data"]["type"] == "skill"
 
-  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, project_skill_path(conn, :show, -1)
+      assert second_result["id"] == "#{project_skill_2.id}"
+      assert second_result["relationships"]["project"]["data"]["id"] == "#{project.id}"
+      assert second_result["relationships"]["project"]["data"]["type"] == "project"
+      assert second_result["relationships"]["skill"]["data"]["id"] == "#{phoenix.id}"
+      assert second_result["relationships"]["skill"]["data"]["type"] == "skill"
     end
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    project = insert(:project)
-    skill = insert(:skill)
-    conn = post conn, project_skill_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "project-skill",
-        "attributes" => %{},
-        "relationships" => relationships(project, skill)
-      }
-    }
-    json = json_response(conn, 201)
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      skill = insert(:skill)
+      project = insert(:project)
+      project_skill = insert(:project_skill, project: project, skill: skill)
+      conn = get conn, project_skill_path(conn, :show, project_skill)
+      data = json_response(conn, 200)["data"]
+      assert data["id"] == "#{project_skill.id}"
+      assert data["type"] == "project-skill"
+      assert data["attributes"] == %{}
+      assert data["relationships"]["project"]["data"]["id"] == "#{project.id}"
+      assert data["relationships"]["project"]["data"]["type"] == "project"
+      assert data["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
+      assert data["relationships"]["skill"]["data"]["type"] == "skill"
+    end
 
-    id = json["data"]["id"] |> String.to_integer
-    project_skill = ProjectSkill |> Repo.get!(id)
-
-    assert json["data"]["id"] == "#{project_skill.id}"
-    assert json["data"]["type"] == "project-skill"
-    assert json["data"]["attributes"] == %{}
-    assert json["data"]["relationships"]["project"]["data"]["id"] == "#{project.id}"
-    assert json["data"]["relationships"]["project"]["data"]["type"] == "project"
-    assert json["data"]["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
-    assert json["data"]["relationships"]["skill"]["data"]["type"] == "skill"
+    test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get conn, project_skill_path(conn, :show, -1)
+      end
+    end
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, project_skill_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "project-skill",
-        "attributes" => %{}
-      }
-    }
+  describe "create" do
+    @tag authenticated: :admin
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      project = insert(:project)
+      skill = insert(:skill)
 
-    assert json_response(conn, 422)["errors"] != %{}
+      payload = build_payload |> put_relationships(project, skill)
+      path = conn |> project_skill_path(:create)
+      json = conn |> post(path, payload) |> json_response(201)
+
+      id = json["data"]["id"] |> String.to_integer
+      project_skill = ProjectSkill |> Repo.get!(id)
+
+      assert json["data"]["id"] == "#{project_skill.id}"
+      assert json["data"]["type"] == "project-skill"
+      assert json["data"]["attributes"] == %{}
+      assert json["data"]["relationships"]["project"]["data"]["id"] == "#{project.id}"
+      assert json["data"]["relationships"]["project"]["data"]["type"] == "project"
+      assert json["data"]["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
+      assert json["data"]["relationships"]["skill"]["data"]["type"] == "skill"
+    end
+
+    @tag authenticated: :admin
+    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+      payload = build_payload
+      path = conn |> project_skill_path(:create)
+      json = conn |> post(path, payload) |> json_response(422)
+
+      assert json["errors"] != %{}
+    end
+
+    test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> project_skill_path(:create)
+      assert conn |> post(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      path = conn |> project_skill_path(:create)
+      assert conn |> post(path) |> json_response(401)
+    end
   end
 
-  test "deletes chosen resource", %{conn: conn} do
-    project_skill = Repo.insert! %ProjectSkill{}
-    conn = delete conn, project_skill_path(conn, :delete, project_skill)
-    assert response(conn, 204)
-    refute Repo.get(ProjectSkill, project_skill.id)
-  end
+  describe "delete" do
+    @tag authenticated: :admin
+    test "deletes chosen resource", %{conn: conn} do
+      project_skill = Repo.insert! %ProjectSkill{}
+      path = conn |> project_skill_path(:delete, project_skill)
+      assert conn |> delete(path) |> response(204)
+      refute Repo.get(ProjectSkill, project_skill.id)
+    end
 
-  test "renders page not found when id is nonexistent on delete", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      delete conn, project_skill_path(conn, :delete, -1)
+    test "does not delete resource and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> project_skill_path(:delete, "id not important")
+      assert conn |> delete(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      project_skill = insert(:project_skill)
+      path = conn |> project_skill_path(:delete, project_skill)
+      assert conn |> delete(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders page not found when id is nonexistent on delete", %{conn: conn} do
+      path = conn |> project_skill_path(:delete, -1)
+      assert conn |> delete(path) |> json_response(404)
     end
   end
 end

--- a/test/controllers/role_skill_controller_test.exs
+++ b/test/controllers/role_skill_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule CodeCorps.RoleSkillControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.RoleSkill
   alias CodeCorps.Repo
@@ -7,136 +7,157 @@ defmodule CodeCorps.RoleSkillControllerTest do
   @valid_attrs %{}
   @invalid_attrs %{}
 
-  setup do
-    conn = %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
-
-    {:ok, conn: conn}
+  defp build_payload, do: %{ "data" => %{"type" => "role-skill", "attributes" => %{}}}
+  defp put_relationships(payload, role, skill) do
+    relationships = build_relationships(role, skill)
+    payload |> put_in(["data", "relationships"], relationships)
   end
 
-  defp attributes do 
-  end
-
-  defp relationships(role, skill) do
+  defp build_relationships(role, skill) do
     %{
-      "role" => %{
-        "data" => %{
-          "type" => "role",
-          "id" => role.id
-        }
-      },
-      "skill" => %{
-        "data" => %{
-          "type" => "skill",
-          "id" => skill.id
-        }
-      },
+      role: %{data: %{id: role.id}},
+      skill: %{data: %{id: skill.id}}
     }
   end
 
-  test "lists all entries on index", %{conn: conn} do
-    conn = get conn, role_skill_path(conn, :index)
-    assert json_response(conn, 200)["data"] == []
-  end
+  describe "index" do
+    test "lists all entries on index", %{conn: conn} do
+      path = conn |> role_skill_path(:index)
+      json = conn |> get(path) |> json_response(200)
+      assert json["data"] == []
+    end
 
-  test "filters resources on index", %{conn: conn} do
-    elixir = insert(:skill, title: "Elixir")
-    phoenix = insert(:skill, title: "Phoenix")
-    rails = insert(:skill, title: "Rails")
+    test "filters resources on index", %{conn: conn} do
+      elixir = insert(:skill, title: "Elixir")
+      phoenix = insert(:skill, title: "Phoenix")
+      rails = insert(:skill, title: "Rails")
 
-    role = insert(:role)
-    role_skill_1 = insert(:role_skill, role: role, skill: elixir)
-    role_skill_2 = insert(:role_skill, role: role, skill: phoenix)
-    insert(:role_skill, role: role, skill: rails)
+      role = insert(:role)
+      role_skill_1 = insert(:role_skill, role: role, skill: elixir)
+      role_skill_2 = insert(:role_skill, role: role, skill: phoenix)
+      insert(:role_skill, role: role, skill: rails)
 
-    conn = get conn, "role-skills/?filter[id]=#{role_skill_1.id},#{role_skill_2.id}"
-    data = json_response(conn, 200)["data"]
-    [first_result, second_result | _] = data
-    assert length(data) == 2
-    assert first_result["id"] == "#{role_skill_1.id}"
-    assert first_result["attributes"] == %{}
-    assert first_result["relationships"]["role"]["data"]["id"] == "#{role.id}"
-    assert first_result["relationships"]["role"]["data"]["type"] == "role"
-    assert first_result["relationships"]["skill"]["data"]["id"] == "#{elixir.id}"
-    assert first_result["relationships"]["skill"]["data"]["type"] == "skill"
-    assert second_result["id"] == "#{role_skill_2.id}"
-    assert second_result["attributes"] == %{}
-    assert second_result["relationships"]["role"]["data"]["id"] == "#{role.id}"
-    assert second_result["relationships"]["role"]["data"]["type"] == "role"
-    assert second_result["relationships"]["skill"]["data"]["id"] == "#{phoenix.id}"
-    assert second_result["relationships"]["skill"]["data"]["type"] == "skill"
-  end
+      path = "role-skills/?filter[id]=#{role_skill_1.id},#{role_skill_2.id}"
+      json = conn |> get(path) |> json_response(200)
 
-  test "shows chosen resource", %{conn: conn} do
-    skill = insert(:skill)
-    role = insert(:role)
-    role_skill = insert(:role_skill, role: role, skill: skill)
-    conn = get conn, role_skill_path(conn, :show, role_skill)
-    data = json_response(conn, 200)["data"]
-    assert data["id"] == "#{role_skill.id}"
-    assert data["type"] == "role-skill"
-    assert data["attributes"] == %{}
-    assert data["relationships"]["role"]["data"]["id"] == "#{role.id}"
-    assert data["relationships"]["role"]["data"]["type"] == "role"
-    assert data["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
-    assert data["relationships"]["skill"]["data"]["type"] == "skill"
-  end
+      data = json["data"]
+      assert length(data) == 2
 
-  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, role_skill_path(conn, :show, -1)
+      [first_result, second_result | _] = data
+
+      assert first_result["id"] == "#{role_skill_1.id}"
+      assert first_result["attributes"] == %{}
+      assert first_result["relationships"]["role"]["data"]["id"] == "#{role.id}"
+      assert first_result["relationships"]["role"]["data"]["type"] == "role"
+      assert first_result["relationships"]["skill"]["data"]["id"] == "#{elixir.id}"
+      assert first_result["relationships"]["skill"]["data"]["type"] == "skill"
+
+      assert second_result["id"] == "#{role_skill_2.id}"
+      assert second_result["attributes"] == %{}
+      assert second_result["relationships"]["role"]["data"]["id"] == "#{role.id}"
+      assert second_result["relationships"]["role"]["data"]["type"] == "role"
+      assert second_result["relationships"]["skill"]["data"]["id"] == "#{phoenix.id}"
+      assert second_result["relationships"]["skill"]["data"]["type"] == "skill"
     end
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    role = insert(:role, name: "Frontend Developer")
-    skill = insert(:skill, title: "test skill")
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      role_skill = insert(:role_skill)
 
-    conn = post conn, role_skill_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "role-skill",
-        "attributes" => attributes,
-        "relationships" => relationships(role, skill)
-      }
-    }
-    json = json_response(conn, 201)
+      path = conn |> role_skill_path(:show, role_skill)
+      json = conn |> get(path) |> json_response(200)
 
-    id = json["data"]["id"] |> String.to_integer
-    role_skill = RoleSkill |> Repo.get!(id)
+      data = json["data"]
+      assert data["id"] == "#{role_skill.id}"
+      assert data["type"] == "role-skill"
+      assert data["attributes"] == %{}
+      assert data["relationships"]["role"]["data"]["id"] == "#{role_skill.role_id}"
+      assert data["relationships"]["role"]["data"]["type"] == "role"
+      assert data["relationships"]["skill"]["data"]["id"] == "#{role_skill.skill_id}"
+      assert data["relationships"]["skill"]["data"]["type"] == "skill"
+    end
 
-    assert json["data"]["id"] == "#{role_skill.id}"
-    assert json["data"]["type"] == "role-skill"
-    assert json["data"]["attributes"] == %{}
-    assert json["data"]["relationships"]["role"]["data"]["id"] == "#{role.id}"
-    assert json["data"]["relationships"]["role"]["data"]["type"] == "role"
-    assert json["data"]["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
-    assert json["data"]["relationships"]["skill"]["data"]["type"] == "skill"
+    test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get conn, role_skill_path(conn, :show, -1)
+      end
+    end
 
+    test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> role_skill_path(:create)
+      assert conn |> post(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      path = conn |> role_skill_path(:create)
+      assert conn |> post(path) |> json_response(401)
+    end
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, role_skill_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "role-skill",
-        "attributes" => attributes
-      }
-    }
+  describe "create" do
+    @tag authenticated: :admin
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      role = insert(:role, name: "Frontend Developer")
+      skill = insert(:skill, title: "test skill")
 
-    assert json_response(conn, 422)["errors"] != %{}
+      path = conn |> role_skill_path(:create)
+      payload = build_payload |> put_relationships(role, skill)
+
+      json = conn |> post(path, payload) |> json_response(201)
+
+      id = json["data"]["id"] |> String.to_integer
+      role_skill = RoleSkill |> Repo.get!(id)
+
+      assert json["data"]["id"] == "#{role_skill.id}"
+      assert json["data"]["type"] == "role-skill"
+      assert json["data"]["attributes"] == %{}
+      assert json["data"]["relationships"]["role"]["data"]["id"] == "#{role.id}"
+      assert json["data"]["relationships"]["role"]["data"]["type"] == "role"
+      assert json["data"]["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
+      assert json["data"]["relationships"]["skill"]["data"]["type"] == "skill"
+    end
+
+    @tag authenticated: :admin
+    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+      path = conn |> role_skill_path(:create)
+      payload = build_payload
+
+      json = conn |> post(path, payload) |> json_response(422)
+      assert json["errors"] != %{}
+    end
   end
 
-  test "deletes resource", %{conn: conn} do
-    skill = insert(:skill, title: "test-skill")
-    role = insert(:role, name: "Frontend Developer")
-    role_skill = insert(:role_skill, role: role, skill: skill)
-    conn = delete conn, role_skill_path(conn, :delete, role_skill)
+  describe "delete" do
+    @tag authenticated: :admin
+    test "deletes resource", %{conn: conn} do
+      role_skill = insert(:role_skill)
+      path = conn |> role_skill_path(:delete, role_skill)
 
-    assert response(conn, 204)
-    refute Repo.get(RoleSkill, role_skill.id)
-    assert Repo.get(CodeCorps.Role, role.id)
-    assert Repo.get(CodeCorps.Skill, skill.id)
+      assert conn |> delete(path) |> response(204)
+
+      refute Repo.get(RoleSkill, role_skill.id)
+      assert Repo.get(CodeCorps.Role, role_skill.role_id)
+      assert Repo.get(CodeCorps.Skill, role_skill.skill_id)
+    end
+
+    test "does not delete resource and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> role_skill_path(:delete, "id not important")
+      assert conn |> delete(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      role_skill = insert(:role_skill)
+      path = conn |> role_skill_path(:delete, role_skill)
+      assert conn |> delete(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders page not found when id is nonexistent on delete", %{conn: conn} do
+      path = conn |> role_skill_path(:delete, -1)
+      assert conn |> delete(path) |> json_response(404)
+    end
   end
 end

--- a/test/controllers/skill_controller_test.exs
+++ b/test/controllers/skill_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule CodeCorps.SkillControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.Skill
   alias CodeCorps.Repo
@@ -11,91 +11,105 @@ defmodule CodeCorps.SkillControllerTest do
   }
   @invalid_attrs %{}
 
-  setup do
-    conn =
-      %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
+  defp build_payload, do: %{ "data" => %{"type" => "skill"}}
+  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
 
-    {:ok, conn: conn}
-  end
+  describe "index" do
+    test "lists all entries on index", %{conn: conn} do
+      path = conn |> skill_path(:index)
+      json = conn |> get(path) |> json_response(200)
 
-  defp relationships do
-    %{}
-  end
+      assert json["data"] == []
+    end
 
-  test "lists all entries on index", %{conn: conn} do
-    conn = get conn, skill_path(conn, :index)
-    assert json_response(conn, 200)["data"] == []
-  end
+    test "filters resources on index", %{conn: conn} do
+      elixir = insert(:skill, title: "Elixir")
+      phoenix = insert(:skill, title: "Phoenix")
+      insert(:skill, title: "Rails")
 
-  test "filters resources on index", %{conn: conn} do
-    elixir = insert(:skill, title: "Elixir")
-    phoenix = insert(:skill, title: "Phoenix")
-    insert(:skill, title: "Rails")
-    params = %{"filter" => %{"id" => "#{elixir.id},#{phoenix.id}"}}
-    conn = get conn, skill_path(conn, :index, params)
-    data = json_response(conn, 200)["data"]
-    assert data |> length == 2
+      params = %{"filter" => %{"id" => "#{elixir.id},#{phoenix.id}"}}
+      path = conn |> skill_path(:index, params)
 
-    [first_result, second_result | _] = data
-    assert first_result["id"] == "#{elixir.id}"
-    assert second_result["id"] == "#{phoenix.id}"
-  end
+      json = conn |> get(path) |> json_response(200)
 
-  test "returns search results on index", %{conn: conn} do
-    ruby = insert(:skill, title: "Ruby")
-    rails = insert(:skill, title: "Rails")
-    insert(:skill, title: "Phoenix")
-    params = %{"query" => "r"}
-    conn = get conn, skill_path(conn, :index, params)
-    data = json_response(conn, 200)["data"]
-    [first_result, second_result | _] = data
-    assert length(data) == 2
-    assert first_result["id"] == "#{ruby.id}"
-    assert second_result["id"] == "#{rails.id}"
-  end
+      data = json["data"]
+      assert data |> length == 2
 
-  test "shows chosen resource", %{conn: conn} do
-    skill = insert(:skill)
-    conn = get conn, skill_path(conn, :show, skill)
-    data = json_response(conn, 200)["data"]
-    assert data["id"] == "#{skill.id}"
-    assert data["type"] == "skill"
-    assert data["attributes"]["title"] == skill.title
-    assert data["attributes"]["description"] == skill.description
-  end
+      [first_result, second_result | _] = data
+      assert first_result["id"] == "#{elixir.id}"
+      assert second_result["id"] == "#{phoenix.id}"
+    end
 
-  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, skill_path(conn, :show, -1)
+    test "returns search results on index", %{conn: conn} do
+      ruby = insert(:skill, title: "Ruby")
+      rails = insert(:skill, title: "Rails")
+      insert(:skill, title: "Phoenix")
+
+      params = %{"query" => "r"}
+      path = conn |> skill_path(:index, params)
+
+      json = conn |> get(path) |> json_response(200)
+      data = json["data"]
+
+      [first_result, second_result | _] = data
+      assert length(data) == 2
+      assert first_result["id"] == "#{ruby.id}"
+      assert second_result["id"] == "#{rails.id}"
     end
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    conn = post conn, skill_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "skill",
-        "attributes" => @valid_attrs,
-        "relationships" => relationships
-      }
-    }
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      skill = insert(:skill)
 
-    assert json_response(conn, 201)["data"]["id"]
-    assert Repo.get_by(Skill, @valid_attrs)
+      path = conn |> skill_path(:show, skill)
+      json = conn |> get(path) |> json_response(200)
+
+      data = json["data"]
+      assert data["id"] == "#{skill.id}"
+      assert data["type"] == "skill"
+      assert data["attributes"]["title"] == skill.title
+      assert data["attributes"]["description"] == skill.description
+    end
+
+    test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get conn, skill_path(conn, :show, -1)
+      end
+    end
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, skill_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "skill",
-        "attributes" => @invalid_attrs,
-        "relationships" => relationships
-      }
-    }
+  describe "create" do
+    @tag authenticated: :admin
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      path = conn |> skill_path(:create)
+      payload = build_payload |> put_attributes(@valid_attrs)
+      json = conn |> post(path, payload) |> json_response(201)
 
-    assert json_response(conn, 422)["errors"] != %{}
+      assert json["data"]["id"]
+      assert Repo.get_by(Skill, @valid_attrs)
+    end
+
+    @tag authenticated: :admin
+    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+      path = conn |> skill_path(:create)
+      payload = build_payload |> put_attributes(@invalid_attrs)
+      json = conn |> post(path, payload) |> json_response(422)
+
+      assert json["errors"] != %{}
+    end
+
+    test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> skill_path(:create)
+      payload = build_payload |> put_attributes(@valid_attrs)
+      assert conn |> post(path, payload) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      path = conn |> skill_path(:create)
+      payload = build_payload |> put_attributes(@valid_attrs)
+      assert conn |> post(path, payload) |> json_response(401)
+    end
   end
 end

--- a/test/controllers/slugged_route_controller_test.exs
+++ b/test/controllers/slugged_route_controller_test.exs
@@ -1,20 +1,11 @@
 defmodule CodeCorps.SluggedRouteControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.SluggedRoute
   alias CodeCorps.Repo
 
   @valid_attrs %{organization_id: 42, slug: "some content", user_id: 42}
   @invalid_attrs %{}
-
-  setup do
-    conn =
-      %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
-
-    {:ok, conn: conn}
-  end
 
   test "shows chosen resource", %{conn: conn} do
     slug = "test-slug"

--- a/test/controllers/user_role_controller_test.exs
+++ b/test/controllers/user_role_controller_test.exs
@@ -1,71 +1,87 @@
 defmodule CodeCorps.UserRoleControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.UserRole
   alias CodeCorps.Repo
 
-  setup do
-    conn =
-      %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
-
-    {:ok, conn: conn}
+  defp build_payload, do: %{ "data" => %{"type" => "user-role", "attributes" => %{}}}
+  defp put_relationships(payload, user, role) do
+    relationships = build_relationships(user, role)
+    payload |> put_in(["data", "relationships"], relationships)
   end
 
-  defp attributes do
-    %{}
-  end
-
-  defp relationships(user, role) do
+  defp build_relationships(user, role) do
     %{
       user: %{data: %{id: user.id}},
       role: %{data: %{id: role.id}}
     }
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    user = insert(:user)
-    role = insert(:role)
+  describe "create" do
+    @tag authenticated: :admin
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      user = insert(:user)
+      role = insert(:role)
 
-    conn = post conn, user_role_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "user-role",
-        "attributes" => attributes,
-        "relationships" => relationships(user, role)
-      }
-    }
+      payload = build_payload |> put_relationships(user, role)
+      path = conn |> user_role_path(:create)
+      json = conn |> post(path, payload) |> json_response(201)
 
-    json = json_response(conn, 201)
+      id = json["data"]["id"] |> String.to_integer
+      user_role = UserRole |> Repo.get!(id)
 
-    id = json["data"]["id"] |> String.to_integer
-    user_role = UserRole |> Repo.get!(id)
+      assert json["data"]["id"] == "#{user_role.id}"
+      assert json["data"]["type"] == "user-role"
+      assert json["data"]["relationships"]["user"]["data"]["id"] == "#{user_role.user_id}"
+      assert json["data"]["relationships"]["role"]["data"]["id"] == "#{user_role.role_id}"
+    end
 
-    assert json["data"]["id"] == "#{user_role.id}"
-    assert json["data"]["type"] == "user-role"
-    assert json["data"]["relationships"]["user"]["data"]["id"] == "#{user.id}"
-    assert json["data"]["relationships"]["role"]["data"]["id"] == "#{role.id}"
+    @tag authenticated: :admin
+    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+      payload = build_payload
+      path = conn |> user_role_path(:create)
+      json = conn |> post(path, payload) |> json_response(422)
+
+      assert json["errors"] != %{}
+    end
+
+    test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> user_role_path(:create)
+      assert conn |> post(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      path = conn |> user_role_path(:create)
+      assert conn |> post(path) |> json_response(401)
+    end
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, user_role_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "user-role",
-        "attributes" => attributes,
-      }
-    }
+  describe "delete" do
+    @tag authenticated: :admin
+    test "deletes resource", %{conn: conn} do
+      user_role = insert(:user_role)
 
-    assert json_response(conn, 422)["errors"] != %{}
-  end
+      path = conn |> user_role_path(:delete, user_role)
+      assert conn |> delete(path) |> response(204)
+    end
 
-  test "deletes resource", %{conn: conn} do
-    role = insert(:role)
-    user = insert(:user)
-    user_role = insert(:user_role, user: user, role: role)
-    response = delete conn, user_role_path(conn, :delete, user_role)
+    test "does not delete resource and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> user_role_path(:delete, "id not important")
+      assert conn |> delete(path) |> json_response(401)
+    end
 
-    assert response.status == 204
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      user_role = insert(:user_role)
+      path = conn |> user_role_path(:delete, user_role)
+      assert conn |> delete(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders page not found when id is nonexistent on delete", %{conn: conn} do
+      path = conn |> user_role_path(:delete, -1)
+      assert conn |> delete(path) |> json_response(404)
+    end
   end
 end

--- a/test/controllers/user_skill_controller_test.exs
+++ b/test/controllers/user_skill_controller_test.exs
@@ -1,122 +1,136 @@
 defmodule CodeCorps.UserSkillControllerTest do
-  use CodeCorps.ConnCase
+  use CodeCorps.ApiCase
 
   alias CodeCorps.UserSkill
   alias CodeCorps.Repo
 
-  setup do
-    conn =
-      %{build_conn | host: "api."}
-      |> put_req_header("accept", "application/vnd.api+json")
-      |> put_req_header("content-type", "application/vnd.api+json")
-
-    {:ok, conn: conn}
+  defp build_payload, do: %{ "data" => %{"type" => "user-skill", "attributes" => %{}}}
+  defp put_relationships(payload, user, skill) do
+    relationships = build_relationships(user, skill)
+    payload |> put_in(["data", "relationships"], relationships)
   end
 
-  defp attributes do
-    %{}
-  end
-
-  defp relationships(user, skill) do
+  defp build_relationships(user, skill) do
     %{
-      "user" => %{
-        "data" => %{
-          "type" => "user",
-          "id" => user.id
-        }
-      },
-      "skill" => %{
-        "data" => %{
-          "type" => "skill",
-          "id" => skill.id
-        }
-      },
+      user: %{data: %{id: user.id}},
+      skill: %{data: %{id: skill.id}}
     }
   end
 
-  test "lists all entries on index", %{conn: conn} do
-    conn = get conn, user_skill_path(conn, :index)
-    assert json_response(conn, 200)["data"] == []
-  end
+  describe "index" do
+    test "lists all entries on index", %{conn: conn} do
+      path = conn |> user_skill_path(:index)
+      json = conn |> get(path) |> json_response(200)
 
-  test "filters resources on index", %{conn: conn} do
-    elixir = insert(:skill, title: "Elixir")
-    phoenix = insert(:skill, title: "Phoenix")
-    rails = insert(:skill, title: "Rails")
+      assert json["data"] == []
+    end
 
-    user = insert(:user)
-    user_skill_1 = insert(:user_skill, user: user, skill: elixir)
-    user_skill_2 = insert(:user_skill, user: user, skill: phoenix)
-    insert(:user_skill, user: user, skill: rails)
+    test "filters resources on index", %{conn: conn} do
+      elixir = insert(:skill, title: "Elixir")
+      phoenix = insert(:skill, title: "Phoenix")
+      rails = insert(:skill, title: "Rails")
 
-    conn = get conn, "user-skills/?filter[id]=#{user_skill_1.id},#{user_skill_2.id}"
-    data = json_response(conn, 200)["data"]
-    [first_result, second_result | _] = data
-    assert length(data) == 2
-    assert first_result["id"] == "#{user_skill_1.id}"
-    assert second_result["id"] == "#{user_skill_2.id}"
-  end
+      user = insert(:user)
+      user_skill_1 = insert(:user_skill, user: user, skill: elixir)
+      user_skill_2 = insert(:user_skill, user: user, skill: phoenix)
+      insert(:user_skill, user: user, skill: rails)
 
-  test "shows chosen resource", %{conn: conn} do
-    skill = insert(:skill)
-    user = insert(:user)
-    user_skill = insert(:user_skill, user: user, skill: skill)
-    conn = get conn, user_skill_path(conn, :show, user_skill)
-    data = json_response(conn, 200)["data"]
-    assert data["id"] == "#{user_skill.id}"
-    assert data["type"] == "user-skill"
-    assert data["relationships"]["user"]["data"]["id"] == "#{user.id}"
-    assert data["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
-  end
+      path = "user-skills/?filter[id]=#{user_skill_1.id},#{user_skill_2.id}"
+      json = conn |> get(path) |> json_response(200)
 
-  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, user_skill_path(conn, :show, -1)
+      data = json["data"]
+      assert length(data) == 2
+
+      [first_result, second_result | _] = data
+      assert first_result["id"] == "#{user_skill_1.id}"
+      assert second_result["id"] == "#{user_skill_2.id}"
     end
   end
 
-  test "creates and renders resource when data is valid", %{conn: conn} do
-    user = insert(:user)
-    skill = insert(:skill, title: "test-skill")
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      user_skill = insert(:user_skill)
+      path = conn |> user_skill_path(:show, user_skill)
+      json = conn |> get(path) |> json_response(200)
 
-    conn = post conn, user_skill_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "user-skill",
-        "attributes" => attributes,
-        "relationships" => relationships(user, skill)
-      }
-    }
+      data = json["data"]
+      assert data["id"] == "#{user_skill.id}"
+      assert data["type"] == "user-skill"
+      assert data["relationships"]["user"]["data"]["id"] == "#{user_skill.user_id}"
+      assert data["relationships"]["skill"]["data"]["id"] == "#{user_skill.skill_id}"
+    end
 
-    json = json_response(conn, 201)
-
-    id = json["data"]["id"] |> String.to_integer
-    user_skill = UserSkill |> Repo.get!(id)
-
-    assert json["data"]["id"] == "#{user_skill.id}"
-    assert json["data"]["type"] == "user-skill"
-    assert json["data"]["relationships"]["user"]["data"]["id"] == "#{user.id}"
-    assert json["data"]["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
+    test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get conn, user_skill_path(conn, :show, -1)
+      end
+    end
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, user_skill_path(conn, :create), %{
-      "meta" => %{},
-      "data" => %{
-        "type" => "user-skill",
-        "attributes" => attributes,
-      }
-    }
+  describe "create" do
+    @tag authenticated: :admin
+    test "creates and renders resource when data is valid", %{conn: conn} do
+      user = insert(:user)
+      skill = insert(:skill, title: "test-skill")
 
-    assert json_response(conn, 422)["errors"] != %{}
+      payload = build_payload |> put_relationships(user, skill)
+      path = conn |> user_skill_path(:create)
+      json = conn |> post(path, payload) |> json_response(201)
+
+      id = json["data"]["id"] |> String.to_integer
+      user_skill = UserSkill |> Repo.get!(id)
+
+      assert json["data"]["id"] == "#{user_skill.id}"
+      assert json["data"]["type"] == "user-skill"
+      assert json["data"]["relationships"]["user"]["data"]["id"] == "#{user.id}"
+      assert json["data"]["relationships"]["skill"]["data"]["id"] == "#{skill.id}"
+    end
+
+    @tag authenticated: :admin
+    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+      payload = build_payload
+      path = conn |> user_skill_path(:create)
+      json = conn |> post(path, payload) |> json_response(422)
+
+      assert json["errors"] != %{}
+    end
+
+    test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> user_skill_path(:create)
+      assert conn |> post(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      path = conn |> user_skill_path(:create)
+      assert conn |> post(path) |> json_response(401)
+    end
   end
 
-  test "deletes resource", %{conn: conn} do
-    skill = insert(:skill, title: "test-skill")
-    user = insert(:user)
-    user_skill = insert(:user_skill, user: user, skill: skill)
-    response = delete conn, user_skill_path(conn, :delete, user_skill)
+  describe "delete" do
+    @tag authenticated: :admin
+    test "deletes resource", %{conn: conn} do
+      user_skill = insert(:user_skill)
+      path = conn |> user_skill_path(:delete, user_skill)
+      assert conn |> delete(path) |> response(204)
+    end
 
-    assert response.status == 204
+    test "does not delete resource and renders 401 when unauthenticated", %{conn: conn} do
+      path = conn |> user_skill_path(:delete, "id not important")
+      assert conn |> delete(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+      user_skill = insert(:user_skill)
+      path = conn |> user_skill_path(:delete, user_skill)
+      assert conn |> delete(path) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders page not found when id is nonexistent on delete", %{conn: conn} do
+      path = conn |> user_skill_path(:delete, -1)
+      assert conn |> delete(path) |> json_response(404)
+    end
   end
 end

--- a/test/support/api_case.ex
+++ b/test/support/api_case.ex
@@ -1,0 +1,68 @@
+defmodule CodeCorps.ApiCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting up a connection, specificaly,
+  those working with the API endpoints.
+
+  It's basically a clone of CodeCorps.ConnCase, with some extras,
+  mainly authentication and proper headers, added.
+  """
+
+  import CodeCorps.Factories
+  use ExUnit.CaseTemplate
+  use Phoenix.ConnTest
+
+  using do
+    quote do
+      # Import conveniences for testing with connections
+      use Phoenix.ConnTest
+
+      alias CodeCorps.Repo
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+
+      import CodeCorps.AuthenticationTestHelpers
+      import CodeCorps.Router.Helpers
+      import CodeCorps.Factories
+
+      # The default endpoint for testing
+      @endpoint CodeCorps.Endpoint
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(CodeCorps.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(CodeCorps.Repo, {:shared, self()})
+    end
+
+    conn =
+      %{build_conn | host: "api."}
+      |> put_req_header("accept", "application/vnd.api+json")
+      |> put_req_header("content-type", "application/vnd.api+json")
+
+    {conn, current_user} = cond do
+      tags[:authenticated] ->
+        conn |> add_authentication_headers(tags[:authenticated])
+      true ->
+        {conn, nil}
+      end
+
+    {:ok, conn: conn, current_user: current_user}
+  end
+
+  defp add_authentication_headers(conn, true) do
+    user = insert(:user)
+    conn = conn |> CodeCorps.AuthenticationTestHelpers.authenticate(user)
+    {conn, user}
+  end
+
+  defp add_authentication_headers(conn, :admin) do
+    admin = insert(:user, admin: true)
+    conn = conn |> CodeCorps.AuthenticationTestHelpers.authenticate(admin)
+    {conn, admin}
+  end
+
+end

--- a/test/support/authentication_test_helpers.ex
+++ b/test/support/authentication_test_helpers.ex
@@ -1,0 +1,18 @@
+defmodule CodeCorps.AuthenticationTestHelpers do
+  use Phoenix.ConnTest
+  import CodeCorps.Factories
+
+  def authenticate(conn) do
+    user = insert(:user)
+
+    conn
+    |> authenticate(user)
+  end
+
+  def authenticate(conn, user) do
+    {:ok, jwt, _} = Guardian.encode_and_sign(user)
+
+    conn
+    |> put_req_header("authorization", "Bearer #{jwt}")
+  end
+end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -14,7 +14,8 @@ defmodule CodeCorps.Factories do
     %CodeCorps.Comment{
       body: "I love elixir!",
       markdown: "I love elixir!",
-      post: build(:post)
+      post: build(:post),
+      user: build(:user)
     }
   end
 
@@ -47,7 +48,8 @@ defmodule CodeCorps.Factories do
   def project_factory do
     %CodeCorps.Project{
       title: sequence(:title, &"Project #{&1}"),
-      slug: sequence(:slug, &"project-#{&1}")
+      slug: sequence(:slug, &"project-#{&1}"),
+      organization: build(:organization)
     }
   end
 

--- a/web/controllers/category_controller.ex
+++ b/web/controllers/category_controller.ex
@@ -4,6 +4,8 @@ defmodule CodeCorps.CategoryController do
   alias CodeCorps.Category
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: Category, only: [:create, :update]
+
   def index(conn, _params) do
     categories = Repo.all(Category)
     render(conn, "index.json-api", data: categories)

--- a/web/controllers/comment_controller.ex
+++ b/web/controllers/comment_controller.ex
@@ -4,6 +4,8 @@ defmodule CodeCorps.CommentController do
   alias CodeCorps.Comment
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: Comment, only: [:create, :update]
+
   plug :scrub_params, "data" when action in [:create, :update]
 
   def index(conn, _params) do

--- a/web/controllers/organization_controller.ex
+++ b/web/controllers/organization_controller.ex
@@ -6,6 +6,7 @@ defmodule CodeCorps.OrganizationController do
 
   import Organization, only: [changeset: 2]
 
+  plug :load_and_authorize_resource, model: Organization, only: [:create, :update]
   plug :scrub_params, "data" when action in [:create, :update]
 
   def index(conn, params) do

--- a/web/controllers/organization_membership_controller.ex
+++ b/web/controllers/organization_membership_controller.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.OrganizationMembershipController do
   alias JaSerializer.Params
   alias CodeCorps.OrganizationMembership
 
+  plug :load_and_authorize_resource, model: OrganizationMembership, only: [:create, :update, :delete]
   plug :scrub_params, "data" when action in [:create, :update]
 
   def index(conn, params) do

--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.PostController do
   alias CodeCorps.Post
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: Post, only: [:create, :update]
   plug :scrub_params, "data" when action in [:create, :update]
 
   def index(conn, params) do

--- a/web/controllers/preview_controller.ex
+++ b/web/controllers/preview_controller.ex
@@ -4,6 +4,8 @@ defmodule CodeCorps.PreviewController do
   alias CodeCorps.Preview
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: Preview, only: [:create]
+
   def create(conn, %{"data" => data = %{"type" => "preview", "attributes" => _project_params}}) do
     user =
       conn

--- a/web/controllers/project_category_controller.ex
+++ b/web/controllers/project_category_controller.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.ProjectCategoryController do
   alias JaSerializer.Params
   alias CodeCorps.ProjectCategory
 
+  plug :load_and_authorize_resource, model: ProjectCategory, only: [:create, :delete]
   plug :scrub_params, "data" when action in [:create]
 
   def create(conn, %{"data" => data = %{"type" => "project-category"}}) do

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.ProjectController do
   alias CodeCorps.Project
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: Project, only: [:create, :update]
   plug :scrub_params, "data" when action in [:create, :update]
 
   def index(conn, %{"slug" => slug}) do

--- a/web/controllers/project_skill_controller.ex
+++ b/web/controllers/project_skill_controller.ex
@@ -6,10 +6,11 @@ defmodule CodeCorps.ProjectSkillController do
   alias CodeCorps.ProjectSkill
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: ProjectSkill, only: [:create, :delete]
   plug :scrub_params, "data" when action in [:create, :update]
 
   def index(conn, params) do
-    project_skills = 
+    project_skills =
       case params do
         %{"filter" => %{"id" => id_list}} ->
           ids = id_list |> coalesce_id_string
@@ -17,7 +18,7 @@ defmodule CodeCorps.ProjectSkillController do
           |> preload([:project, :skill])
           |> where([p], p.id in ^ids)
           |> Repo.all
-        %{} -> 
+        %{} ->
           ProjectSkill
           |> preload([:user, :skill])
           |> Repo.all
@@ -42,7 +43,7 @@ defmodule CodeCorps.ProjectSkillController do
   end
 
   def show(conn, %{"id" => id}) do
-    project_skill = 
+    project_skill =
       ProjectSkill
       |> preload([:project, :skill])
       |> Repo.get!(id)

--- a/web/controllers/role_controller.ex
+++ b/web/controllers/role_controller.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.RoleController do
   alias CodeCorps.Role
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: Role, only: [:create]
   plug :scrub_params, "data" when action in [:create]
 
   def index(conn, _params) do

--- a/web/controllers/role_skill_controller.ex
+++ b/web/controllers/role_skill_controller.ex
@@ -6,6 +6,7 @@ defmodule CodeCorps.RoleSkillController do
   alias CodeCorps.RoleSkill
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: RoleSkill, only: [:create, :delete]
   plug :scrub_params, "data" when action in [:create]
 
   def index(conn, params) do

--- a/web/controllers/skill_controller.ex
+++ b/web/controllers/skill_controller.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.SkillController do
   alias CodeCorps.Skill
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: Skill, only: [:create]
   plug :scrub_params, "data" when action in [:create]
 
   def index(conn, params) do

--- a/web/controllers/user_category_controller.ex
+++ b/web/controllers/user_category_controller.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.UserCategoryController do
   alias CodeCorps.UserCategory
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: UserCategory, only: [:create, :delete]
   plug :scrub_params, "data" when action in [:create]
 
   def index(conn, params) do

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.UserController do
   alias CodeCorps.User
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: User, only: [:update]
   plug :scrub_params, "data" when action in [:create, :update]
 
   def index(conn, params) do

--- a/web/controllers/user_role_controller.ex
+++ b/web/controllers/user_role_controller.ex
@@ -4,6 +4,8 @@ defmodule CodeCorps.UserRoleController do
   alias CodeCorps.UserRole
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: UserRole, only: [:create, :delete]
+
   def create(conn, %{"data" => data = %{"type" => "user-role"}}) do
     changeset = UserRole.changeset(%UserRole{}, Params.to_attributes(data))
 

--- a/web/controllers/user_skill_controller.ex
+++ b/web/controllers/user_skill_controller.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.UserSkillController do
   alias CodeCorps.UserSkill
   alias JaSerializer.Params
 
+  plug :load_and_authorize_resource, model: UserSkill, only: [:create, :delete]
   plug :scrub_params, "data" when action in [:create]
 
   def index(conn, params) do

--- a/web/helpers/authentication_helpers.ex
+++ b/web/helpers/authentication_helpers.ex
@@ -1,0 +1,18 @@
+defmodule CodeCorps.AuthenticationHelpers do
+  use Phoenix.Controller
+  import Plug.Conn, only: [halt: 1, put_status: 2]
+
+  def handle_unauthorized(conn) do
+    conn
+    |> put_status(401)
+    |> render(CodeCorps.AuthView, "error.json", message: "Not authorized")
+    |> halt
+  end
+
+  def handle_not_found(conn) do
+    conn
+    |> put_status(:not_found)
+    |> render(CodeCorps.ErrorView, "404.json")
+    |> halt
+  end
+end

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -1,0 +1,91 @@
+defmodule Canary.Abilities do
+  alias CodeCorps.Category
+  alias CodeCorps.Comment
+  alias CodeCorps.Organization
+  alias CodeCorps.OrganizationMembership
+  alias CodeCorps.Post
+  alias CodeCorps.Preview
+  alias CodeCorps.Project
+  alias CodeCorps.ProjectCategory
+  alias CodeCorps.ProjectSkill
+  alias CodeCorps.Role
+  alias CodeCorps.RoleSkill
+  alias CodeCorps.Skill
+  alias CodeCorps.User
+  alias CodeCorps.UserCategory
+  alias CodeCorps.UserRole
+  alias CodeCorps.UserSkill
+
+  alias CodeCorps.CategoryPolicy
+  alias CodeCorps.CommentPolicy
+  alias CodeCorps.OrganizationPolicy
+  alias CodeCorps.OrganizationMembershipPolicy
+  alias CodeCorps.PostPolicy
+  alias CodeCorps.PreviewPolicy
+  alias CodeCorps.ProjectPolicy
+  alias CodeCorps.ProjectCategoryPolicy
+  alias CodeCorps.ProjectSkillPolicy
+  alias CodeCorps.RolePolicy
+  alias CodeCorps.RoleSkillPolicy
+  alias CodeCorps.SkillPolicy
+  alias CodeCorps.UserPolicy
+  alias CodeCorps.UserCategoryPolicy
+  alias CodeCorps.UserRolePolicy
+  alias CodeCorps.UserSkillPolicy
+
+  defimpl Canada.Can, for: User do
+    # NOTE: Canary sets an :unauthorized and a :not_found handler on a config level
+    # The problem is, it will still go through the authorization process first and only call the
+    # not found handler after the unauthorized handler does its thing. This means that our
+    # unauthorized handler will halt the connection and respond, so the not_found handler
+    # will never do anything
+    #
+    # The only solution is to have a catch_all match for the resource being nil, which returns true
+    def can?(%User{}, _action, nil), do: true
+
+    def can?(%User{} = current_user, :update, %User{} = user), do: UserPolicy.update?(user, current_user)
+
+    def can?(%User{} = user, :create, Category), do: CategoryPolicy.create?(user)
+    def can?(%User{} = user, :update, %Category{}), do: CategoryPolicy.update?(user)
+
+    def can?(%User{} = user, :create, Comment), do: CommentPolicy.create?(user)
+    def can?(%User{} = user, :update, %Comment{} = comment), do: CommentPolicy.update?(user, comment)
+
+    def can?(%User{} = user, :create, Organization), do: OrganizationPolicy.create?(user)
+    def can?(%User{} = user, :update, %Organization{} = organization), do: OrganizationPolicy.update?(user, organization)
+
+    def can?(%User{} = user, :create, OrganizationMembership), do: OrganizationMembershipPolicy.create?(user)
+    def can?(%User{} = user, :update, %OrganizationMembership{} = membership), do: OrganizationMembershipPolicy.update?(user, membership)
+    def can?(%User{} = user, :delete, %OrganizationMembership{} = membership), do: OrganizationMembershipPolicy.delete?(user, membership)
+
+    def can?(%User{} = user, :create, Post), do: PostPolicy.create?(user)
+    def can?(%User{} = user, :update, %Post{} = post), do: PostPolicy.update?(user, post)
+
+    def can?(%User{} = user, :create, Preview), do: PreviewPolicy.create?(user)
+
+    def can?(%User{} = user, :create, Project), do: ProjectPolicy.create?(user)
+    def can?(%User{} = user, :update, %Project{} = project), do: ProjectPolicy.update?(user, project)
+
+    def can?(%User{} = user, :create, ProjectCategory), do: ProjectCategoryPolicy.create?(user)
+    def can?(%User{} = user, :delete, %ProjectCategory{}), do: ProjectCategoryPolicy.delete?(user)
+
+    def can?(%User{} = user, :create, ProjectSkill), do: ProjectSkillPolicy.create?(user)
+    def can?(%User{} = user, :delete, %ProjectSkill{}), do: ProjectSkillPolicy.delete?(user)
+
+    def can?(%User{} = user, :create, Role), do: RolePolicy.create?(user)
+
+    def can?(%User{} = user, :create, RoleSkill), do: RoleSkillPolicy.create?(user)
+    def can?(%User{} = user, :delete, %RoleSkill{}), do: RoleSkillPolicy.delete?(user)
+
+    def can?(%User{} = user, :create, Skill), do: SkillPolicy.create?(user)
+
+    def can?(%User{} = user, :create, UserCategory), do: UserCategoryPolicy.create?(user)
+    def can?(%User{} = user, :delete, %UserCategory{}), do: UserCategoryPolicy.delete?(user)
+
+    def can?(%User{} = user, :create, UserRole), do: UserRolePolicy.create?(user)
+    def can?(%User{} = user, :delete, %UserRole{}), do: UserRolePolicy.delete?(user)
+
+    def can?(%User{} = user, :create, UserSkill), do: UserSkillPolicy.create?(user)
+    def can?(%User{} = user, :delete, %UserSkill{}), do: UserSkillPolicy.delete?(user)
+  end
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -15,6 +15,7 @@ defmodule CodeCorps.User do
   import CodeCorps.ModelHelpers
 
   schema "users" do
+    field :admin, :boolean
     field :base64_photo_data, :string, virtual: true
     field :biography, :string
     field :encrypted_password, :string

--- a/web/plugs/current_user.ex
+++ b/web/plugs/current_user.ex
@@ -1,0 +1,22 @@
+defmodule CodeCorps.Plug.CurrentUser do
+  import Plug.Conn
+
+  alias CodeCorps.GuardianSerializer
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    current_token = Guardian.Plug.current_token(conn)
+    case Guardian.decode_and_verify(current_token) do
+      {:ok, claims} ->
+        case GuardianSerializer.from_token(claims["sub"]) do
+          {:ok, user} ->
+            Plug.Conn.assign(conn, :current_user, user)
+          {:error, _reason} ->
+            conn
+        end
+      {:error, _reason} ->
+        conn
+    end
+  end
+end

--- a/web/policies/category_policy.ex
+++ b/web/policies/category_policy.ex
@@ -1,0 +1,8 @@
+defmodule CodeCorps.CategoryPolicy do
+  alias CodeCorps.User
+
+  def create?(%User{admin: true}), do: true
+  def create?(%User{admin: false}), do: false
+  def update?(%User{admin: true}), do: true
+  def update?(%User{admin: false}), do: false
+end

--- a/web/policies/comment_policy.ex
+++ b/web/policies/comment_policy.ex
@@ -1,0 +1,8 @@
+defmodule CodeCorps.CommentPolicy do
+  alias CodeCorps.Comment
+  alias CodeCorps.User
+
+  def create?(%User{}), do: true
+
+  def update?(%User{} = user, %Comment{} = comment), do: user.id == comment.user_id
+end

--- a/web/policies/organization_membership_policy.ex
+++ b/web/policies/organization_membership_policy.ex
@@ -1,0 +1,61 @@
+defmodule CodeCorps.OrganizationMembershipPolicy do
+  alias CodeCorps.User
+  alias CodeCorps.Organization
+  alias CodeCorps.OrganizationMembership
+
+  alias CodeCorps.Repo
+
+  import Ecto.Query
+
+  # TODO: Make it so validation handles the fact that membership role needs to be "pending" on create
+  def create?(%User{} = _user), do: true
+
+  def update?(%User{} = user, %OrganizationMembership{} = current_membership) do
+    current_organization = current_membership |> fetch_organization
+    user_membership = user |> fetch_membership(current_organization)
+
+    permitted? = case user_membership do
+      # owner can update any membership
+      %OrganizationMembership{role: "owner"} -> true
+      # admin can only update lower level roles
+      %OrganizationMembership{role: "admin"} -> current_membership.role in ["pending", "contributor"]
+      # all other members, or non-members, are not permitted
+      _ -> false
+    end
+
+    permitted?
+  end
+
+  # user can always leave the organization on their own
+  def delete?(%User{} = user, %OrganizationMembership{} = current_membership) do
+    user_membership = cond do
+      user.id == current_membership.member_id ->
+        current_membership
+      true ->
+        organization = current_membership |> fetch_organization
+        user |> fetch_membership(organization)
+    end
+
+    permitted? = case user_membership do
+      # owner can delete any membership
+      %OrganizationMembership{role: "owner"} -> true
+      # admin can only delete lower level roles
+      %OrganizationMembership{role: "admin"} -> user_membership.role in ["pending", "contributor"]
+      # all other members, or non-members, are not permitted
+      _ -> false
+    end
+
+    permitted?
+  end
+
+  defp fetch_organization(membership) do
+    Organization
+    |> Repo.get(membership.organization_id)
+  end
+  defp fetch_membership(user, nil), do: nil
+  defp fetch_membership(user, organization) do
+    OrganizationMembership
+    |> where([m], m.member_id == ^user.id and m.organization_id == ^organization.id)
+    |> Repo.one
+  end
+end

--- a/web/policies/organization_policy.ex
+++ b/web/policies/organization_policy.ex
@@ -1,0 +1,21 @@
+defmodule CodeCorps.OrganizationPolicy do
+  alias CodeCorps.User
+  alias CodeCorps.Organization
+  alias CodeCorps.OrganizationMembership
+
+  import Ecto.Query
+
+  def create?(%User{admin: true}), do: true
+  def create?(%User{admin: false}), do: false
+
+  def update?(%User{} = user, %Organization{} = organization), do: user |> role_is_at_least_admin(organization)
+
+  defp role_is_at_least_admin(%User{} = user, %Organization{} = organization) do
+    count =
+      OrganizationMembership
+      |> where([m], m.member_id == ^user.id and m.organization_id == ^organization.id and m.role in ["admin", "owner"])
+      |> CodeCorps.Repo.aggregate(:count, :id)
+
+    count > 0
+  end
+end

--- a/web/policies/post_policy.ex
+++ b/web/policies/post_policy.ex
@@ -1,0 +1,41 @@
+defmodule CodeCorps.PostPolicy do
+  alias CodeCorps.OrganizationMembership
+  alias CodeCorps.Post
+  alias CodeCorps.Project
+  alias CodeCorps.User
+
+  alias CodeCorps.Repo
+
+  import Ecto.Query
+
+  # TODO: Need to be able to see what resource is being created here
+  # Previously, any user could create issues and ideas, but only
+  # approved members of organization could create other post types
+  def create?(%User{} = _user), do: true
+
+  def update?(%User{} = user, %Post{} = post) do
+    permitted? = cond do
+      # author can update own post
+      user.id == post.user_id -> true
+      # organization admin or higher can update other people's posts
+      user |> is_admin_or_higher(post) -> true
+      # do not permit for any other case
+      true -> false
+    end
+
+    permitted?
+  end
+
+  defp is_admin_or_higher(%User{} = user, %Post{} = post) do
+    project = Project |> Repo.get(post.project_id)
+    membership =
+      OrganizationMembership
+      |> where([m], m.member_id == ^user.id and m.organization_id == ^project.organization_id)
+      |> Repo.one
+
+    membership |> is_admin_or_higher
+  end
+
+  defp is_admin_or_higher(nil), do: false
+  defp is_admin_or_higher(%OrganizationMembership{} = membership), do: membership.role in ["admin", "owner"]
+end

--- a/web/policies/preview_policy.ex
+++ b/web/policies/preview_policy.ex
@@ -1,0 +1,5 @@
+defmodule CodeCorps.PreviewPolicy do
+  alias CodeCorps.User
+
+  def create?(%User{} = _user), do: true
+end

--- a/web/policies/project_category_policy.ex
+++ b/web/policies/project_category_policy.ex
@@ -1,0 +1,34 @@
+defmodule CodeCorps.ProjectCategoryPolicy do
+  alias CodeCorps.OrganizationMembership
+  alias CodeCorps.ProjectCategory
+  alias CodeCorps.User
+
+  alias CodeCorps.Repo
+
+  import Ecto.Query
+
+  # TODO: Need to figure out how to pass in params. We need to know
+  # if user is at least admin in organization, before they can assign
+  # a category to a project. Same goes for delete
+  def create?(%User{admin: true} = _user), do: true
+  def create?(%User{} = _user), do: false
+  def create?(%User{} = user, %ProjectCategory{} = project_category), do: user |> is_admin_or_higher(project_category)
+
+  def delete?(%User{admin: true} = _user), do: true
+  def delete?(%User{} = _user), do: false
+  def delete?(%User{} = user, %ProjectCategory{} = project_category), do: user |> is_admin_or_higher(project_category)
+
+  defp is_admin_or_higher(%User{} = user, %ProjectCategory{} = project_category) do
+    project = Project |> Repo.get(project_category.project_id)
+
+    membership =
+      OrganizationMembership
+      |> where([m], m.member_id == ^user.id and m.organization_id == ^project.organization_id)
+      |> Repo.one
+
+    membership |> is_admin_or_higher
+  end
+
+  defp is_admin_or_higher(nil), do: false
+  defp is_admin_or_higher(%OrganizationMembership{} = membership), do: membership.role in ["admin", "owner"]
+end

--- a/web/policies/project_policy.ex
+++ b/web/policies/project_policy.ex
@@ -1,0 +1,29 @@
+defmodule CodeCorps.ProjectPolicy do
+  alias CodeCorps.OrganizationMembership
+  alias CodeCorps.Project
+  alias CodeCorps.User
+
+  alias CodeCorps.Repo
+
+  import Ecto.Query
+
+  # TODO: ProjectPolicy needs testing for the case of user being at least admin
+  # in project organization
+
+  def create?(%User{admin: true}), do: true
+  def create?(%User{}), do: false
+  def create?(%User{} = user, %Project{} = project), do: user |> fetch_membership(project) |> is_admin_or_higher
+
+  def update?(%User{admin: true}, %Project{}), do: true
+  def update?(%User{}, %Project{}), do: false
+  def update?(%User{} = user, %Project{} = project), do: user |> fetch_membership(project) |> is_admin_or_higher
+
+  defp fetch_membership(%User{} = user, %Project{} = project) do
+    OrganizationMembership
+    |> where([m], m.member_id == ^user.id and m.organization_id == ^project.organization_id)
+    |> Repo.one
+  end
+
+  defp is_admin_or_higher(nil), do: false
+  defp is_admin_or_higher(%OrganizationMembership{} = membership), do: membership.role in ["admin", "owner"]
+end

--- a/web/policies/project_skill_policy.ex
+++ b/web/policies/project_skill_policy.ex
@@ -1,0 +1,34 @@
+defmodule CodeCorps.ProjectSkillPolicy do
+  alias CodeCorps.OrganizationMembership
+  alias CodeCorps.ProjectSkill
+  alias CodeCorps.User
+
+  alias CodeCorps.Repo
+
+  import Ecto.Query
+
+  # TODO: Need to figure out how to pass in params. We need to know
+  # if user is at least admin in organization, before they can assign
+  # a category to a project. Same goes for delete
+  def create?(%User{admin: true} = _user), do: true
+  def create?(%User{} = _user), do: false
+  def create?(%User{} = user, %ProjectSkill{} = project_skill), do: user |> is_admin_or_higher(project_skill)
+
+  def delete?(%User{admin: true} = _user), do: true
+  def delete?(%User{} = _user), do: false
+  def delete?(%User{} = user, %ProjectSkill{} = project_skill), do: user |> is_admin_or_higher(project_skill)
+
+  defp is_admin_or_higher(%User{} = user, %ProjectSkill{} = project_skill) do
+    project = Project |> Repo.get(project_skill.project_id)
+
+    membership =
+      OrganizationMembership
+      |> where([m], m.member_id == ^user.id and m.organization_id == ^project.organization_id)
+      |> Repo.one
+
+    membership |> is_admin_or_higher
+  end
+
+  defp is_admin_or_higher(nil), do: false
+  defp is_admin_or_higher(%OrganizationMembership{} = membership), do: membership.role in ["admin", "owner"]
+end

--- a/web/policies/role_policy.ex
+++ b/web/policies/role_policy.ex
@@ -1,0 +1,6 @@
+defmodule CodeCorps.RolePolicy do
+  alias CodeCorps.User
+
+  def create?(%User{admin: true}), do: true
+  def create?(%User{admin: false}), do: false
+end

--- a/web/policies/role_skill_policy.ex
+++ b/web/policies/role_skill_policy.ex
@@ -1,0 +1,9 @@
+defmodule CodeCorps.RoleSkillPolicy do
+  alias CodeCorps.User
+
+  def create?(%User{admin: true}), do: true
+  def create?(%User{admin: false}), do: false
+
+  def delete?(%User{admin: true}), do: true
+  def delete?(%User{admin: false}), do: false
+end

--- a/web/policies/skill_policy.ex
+++ b/web/policies/skill_policy.ex
@@ -1,0 +1,6 @@
+defmodule CodeCorps.SkillPolicy do
+  alias CodeCorps.User
+
+  def create?(%User{admin: true}), do: true
+  def create?(%User{admin: false}), do: false
+end

--- a/web/policies/user_category_policy.ex
+++ b/web/policies/user_category_policy.ex
@@ -1,0 +1,19 @@
+defmodule CodeCorps.UserCategoryPolicy do
+  alias CodeCorps.OrganizationMembership
+  alias CodeCorps.UserCategory
+  alias CodeCorps.User
+
+  alias CodeCorps.Repo
+
+  import Ecto.Query
+
+  def create?(%User{admin: true}), do: true
+  def create?(%User{}), do: false
+  # TODO: Need to figure out how to pass in params for create
+  # A non-admin user can modify their own category. This method is right now unreachable
+  def create?(%User{} = user, %UserCategory{} = user_category), do: user.id == user_category.user_id
+
+  def delete?(%User{admin: true}), do: true
+  def delete?(%User{}), do: false
+  def delete?(%User{} = user, %UserCategory{} = user_category), do: user.id == user_category.user_id
+end

--- a/web/policies/user_policy.ex
+++ b/web/policies/user_policy.ex
@@ -1,0 +1,5 @@
+defmodule CodeCorps.UserPolicy do
+  alias CodeCorps.User
+
+  def update?(%User{} = user, %User{} = current_user), do: user.id == current_user.id
+end

--- a/web/policies/user_role_policy.ex
+++ b/web/policies/user_role_policy.ex
@@ -1,0 +1,19 @@
+defmodule CodeCorps.UserRolePolicy do
+  alias CodeCorps.OrganizationMembership
+  alias CodeCorps.UserRole
+  alias CodeCorps.User
+
+  alias CodeCorps.Repo
+
+  import Ecto.Query
+
+  def create?(%User{admin: true}), do: true
+  def create?(%User{}), do: false
+  # TODO: Need to figure out how to pass in params for create
+  # A non-admin user can modify their own category. This method is right now unreachable
+  def create?(%User{} = user, %UserRole{} = user_role), do: user.id == user_role.user_id
+
+  def delete?(%User{admin: true}), do: true
+  def delete?(%User{}), do: false
+  def delete?(%User{} = user, %UserRole{} = user_role), do: user.id == user_role.user_id
+end

--- a/web/policies/user_skill_policy.ex
+++ b/web/policies/user_skill_policy.ex
@@ -1,0 +1,19 @@
+defmodule CodeCorps.UserSkillPolicy do
+  alias CodeCorps.OrganizationMembership
+  alias CodeCorps.UserSkill
+  alias CodeCorps.User
+
+  alias CodeCorps.Repo
+
+  import Ecto.Query
+
+  def create?(%User{admin: true}), do: true
+  def create?(%User{}), do: false
+  # TODO: Need to figure out how to pass in params for create
+  # A non-admin user can modify their own skill. This method is right now unreachable
+  def create?(%User{} = user, %UserSkill{} = user_skill), do: user.id == user_skill.user_id
+
+  def delete?(%User{admin: true}), do: true
+  def delete?(%User{}), do: false
+  def delete?(%User{} = user, %UserSkill{} = user_skill), do: user.id == user_skill.user_id
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -11,9 +11,14 @@ defmodule CodeCorps.Router do
 
   pipeline :api do
     plug :accepts, ["json-api", "json"]
-    plug Guardian.Plug.VerifyHeader
-    plug Guardian.Plug.LoadResource
     plug JaSerializer.Deserializer
+  end
+
+  pipeline :with_token do
+    plug Guardian.Plug.VerifyHeader, realm: "Bearer"
+    plug Guardian.Plug.LoadResource
+    plug Guardian.Plug.EnsureAuthenticated
+    plug CodeCorps.Plug.CurrentUser
   end
 
   scope "/", CodeCorps do
@@ -25,47 +30,59 @@ defmodule CodeCorps.Router do
   scope "/", CodeCorps, host: "api." do
     pipe_through :api
 
-    resources "/categories", CategoryController, only: [:index, :show, :create, :update]
-
-    resources "/comments", CommentController, only: [:index, :show, :create, :update]
-
     post "/login", AuthController, :create
-    delete "/logout", AuthController, :delete
 
-    resources "/organizations", OrganizationController, only: [:index, :show, :create, :update] do
+    resources "/categories", CategoryController, only: [:index, :show]
+    resources "/comments", CommentController, only: [:index, :show]
+
+    resources "/organizations", OrganizationController, only: [:index, :show] do
       resources "/memberships", OrganizationMembershipController, only: [:index]
     end
 
-    resources "/organization-memberships", OrganizationMembershipController, only: [:index, :show, :create, :update, :delete]
+    resources "/organization-memberships", OrganizationMembershipController, only: [:index, :show]
 
-    resources "/posts", PostController, only: [:create, :index, :show, :update] do
+    resources "/posts", PostController, only: [:index, :show] do
       resources "/comments", CommentController, only: [:index, :show]
     end
 
-    resources "/previews", PreviewController, only: [:create]
-
-    resources "/projects", ProjectController, only: [:index, :show, :create, :update] do
+    resources "/projects", ProjectController, only: [:index, :show] do
       resources "/posts", PostController, only: [:index, :show]
     end
 
-    resources "/project_categories", ProjectCategoryController, only: [:create, :delete]
-    resources "/project-skills", ProjectSkillController, only: [:index, :show, :create, :delete]
-
-    resources "/roles", RoleController, only: [:create, :index, :show]
-    resources "/role-skills", RoleSkillController, only: [:index, :show, :create, :delete]
-
-    resources "/skills", SkillController, only: [:create, :index, :show]
-
+    resources "/project-skills", ProjectSkillController, only: [:index, :show]
+    resources "/roles", RoleController, only: [:index, :show]
+    resources "/skills", SkillController, only: [:index, :show]
     get "/users/email_available", UserController, :email_available
     get "/users/username_available", UserController, :username_available
-    resources "/users", UserController, only: [:index, :show, :create, :update]
-
-    resources "/user-categories", UserCategoryController, only: [:index, :show, :create, :delete]
-    resources "/user-roles", UserRoleController, only: [:create, :delete]
-    resources "/user-skills", UserSkillController, only: [:index, :show, :create, :delete]
-
+    resources "/users", UserController, only: [:index, :show, :create]
+    resources "/user-categories", UserCategoryController, only: [:index, :show]
+    resources "/user-skills", UserSkillController, only: [:index, :show]
+    resources "/role-skills", RoleSkillController, only: [:index, :show]
     get "/:slug", SluggedRouteController, :show
     get "/:slug/projects", ProjectController, :index
     get "/:slug/:project_slug", ProjectController, :show
+  end
+
+  scope "/", CodeCorps, host: "api." do
+    pipe_through [:api, :with_token]
+
+    delete "/logout", AuthController, :delete
+
+    resources "/categories", CategoryController, only: [:create, :update]
+    resources "/comments", CommentController, only: [:create, :update]
+    resources "/organizations", OrganizationController, only: [:create, :update]
+    resources "/organization-memberships", OrganizationMembershipController, only: [:create, :update, :delete]
+    resources "/posts", PostController, only: [:create, :update]
+    resources "/previews", PreviewController, only: [:create]
+    resources "/projects", ProjectController, only: [:create, :update]
+    resources "/project-categories", ProjectCategoryController, only: [:create, :delete]
+    resources "/project-skills", ProjectSkillController, only: [:create, :delete]
+    resources "/roles", RoleController, only: [:create]
+    resources "/skills", SkillController, only: [:create]
+    resources "/users", UserController, only: [:update]
+    resources "/user-categories", UserCategoryController, only: [:create, :delete]
+    resources "/user-roles", UserRoleController, only: [:create, :delete]
+    resources "/user-skills", UserSkillController, only: [:create, :delete]
+    resources "/role-skills", RoleSkillController, only: [:create, :delete]
   end
 end

--- a/web/views/error_view.ex
+++ b/web/views/error_view.ex
@@ -1,6 +1,18 @@
 defmodule CodeCorps.ErrorView do
   use CodeCorps.Web, :view
 
+  def render("404.json", _assings) do
+    %{
+      errors: [
+        %{
+          id: "NOT_FOUND",
+          title: "404 Resource not found",
+          status: 404,
+        }
+      ]
+    }
+  end
+
   def render("404.html", _assigns) do
     "Page not found"
   end

--- a/web/web.ex
+++ b/web/web.ex
@@ -36,6 +36,8 @@ defmodule CodeCorps.Web do
 
       import CodeCorps.Router.Helpers
       import CodeCorps.Gettext
+
+      import Canary.Plugs
     end
   end
 


### PR DESCRIPTION
This is a first spike of what `canary` might look like.

Way unfinished but would love thoughts on this now.

Essentially having trouble finding a way to bring in the `current_user` that `canary` needs for requests. Trying to not have the server choke when the token is `nil`.

Had to split apart those endpoints that need authentication from those that do not. Added a `:with_token` pipeline for those that need authed.
### Notes by begedin:

The way canary works, we can't really look at what changes are happening to the record, especially on create. Due to that, organization membership permissions need to be simplified a bit. There is also a list of things that should be converted to tasks, post merge
- For creation of an organization membership, only a "pending" value should be allowed for the role field. This should be done trough the changeset, not permissions.
- More incoming
