### PR TITLE
Removed unecessary function match from post_policy

### DIFF
--- a/web/policies/project_policy.ex
+++ b/web/policies/project_policy.ex
@@ -15,7 +15,6 @@ defmodule CodeCorps.ProjectPolicy do
   def create?(%User{} = user, %Project{} = project), do: user |> fetch_membership(project) |> is_admin_or_higher
 
   def update?(%User{admin: true}, %Project{}), do: true
-  def update?(%User{}, %Project{}), do: false
   def update?(%User{} = user, %Project{} = project), do: user |> fetch_membership(project) |> is_admin_or_higher
 
   defp fetch_membership(%User{} = user, %Project{} = project) do


### PR DESCRIPTION
While we do lack tests for all policies, this is a quick fix to remove a function that will always match and prevent the proper function from being called.
