### PR TITLE
Post state and status management

### DIFF
--- a/test/models/post_test.exs
+++ b/test/models/post_test.exs
@@ -12,7 +12,7 @@ defmodule CodeCorps.PostTest do
     post_type: "nonexistent"
   }
 
-  describe "&create/2" do
+  describe "create/2" do
     test "is invalid with invalid attributes" do
       changeset = Post.changeset(%Post{}, @invalid_attrs)
       refute changeset.valid?
@@ -38,7 +38,7 @@ defmodule CodeCorps.PostTest do
     end
   end
 
-  describe "&create_changeset/2" do
+  describe "create_changeset/2" do
     test "is valid with valid attributes" do
       user = insert(:user)
       project = insert(:project)
@@ -92,7 +92,7 @@ defmodule CodeCorps.PostTest do
       assert changeset |> get_field(:status) == "open"
     end
   end
-  describe "&update_changeset/2" do
+  describe "update_changeset/2" do
     test "sets state to 'edited'" do
       changeset = Post.update_changeset(%Post{}, %{})
       assert changeset |> get_change(:state) == "edited"

--- a/test/models/post_test.exs
+++ b/test/models/post_test.exs
@@ -7,11 +7,9 @@ defmodule CodeCorps.PostTest do
     title: "Test post",
     post_type: "issue",
     markdown: "A test post",
-    status: "open"
   }
   @invalid_attrs %{
-    post_type: "nonexistent",
-    status: "nonexistent"
+    post_type: "nonexistent"
   }
 
   describe "&create/2" do
@@ -50,7 +48,6 @@ defmodule CodeCorps.PostTest do
         title: "some content",
         project_id: project.id,
         user_id: user.id,
-        status: "open"
       })
       assert changeset.valid?
     end

--- a/test/models/post_test.exs
+++ b/test/models/post_test.exs
@@ -20,12 +20,6 @@ defmodule CodeCorps.PostTest do
       refute changeset.valid?
     end
 
-    test "only allows specific values for status" do
-      changes = Map.put(@valid_attrs, :status, "nonexistent")
-      changeset = Post.changeset(%Post{}, changes)
-      refute changeset.valid?
-    end
-
     test "only allows specific values for post_type" do
       changes = Map.put(@valid_attrs, :post_type, "nonexistent")
       changeset = Post.changeset(%Post{}, changes)
@@ -91,14 +85,26 @@ defmodule CodeCorps.PostTest do
     end
 
     test "sets state to 'published'" do
-      changeset = Post.create_changeset(%Post{}, %{project_id: 1, user_id: 2})
+      changeset = Post.create_changeset(%Post{}, %{})
       assert changeset |> get_change(:state) == "published"
+    end
+
+    test "sets status to 'open'" do
+      changeset = Post.create_changeset(%Post{}, %{})
+      # open is default, so we `get_field` instead of `get_change`
+      assert changeset |> get_field(:status) == "open"
     end
   end
   describe "&update_changeset/2" do
     test "sets state to 'edited'" do
       changeset = Post.update_changeset(%Post{}, %{})
       assert changeset |> get_change(:state) == "edited"
+    end
+
+    test "only allows specific values for status" do
+      changes = Map.put(@valid_attrs, :status, "nonexistent")
+      changeset = Post.update_changeset(%Post{}, changes)
+      refute changeset.valid?
     end
   end
 

--- a/test/models/post_test.exs
+++ b/test/models/post_test.exs
@@ -14,76 +14,92 @@ defmodule CodeCorps.PostTest do
     status: "nonexistent"
   }
 
-  test "create changeset with valid attributes is valid" do
-    user = insert(:user)
-    project = insert(:project)
-    changeset = Post.create_changeset(%Post{}, %{
-      markdown: "some content",
-      post_type: "issue",
-      title: "some content",
-      project_id: project.id,
-      user_id: user.id,
-      status: "open"
-    })
-    assert changeset.valid?
+  describe "&create/2" do
+    test "is invalid with invalid attributes" do
+      changeset = Post.changeset(%Post{}, @invalid_attrs)
+      refute changeset.valid?
+    end
+
+    test "only allows specific values for status" do
+      changes = Map.put(@valid_attrs, :status, "nonexistent")
+      changeset = Post.changeset(%Post{}, changes)
+      refute changeset.valid?
+    end
+
+    test "only allows specific values for post_type" do
+      changes = Map.put(@valid_attrs, :post_type, "nonexistent")
+      changeset = Post.changeset(%Post{}, changes)
+      refute changeset.valid?
+    end
+
+    test "renders body html from markdown" do
+      user = insert(:user)
+      project = insert(:project)
+      changes = Map.merge(@valid_attrs, %{
+        markdown: "A **strong** body",
+        project_id: project.id,
+        user_id: user.id
+      })
+      changeset = Post.changeset(%Post{}, changes)
+      assert changeset.valid?
+      assert changeset |> get_change(:body) == "<p>A <strong>strong</strong> body</p>\n"
+    end
   end
 
