### PR TITLE
Paginate Posts

### DIFF
--- a/lib/code_corps/repo.ex
+++ b/lib/code_corps/repo.ex
@@ -1,3 +1,4 @@
 defmodule CodeCorps.Repo do
   use Ecto.Repo, otp_app: :code_corps
+  use Scrivener, page_size: 10
 end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,8 @@ defmodule CodeCorps.Mixfile do
         :earmark,
         :ex_aws,
         :httpoison,
-        :arc_ecto
+        :arc_ecto,
+        :scrivener_ecto
       ]
     ]
   end
@@ -70,6 +71,7 @@ defmodule CodeCorps.Mixfile do
       {:httpoison, "~> 0.7"},
       {:poison, "~> 1.2"},
       {:canary, "~> 0.14.2"}, # Authorization
+      {:scrivener_ecto, "~> 1.0"} # DB query pagination
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -43,5 +43,7 @@
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "postgrex": {:hex, :postgrex, "0.11.2", "139755c1359d3c5c6d6e8b1ea72556d39e2746f61c6ddfb442813c91f53487e8", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
+  "scrivener": {:hex, :scrivener, "2.1.1", "eb52c8b7d283e8999edd6fd50d872ab870669d1f4504134841d0845af11b5ef3", [:mix], []},
+  "scrivener_ecto": {:hex, :scrivener_ecto, "1.0.1", "013ff84d3bf1a29ecc5cead9808c2433c4cc5531333249cb0186454d06e817c3", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: false]}, {:postgrex, "~> 0.11.2", [hex: :postgrex, optional: true]}, {:scrivener, "~> 2.0", [hex: :scrivener, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "uuid": {:hex, :uuid, "1.1.4", "36c7734e4c8e357f2f67ba57fb61799d60c20a7f817b104896cca64b857e3686", [:mix], []}}

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -5,6 +5,7 @@ alias CodeCorps.Project
 alias CodeCorps.Role
 alias CodeCorps.Skill
 alias CodeCorps.User
+alias CodeCorps.Post
 
 # Users
 
@@ -274,4 +275,25 @@ cond do
       Category.create_changeset(%Category{}, category)
       |> Repo.insert!
     end)
+end
+
+# Posts
+
+cond do
+  Repo.all(Post) != [] ->
+    IO.puts "Posts detected, aborting post seed."
+  true ->
+    for i <- 1..50 do
+      %Post{}
+      |> Post.create_changeset(%{
+        title: "test post #{i}",
+        markdown: "test *body* #{i}",
+        post_type: Enum.random(~w{idea issue task}),
+        status: "open",
+        number: i,
+        project_id: 1,
+        user_id: 1
+      })
+      |> Repo.insert!
+    end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -30,7 +30,7 @@ cond do
     Enum.each(users, fn user ->
       %User{}
       |> User.registration_changeset(user)
-      |> Repo.insert!()
+      |> Repo.insert!
     end)
 end
 

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -176,4 +176,66 @@ defmodule CodeCorps.PostControllerTest do
       assert conn |> put(path, payload) |> json_response(401)
     end
   end
