### PR TITLE
Fix project changesets

### DIFF
--- a/test/models/project_test.exs
+++ b/test/models/project_test.exs
@@ -6,50 +6,71 @@ defmodule CodeCorps.ProjectTest do
   @valid_attrs %{title: "A title"}
   @invalid_attrs %{}
 
-  test "changeset with valid attributes is valid" do
-    changeset = Project.changeset(%Project{}, @valid_attrs)
-    assert changeset.valid?
+  describe "changeset/3" do
+    test "with valid attributes is valid" do
+      changeset = Project.changeset(%Project{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "with invalid attributes is invalid and has errors" do
+      changeset = Project.changeset(%Project{}, @invalid_attrs)
+      refute changeset.valid?
+
+      assert changeset.errors[:title] == {"can't be blank", []}
+    end
+
+    test "with long_description_markdown renders long_description_body" do
+      changeset = Project.changeset(%Project{}, @valid_attrs |> Map.merge(%{long_description_markdown: "Something"}))
+      assert changeset |> fetch_change(:long_description_body) == { :ok, "<p>Something</p>\n" }
+    end
+
+    test "without long_description_markdown doesn't render long_description_body" do
+      changeset = Project.changeset(%Project{}, @valid_attrs)
+      assert changeset |> fetch_change(:long_description_body) == :error
+    end
+
+    @tag :requires_env
+    test "uploads base64icon data to aws" do
+      # 1x1 black pixel gif
+      icon_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="
+      project = insert(:project)
+      attrs = %{base64_icon_data: icon_data, title: "Test"}
+
+      changeset = Project.changeset(project, attrs)
+
+      assert changeset.valid?
+      [_, file_type] = changeset.changes.icon.file_name |> String.split(".")
+      assert file_type == "gif"
+    end
+
+    test "generates slug from title" do
+      changeset = Project.changeset(%Project{}, @valid_attrs)
+      assert changeset |> get_change(:slug) == "a-title"
+    end
+
+    test "validates slug is unique" do
+      insert(:project, slug: "used-slug")
+      changeset = Project.changeset(%Project{}, %{title: "Used Slug"})
+
+      {result, changeset} = Repo.insert(changeset)
+      {message, _} = changeset.errors[:slug]
+
+      assert result == :error
+      assert message == "has already been taken"
+    end
   end
 
-  test "changeset with invalid attributes is invalid and has errors" do
-    changeset = Project.changeset(%Project{}, @invalid_attrs)
-    refute changeset.valid?
-
-    assert changeset.errors[:title] == {"can't be blank", []}
+  describe "create_changeset/3" do
+    test "accepts setting of organization_id" do
+      changeset = Project.create_changeset(%Project{}, %{organization_id: 1})
+      assert {:ok, 1} == changeset |> fetch_change(:organization_id)
+    end
   end
 
-  test "changeset with long_description_markdown renders long_description_body" do
-    changeset = Project.changeset(%Project{}, @valid_attrs |> Map.merge(%{long_description_markdown: "Something"}))
-    assert changeset |> fetch_change(:long_description_body) == { :ok, "<p>Something</p>\n" }
-  end
-
-  test "changeset without long_description_markdown doesn't render long_description_body" do
-    changeset = Project.changeset(%Project{}, @valid_attrs)
-    assert changeset |> fetch_change(:long_description_body) == :error
-  end
-
-  test "create changeset with valid attributes" do
-    changeset = Project.create_changeset(%Project{}, @valid_attrs)
-    assert changeset.valid?
-    assert changeset.changes.slug == "a-title"
-  end
-
-  test "create changeset with invalid attributes" do
-    changeset = Project.create_changeset(%Project{}, @invalid_attrs)
-    refute changeset.valid?
-  end
-
-  @tag :requires_env
-  test "uploads base64icon data to aws" do
-    # 1x1 black pixel gif
-    icon_data = "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="
-    project = insert(:project)
-    attrs = %{base64_icon_data: icon_data, title: "Test"}
-
-    changeset = Project.changeset(project, attrs)
-
-    assert changeset.valid?
-    [_, file_type] = changeset.changes.icon.file_name |> String.split(".")
-    assert file_type == "gif"
+  describe "update_changeset/3" do
+    test "rejects setting of organization id" do
+      changeset = Project.update_changeset(%Project{}, %{organization_id: 1})
+      assert :error == changeset |> fetch_change(:organization_id)
+    end
   end
 end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -5,7 +5,7 @@ defmodule CodeCorps.Factories do
   def category_factory do
     %CodeCorps.Category{
       name: sequence(:name, &"Category #{&1}"),
-      slug: sequence(:slug, &"category_#{&1}"),
+      slug: sequence(:slug, &"category-#{&1}"),
       description: sequence(:description, &"A description for category #{&1}"),
     }
   end
@@ -47,7 +47,7 @@ defmodule CodeCorps.Factories do
   def project_factory do
     %CodeCorps.Project{
       title: sequence(:title, &"Project #{&1}"),
-      slug: sequence(:slug, &"project_#{&1}")
+      slug: sequence(:slug, &"project-#{&1}")
     }
   end
 

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -67,7 +67,7 @@ defmodule CodeCorps.ProjectController do
     changeset =
       Project
       |> Repo.get!(id)
-      |> Project.changeset(Params.to_attributes(data))
+      |> Project.update_changeset(Params.to_attributes(data))
 
     case Repo.update(changeset) do
       {:ok, project} ->

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -34,7 +34,7 @@ defmodule CodeCorps.Project do
 
   def changeset(struct, params) do
     struct
-  	|> cast(params, [:title, :description, :long_description_markdown, :organization_id, :base64_icon_data])
+    |> cast(params, [:title, :description, :long_description_markdown, :base64_icon_data])
     |> validate_required(:title)
     |> generate_slug(:title, :slug)
     |> validate_slug(:slug)
@@ -48,9 +48,16 @@ defmodule CodeCorps.Project do
   """
   def create_changeset(struct, params) do
     struct
+    |> cast(params, [:organization_id])
     |> changeset(params)
-    |> generate_slug(:title, :slug)
-    |> validate_required([:slug])
-    |> validate_slug(:slug)
+
+  end
+
+  @doc """
+  Builds a changeset for updating a project.
+  """
+  def update_changeset(struct, params) do
+    struct
+    |> changeset(params)
   end
 end


### PR DESCRIPTION
Fixes #93 and adds some stuff on top
- add update_changeset which does not allow organization id
- add specs for slugs and update/create changesets