-  test "number is auto-sequenced scoped to project" do
-    user = insert(:user)
-    project_a = insert(:project, title: "Project A")
-    project_b = insert(:project, title: "Project B")
+  describe "&create_changeset/2" do
+    test "is valid with valid attributes" do
+      user = insert(:user)
+      project = insert(:project)
+      changeset = Post.create_changeset(%Post{}, %{
+        markdown: "some content",
+        post_type: "issue",
+        title: "some content",
+        project_id: project.id,
+        user_id: user.id,
+        status: "open"
+      })
+      assert changeset.valid?
+    end
 
-    insert(:post, project: project_a, user: user, title: "Project A Post 1")
-    insert(:post, project: project_a, user: user, title: "Project A Post 2")
+    test "auto-sequences number, scoped to project" do
+      user = insert(:user)
+      project_a = insert(:project, title: "Project A")
+      project_b = insert(:project, title: "Project B")
 
-    insert(:post, project: project_b, user: user, title: "Project B Post 1")
+      insert(:post, project: project_a, user: user, title: "Project A Post 1")
+      insert(:post, project: project_a, user: user, title: "Project A Post 2")
 
-    changes = Map.merge(@valid_attrs, %{
-      project_id: project_a.id,
-      user_id: user.id
-    })
-    changeset = Post.create_changeset(%Post{}, changes)
-    {:ok, result} = Repo.insert(changeset)
-    result = Repo.get(Post, result.id)
-    assert result.number == 3
+      insert(:post, project: project_b, user: user, title: "Project B Post 1")
 
-    changes = Map.merge(@valid_attrs, %{
-      project_id: project_b.id,
-      user_id: user.id
-    })
-    changeset = Post.create_changeset(%Post{}, changes)
-    {:ok, result} = Repo.insert(changeset)
-    result = Repo.get(Post, result.id)
-    assert result.number == 2
+      changes = Map.merge(@valid_attrs, %{
+        project_id: project_a.id,
+        user_id: user.id
+      })
+      changeset = Post.create_changeset(%Post{}, changes)
+      {:ok, result} = Repo.insert(changeset)
+      result = Repo.get(Post, result.id)
+      assert result.number == 3
+
+      changes = Map.merge(@valid_attrs, %{
+        project_id: project_b.id,
+        user_id: user.id
+      })
+      changeset = Post.create_changeset(%Post{}, changes)
+      {:ok, result} = Repo.insert(changeset)
+      result = Repo.get(Post, result.id)
+      assert result.number == 2
+    end
+
+    test "sets state to 'published'" do
+      changeset = Post.create_changeset(%Post{}, %{project_id: 1, user_id: 2})
+      assert changeset |> get_change(:state) == "published"
+    end
+  end
+  describe "&update_changeset/2" do
+    test "sets state to 'edited'" do
+      changeset = Post.update_changeset(%Post{}, %{})
+      assert changeset |> get_change(:state) == "edited"
+    end
   end
 
-  test "changeset with invalid attributes" do
-    changeset = Post.changeset(%Post{}, @invalid_attrs)
-    refute changeset.valid?
-  end
-
-  test "changeset, status not included" do
-    changes = Map.put(@valid_attrs, :status, "nonexistent")
-    changeset = Post.changeset(%Post{}, changes)
-    refute changeset.valid?
-  end
-
-  test "changeset, post_type not included" do
-    changes = Map.put(@valid_attrs, :post_type, "nonexistent")
-    changeset = Post.changeset(%Post{}, changes)
-    refute changeset.valid?
-  end
-
-  test "changeset renders body html from markdown" do
-    user = insert(:user)
-    project = insert(:project)
-    changes = Map.merge(@valid_attrs, %{
-      markdown: "A **strong** body",
-      project_id: project.id,
-      user_id: user.id
-    })
-    changeset = Post.create_changeset(%Post{}, changes)
-    assert changeset.valid?
-    assert changeset |> get_change(:body) == "<p>A <strong>strong</strong> body</p>\n"
-  end
 end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -40,6 +40,7 @@ defmodule CodeCorps.Factories do
       post_type: "issue",
       markdown: "A test post",
       status: "open",