+  
+  describe "pagination" do
+    test "specifying a page size works", %{conn: conn} do
+      project_1 = insert(:project)
+      user = insert(:user)
+      insert(:post, project: project_1, user: user)
+      insert(:post, project: project_1, user: user)
+      insert(:post, project: project_1, user: user)
+
+      path = conn |> post_path(:index)
+      json =
+        conn
+        |> get(path, page_size: 2)
+        |> json_response(200)
+
+      assert json["data"] |> Enum.count == 2
+    end
+    
+    test "specifying a page number works", %{conn: conn} do
+      project_1 = insert(:project)
+      user = insert(:user)
+      insert(:post, project: project_1, user: user)
+      insert(:post, project: project_1, user: user)
+      post_to_test = insert(:post, project: project_1, user: user)
+      insert(:post, project: project_1, user: user)
+      
+      path = conn |> post_path(:index)
+      json =
+        conn
+        |> get(path, page: 2, page_size: 2)
+        |> json_response(200)
+      
+      [ %{"id" => id} | _ ] = json["data"]
+        
+      assert String.to_integer(id) == post_to_test.id
+    end
+    
+    test "paginated results include a valid meta key", %{conn: conn} do
+      project_1 = insert(:project)
+      user = insert(:user)
+      insert(:post, project: project_1, user: user)
+      insert(:post, project: project_1, user: user)
+      insert(:post, project: project_1, user: user)
+      insert(:post, project: project_1, user: user)
+      insert(:post, project: project_1, user: user)
+      insert(:post, project: project_1, user: user)
+      
+      meta = %{
+        "total_records" => 6,
+        "total_pages" => 3,
+        "page_size" => 2,
+        "current_page" => 1,
+      }
+      path = conn |> post_path(:index)
+      json =
+        conn
+        |> get(path, page_size: 2)
+        |> json_response(200)
+        
+      assert json["meta"] == meta
+    end
+  end
 end

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -188,7 +188,7 @@ defmodule CodeCorps.PostControllerTest do
       path = conn |> post_path(:index)
       json =
         conn
-        |> get(path, page_size: 2)
+        |> get(path, page: %{page_size: 2})
         |> json_response(200)
 
       assert json["data"] |> Enum.count == 2
@@ -205,7 +205,7 @@ defmodule CodeCorps.PostControllerTest do
       path = conn |> post_path(:index)
       json =
         conn
-        |> get(path, page: 2, page_size: 2)
+        |> get(path, page: %{ page: 2, page_size: 2 })
         |> json_response(200)
       
       [ %{"id" => id} | _ ] = json["data"]
@@ -232,7 +232,7 @@ defmodule CodeCorps.PostControllerTest do
       path = conn |> post_path(:index)
       json =
         conn
-        |> get(path, page_size: 2)
+        |> get(path, page: %{ page_size: 2 })
         |> json_response(200)
         
       assert json["meta"] == meta

--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -12,8 +12,16 @@ defmodule CodeCorps.PostController do
       Post
       |> preload([:comments, :project, :user])
       |> Post.index_filters(params)
-      |> Repo.all
-    render(conn, "index.json-api", data: posts)
+      |> Repo.paginate(params)
+
+    meta = %{
+      current_page: posts.page_number,
+      page_size: posts.page_size,
+      total_pages: posts.total_pages,
+      total_records: posts.total_entries
+    }
+
+    render(conn, "index.json-api", data: posts, opts: [meta: meta])
   end
 
   def create(conn, %{"data" => data = %{"type" => "post", "attributes" => _post_params}}) do

--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -12,7 +12,7 @@ defmodule CodeCorps.PostController do
       Post
       |> preload([:comments, :project, :user])
       |> Post.index_filters(params)
-      |> Repo.paginate(params)
+      |> Repo.paginate(params["page"])
 
     meta = %{
       current_page: posts.page_number,


### PR DESCRIPTION
For #85. 

Adds two additional query param inputs to the `PostController` index action: `page[page]` and `page[page-size]`. `page[page]` defaults to 1 and `page[page-size]` defaults to 10 if not provided.

This slightly tweaks the pagination inputs from what the ember adapter is currently providing.
For the ember app to comply with this implementation, the [post adapter will need to update the name of the key in the page dict at which it sets the desired page number](https://github.com/code-corps/code-corps-ember/blob/develop/app/adapters/post.js#L14) from `number` to `page`. https://github.com/code-corps/code-corps-ember/pull/363

So given a query string that look like this:

```
?page[number]=2&status=open
------^ needs to change
```

changes to

```
?page[page]=2&status=open
```

And that should be it.

For reference, we're leveraging [Scrivener.Ecto](https://github.com/drewolson/scrivener_ecto) which is just delightful and also [ja_serializer](https://github.com/AgilionApps/ja_serializer#pagination) has out-of-the-box integration.
