### PR TITLE
Fix unused variable warning

### DIFF
--- a/web/policies/organization_membership_policy.ex
+++ b/web/policies/organization_membership_policy.ex
@@ -52,7 +52,7 @@ defmodule CodeCorps.OrganizationMembershipPolicy do
     Organization
     |> Repo.get(membership.organization_id)
   end
-  defp fetch_membership(user, nil), do: nil
+  defp fetch_membership(_user, nil), do: nil
   defp fetch_membership(user, organization) do
     OrganizationMembership
     |> where([m], m.member_id == ^user.id and m.organization_id == ^organization.id)


### PR DESCRIPTION
Since the `user` variable is never used, the compiler throws a warning.
The `_` signifies that we don't care about the value of the variable so
the compiler will ignore it.