+      state: "published",
       project: build(:project),
       user: build(:user)
     }

--- a/test/views/post_view_test.exs
+++ b/test/views/post_view_test.exs
@@ -25,6 +25,7 @@ defmodule CodeCorps.PostViewTest do
           "number" => post.number,
           "post-type" => post.post_type,
           "status" => post.status,
+          "state" => post.state,
           "title" => post.title,
           "updated-at" => post.updated_at,
         },

--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -64,7 +64,7 @@ defmodule CodeCorps.PostController do
       Post
       |> preload([:comments, :project, :user])
       |> Repo.get!(id)
-      |> Post.changeset(Params.to_attributes(data))
+      |> Post.update_changeset(Params.to_attributes(data))
 
     case Repo.update(changeset) do
       {:ok, post} ->

--- a/web/models/post.ex
+++ b/web/models/post.ex
@@ -10,6 +10,7 @@ defmodule CodeCorps.Post do
     field :markdown, :string
     field :number, :integer
     field :post_type, :string
+    field :state, :string, default: "published"
     field :status, :string, default: "open"
     field :title, :string
 
@@ -33,9 +34,16 @@ defmodule CodeCorps.Post do
     struct
     |> changeset(params)
     |> cast(params, [:project_id, :user_id])
+    |> put_change(:state, "published")
     |> validate_required([:project_id, :user_id])
     |> assoc_constraint(:project)
     |> assoc_constraint(:user)
+  end
+
+  def update_changeset(struct, params) do
+    struct
+    |> changeset(params)
+    |> put_change(:state, "edited")
   end
 
   defp post_types do

--- a/web/models/post.ex
+++ b/web/models/post.ex
@@ -10,7 +10,7 @@ defmodule CodeCorps.Post do
     field :markdown, :string
     field :number, :integer
     field :post_type, :string
-    field :state, :string, default: "published"
+    field :state, :string
     field :status, :string, default: "open"
     field :title, :string
 
@@ -34,10 +34,10 @@ defmodule CodeCorps.Post do
     struct
     |> changeset(params)
     |> cast(params, [:project_id, :user_id])
-    |> put_change(:state, "published")
     |> validate_required([:project_id, :user_id])
     |> assoc_constraint(:project)
     |> assoc_constraint(:user)
+    |> put_change(:state, "published")
   end
 
   def update_changeset(struct, params) do

--- a/web/models/post.ex
+++ b/web/models/post.ex
@@ -23,10 +23,9 @@ defmodule CodeCorps.Post do
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:title, :markdown, :post_type, :status])
-    |> validate_required([:title, :markdown, :post_type, :status])
+    |> cast(params, [:title, :markdown, :post_type])
+    |> validate_required([:title, :markdown, :post_type])
     |> validate_inclusion(:post_type, post_types)
-    |> validate_inclusion(:status, statuses)
     |> MarkdownRenderer.render_markdown_to_html(:markdown, :body)
   end
 
@@ -38,12 +37,16 @@ defmodule CodeCorps.Post do
     |> assoc_constraint(:project)
     |> assoc_constraint(:user)
     |> put_change(:state, "published")
+    |> put_change(:status, "open")
   end
 
   def update_changeset(struct, params) do
     struct
     |> changeset(params)
+    |> cast(params, [:status])
+    |> validate_inclusion(:status, statuses)
     |> put_change(:state, "edited")
+
   end
 
   defp post_types do

--- a/web/views/post_view.ex
+++ b/web/views/post_view.ex
@@ -2,7 +2,7 @@ defmodule CodeCorps.PostView do
   use CodeCorps.Web, :view
   use JaSerializer.PhoenixView
 
-  attributes [:body, :markdown, :number, :post_type, :status, :title, :inserted_at, :updated_at]
+  attributes [:body, :markdown, :number, :post_type, :status, :state, :title, :inserted_at, :updated_at]
 
   has_one :project, serializer: CodeCorps.ProjectView
   has_one :user, serializer: CodeCorps.UserView


### PR DESCRIPTION
Closes #83, #169

I truly believe a state machine is a complete overkill for this one. 

There are only two cases for state:
- When we are creating the post, it comes out as "published"
- When we are updating it, it becomes "edited"

Due to that, manually putting those two changes into the respective changesets is more than enough.

Also, there are only two cases for status:
- When we are creating the post, it comes out as "open".
- During update, we can set it to "open" or "closed" and nothing else.

While I was at it, I reorganized the post model tests. We are lacking in that area and we should write more, but it's outside of this PRs scope.
