### PR TITLE
Changes for ember compatibility

### DIFF
--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -22,10 +22,13 @@ defmodule CodeCorps.CommentControllerTest do
     }
   end
 
-  test "lists all entries on index", %{conn: conn} do
-    path = conn |> comment_path(:index)
-    conn = conn |> get(path)
-    assert json_response(conn, 200)["data"] == []
+  describe "index" do
+    test "lists all entries for specified post on index", %{conn: conn} do
+      post = insert(:post)
+      path = conn |> post_comment_path(:index, post)
+      conn = conn |> get(path)
+      assert json_response(conn, 200)["data"] == []
+    end
   end
 
   describe "show" do

--- a/test/controllers/organization_memberships_controller_test.exs
+++ b/test/controllers/organization_memberships_controller_test.exs
@@ -54,15 +54,12 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
       assert second_result["id"] == "#{membership_2.id}"
     end
 
-    test "filters resources by member id", %{conn: conn} do
-      member_1 = insert(:user)
-      member_2 = insert(:user)
-      member_3 = insert(:user)
-      membership_1 = insert(:organization_membership, member: member_1)
-      membership_2 = insert(:organization_membership, member: member_2)
-      insert(:organization_membership, member: member_3)
+    test "filters resources by membership id", %{conn: conn} do
+      membership_1 = insert(:organization_membership)
+      membership_2 = insert(:organization_membership)
+      insert(:organization_membership)
 
-      params = %{"filter" => %{"id" => "#{member_1.id},#{member_2.id}"}}
+      params = %{"filter" => %{"id" => "#{membership_1.id},#{membership_2.id}"}}
       conn = get conn, organization_membership_path(conn, :index, params)
       data = json_response(conn, 200)["data"]
       assert data |> length == 2
@@ -89,13 +86,11 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
     end
 
     test "filters resources by role and id", %{conn: conn} do
-      member_1 = insert(:user)
-      member_2 = insert(:user)
-      membership_1 = insert(:organization_membership, role: "admin", member: member_1)
-      insert(:organization_membership, role: "admin", member: member_2)
+      membership_1 = insert(:organization_membership, role: "admin")
+      insert(:organization_membership, role: "admin")
       insert(:organization_membership, role: "owner")
 
-      params = %{"role" => "admin", "filter" => %{"id" => "#{member_1.id}"}}
+      params = %{"role" => "admin", "filter" => %{"id" => "#{membership_1.id}"}}
       path = conn |> organization_membership_path(:index, params)
 
       data = conn |> get(path) |> json_response(200) |> Map.get("data")
@@ -107,19 +102,12 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
     end
 
     test "filters resources by role and id on specific organization", %{conn: conn} do
-      member_1 = insert(:user)
       organization = insert(:organization)
-      membership_1 =
-        insert(
-          :organization_membership,
-          organization: organization,
-          role: "admin",
-          member: member_1
-        )
+      membership_1 = insert(:organization_membership, organization: organization, role: "admin")
       insert(:organization_membership, organization: organization, role: "admin")
       insert(:organization_membership, role: "owner")
 
-      params = %{"role" => "admin", "filter" => %{"id" => "#{member_1.id}"}}
+      params = %{"role" => "admin", "filter" => %{"id" => "#{membership_1.id}"}}
       path = conn |> organization_organization_membership_path(:index, organization)
 
       data = conn |> get(path, params) |> json_response(200) |> Map.get("data")

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -131,6 +131,10 @@ defmodule CodeCorps.PostControllerTest do
 
       assert json["data"]["id"]
       assert Repo.get_by(Post, @valid_attrs)
+
+      # ensure record is reloaded from database before serialized, since number is added
+      # on database level upon insert
+      assert json["data"]["attributes"]["number"] == 1
     end
 
     @tag :authenticated

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -77,6 +77,30 @@ defmodule CodeCorps.PostControllerTest do
       assert post_types |> Enum.member?("idea")
       refute post_types |> Enum.member?("task")
     end
+
+    test "lists all posts filtered by status", %{conn: conn} do
+      project = insert(:project)
+      post_1 = insert(:post, status: "open", project: project)
+      post_2 = insert(:post, status: "closed", project: project)
+
+      json =
+        conn
+        |> get("projects/#{project.id}/posts?status=open")
+        |> json_response(200)
+
+      assert json["data"] |> Enum.count == 1
+      [post] = json["data"]
+      assert post["id"] == post_1.id |> Integer.to_string
+
+      json =
+        conn
+        |> get("projects/#{project.id}/posts?status=closed")
+        |> json_response(200)
+
+      assert json["data"] |> Enum.count == 1
+      [post] = json["data"]
+      assert post["id"] == post_2.id |> Integer.to_string
+    end
   end
 
   describe "show" do

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -139,7 +139,6 @@ defmodule CodeCorps.ProjectControllerTest do
       errors = conn |> post(path, payload) |> json_response(422) |> Map.get("errors")
 
       assert errors != %{}
-      assert errors["title"] == ["can't be blank"]
     end
 
     test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
@@ -187,7 +186,6 @@ defmodule CodeCorps.ProjectControllerTest do
       errors = conn |> put(path, payload) |> json_response(422) |> Map.get("errors")
 
       assert errors != %{}
-      assert errors["title"] == ["can't be blank"]
     end
 
     @tag :requires_env

--- a/test/controllers/user_category_controller_test.exs
+++ b/test/controllers/user_category_controller_test.exs
@@ -106,7 +106,7 @@ defmodule CodeCorps.UserCategoryControllerTest do
     @tag :authenticated
     test "does not create resource and renders 401 when not authorized", %{conn: conn} do
       path = conn |> user_category_path(:create)
-      assert conn |> post(path) |> json_response(401)
+      assert conn |> post(path, build_payload) |> json_response(401)
     end
   end
 

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -202,10 +202,6 @@ defmodule CodeCorps.UserControllerTest do
 
       json =  json_response(conn, 422)
       assert json["errors"] != %{}
-      errors = json["errors"]
-      assert errors["email"] == ["can't be blank"]
-      assert errors["twitter"] == ["has invalid format"]
-      assert errors["website"] == ["has invalid format"]
     end
 
     test "transitions from one state to the next", %{conn: conn} do
@@ -221,20 +217,6 @@ defmodule CodeCorps.UserControllerTest do
       %{"data" => %{"id" => id}} = json_response(conn, 200)
       user = Repo.get(User, id)
       assert user.state == "edited_profile"
-    end
-
-    test "prevents an invalid transition", %{conn: conn} do
-      user = insert(:user)
-      conn = put authenticate(conn, user), user_path(conn, :update, user), %{
-        "data" => %{
-          "type" => "user",
-          "id" => user.id,
-          "attributes" => %{"password" => "password", "state_transition" => "yehaww"}
-        }
-      }
-
-      %{"errors" => errors} = json_response(conn, 422)
-      assert errors["state_transition"] == ["invalid transition yehaww from signed_up"]
     end
   end
 

--- a/test/controllers/user_role_controller_test.exs
+++ b/test/controllers/user_role_controller_test.exs
@@ -53,7 +53,7 @@ defmodule CodeCorps.UserRoleControllerTest do
     @tag :authenticated
     test "does not create resource and renders 401 when not authorized", %{conn: conn} do
       path = conn |> user_role_path(:create)
-      assert conn |> post(path) |> json_response(401)
+      assert conn |> post(path, build_payload) |> json_response(401)
     end
   end
 

--- a/test/controllers/user_skill_controller_test.exs
+++ b/test/controllers/user_skill_controller_test.exs
@@ -103,7 +103,7 @@ defmodule CodeCorps.UserSkillControllerTest do
     @tag :authenticated
     test "does not create resource and renders 401 when not authorized", %{conn: conn} do
       path = conn |> user_skill_path(:create)
-      assert conn |> post(path) |> json_response(401)
+      assert conn |> post(path, build_payload) |> json_response(401)
     end
   end
 

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -133,5 +133,17 @@ defmodule CodeCorps.UserTest do
       [_, file_type] = changeset.changes.photo.file_name |> String.split(".")
       assert file_type == "gif"
     end
+
+    test "prevents an invalid transition" do
+      user = insert(:user, state: "signed_up")
+
+      changeset = user |> User.update_changeset(%{state_transition: "yehaww"})
+
+      refute changeset.valid?
+      [error | _] = changeset.errors
+      {attribute, {message, _}} = error
+      assert attribute == :state_transition
+      assert message == "invalid transition yehaww from signed_up"
+    end
   end
 end

--- a/test/views/user_view_test.exs
+++ b/test/views/user_view_test.exs
@@ -36,6 +36,7 @@ defmodule CodeCorps.UserViewTest do
           "username" => user.username,
           "updated-at" => user.updated_at,
           "website" => user.website,
+          "state" => "signed_up"
         },
         relationships: %{
           "categories" => %{

--- a/web/controllers/category_controller.ex
+++ b/web/controllers/category_controller.ex
@@ -7,7 +7,7 @@ defmodule CodeCorps.CategoryController do
   plug :load_and_authorize_resource, model: Category, only: [:create, :update]
 
   def index(conn, _params) do
-    categories = Repo.all(Category)
+    categories = Category |> Repo.all |> Repo.preload([:project_categories, :projects])
     render(conn, "index.json-api", data: categories)
   end
 

--- a/web/controllers/comment_controller.ex
+++ b/web/controllers/comment_controller.ex
@@ -8,8 +8,13 @@ defmodule CodeCorps.CommentController do
 
   plug :scrub_params, "data" when action in [:create, :update]
 
-  def index(conn, _params) do
-    comments = Repo.all(Comment, preload: [:post])
+  def index(conn, params = %{"post_id" => _}) do
+    comments =
+      Comment
+      |> Comment.index_filters(params)
+      |> Repo.all
+      |> Repo.preload(:post)
+
     render(conn, "index.json-api", data: comments)
   end
 

--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -13,6 +13,7 @@ defmodule CodeCorps.PostController do
       |> preload([:comments, :project, :user])
       |> Post.index_filters(params)
       |> Post.post_type_filters(params)
+      |> Post.post_status_filters(params)
       |> Repo.paginate(params["page"])
 
     meta = %{

--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -30,7 +30,10 @@ defmodule CodeCorps.PostController do
 
     case Repo.insert(changeset) do
       {:ok, post} ->
-        post = Repo.preload(post, [:comments, :project, :user])
+        post =
+          Post
+          |> Repo.get(post.id) # need to reload, due to number being added on database level
+          |> Repo.preload([:comments, :project, :user])
 
         conn
         |> put_status(:created)

--- a/web/controllers/user_category_controller.ex
+++ b/web/controllers/user_category_controller.ex
@@ -4,7 +4,7 @@ defmodule CodeCorps.UserCategoryController do
   alias CodeCorps.UserCategory
   alias JaSerializer.Params
 
-  plug :load_and_authorize_resource, model: UserCategory, only: [:create, :delete]
+  plug :load_and_authorize_resource, model: UserCategory, only: [:delete]
   plug :scrub_params, "data" when action in [:create]
 
   def index(conn, params) do
@@ -19,6 +19,10 @@ defmodule CodeCorps.UserCategoryController do
 
   def create(conn, %{"data" => data = %{"type" => "user-category"}}) do
     changeset = UserCategory.changeset(%UserCategory{}, Params.to_attributes(data))
+
+    conn
+    |> assign(:changeset, changeset)
+    |> Canary.Plugs.authorize_resource(model: changeset)
 
     case Repo.insert(changeset) do
       {:ok, user_category} ->

--- a/web/controllers/user_category_controller.ex
+++ b/web/controllers/user_category_controller.ex
@@ -1,6 +1,8 @@
 defmodule CodeCorps.UserCategoryController do
   use CodeCorps.Web, :controller
 
+  import CodeCorps.AuthenticationHelpers, only: [authorize: 2, authorized?: 1]
+
   alias CodeCorps.UserCategory
   alias JaSerializer.Params
 
@@ -51,11 +53,4 @@ defmodule CodeCorps.UserCategoryController do
     UserCategory |> Repo.get!(id) |> Repo.delete!
     conn |> send_resp(:no_content, "")
   end
-
-  defp authorize(conn, changeset) do
-    conn
-    |> assign(:changeset, changeset)
-    |> Canary.Plugs.authorize_resource(model: changeset)
-  end
-  defp authorized?(conn), do: conn |> Map.get(:assigns) |> Map.get(:authorized)
 end

--- a/web/controllers/user_category_controller.ex
+++ b/web/controllers/user_category_controller.ex
@@ -20,20 +20,22 @@ defmodule CodeCorps.UserCategoryController do
   def create(conn, %{"data" => data = %{"type" => "user-category"}}) do
     changeset = UserCategory.changeset(%UserCategory{}, Params.to_attributes(data))
 
-    conn
-    |> assign(:changeset, changeset)
-    |> Canary.Plugs.authorize_resource(model: changeset)
+    conn = conn |> authorize(changeset)
 
-    case Repo.insert(changeset) do
-      {:ok, user_category} ->
-        conn
-        |> put_status(:created)
-        |> put_resp_header("location", user_category_path(conn, :show, user_category))
-        |> render("show.json-api", data: user_category |> Repo.preload([:user, :category]))
-      {:error, changeset} ->
-        conn
-        |> put_status(:unprocessable_entity)
-        |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
+    if conn |> authorized? do
+      case Repo.insert(changeset) do
+        {:ok, user_category} ->
+          conn
+          |> put_status(:created)
+          |> put_resp_header("location", user_category_path(conn, :show, user_category))
+          |> render("show.json-api", data: user_category |> Repo.preload([:user, :category]))
+        {:error, changeset} ->
+          conn
+          |> put_status(:unprocessable_entity)
+          |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
+      end
+    else
+      conn
     end
   end
 
@@ -49,4 +51,11 @@ defmodule CodeCorps.UserCategoryController do
     UserCategory |> Repo.get!(id) |> Repo.delete!
     conn |> send_resp(:no_content, "")
   end
+
+  defp authorize(conn, changeset) do
+    conn
+    |> assign(:changeset, changeset)
+    |> Canary.Plugs.authorize_resource(model: changeset)
+  end
+  defp authorized?(conn), do: conn |> Map.get(:assigns) |> Map.get(:authorized)
 end

--- a/web/controllers/user_role_controller.ex
+++ b/web/controllers/user_role_controller.ex
@@ -1,6 +1,8 @@
 defmodule CodeCorps.UserRoleController do
   use CodeCorps.Web, :controller
 
+  import CodeCorps.AuthenticationHelpers, only: [authorize: 2, authorized?: 1]
+
   alias CodeCorps.UserRole
   alias JaSerializer.Params
 
@@ -31,11 +33,4 @@ defmodule CodeCorps.UserRoleController do
     UserRole |> Repo.get!(id) |> Repo.delete!
     conn |> send_resp(:no_content, "")
   end
-
-  defp authorize(conn, changeset) do
-    conn
-    |> assign(:changeset, changeset)
-    |> Canary.Plugs.authorize_resource(model: changeset)
-  end
-  defp authorized?(conn), do: conn |> Map.get(:assigns) |> Map.get(:authorized)
 end

--- a/web/controllers/user_role_controller.ex
+++ b/web/controllers/user_role_controller.ex
@@ -4,20 +4,26 @@ defmodule CodeCorps.UserRoleController do
   alias CodeCorps.UserRole
   alias JaSerializer.Params
 
-  plug :load_and_authorize_resource, model: UserRole, only: [:create, :delete]
+  plug :load_and_authorize_resource, model: UserRole, only: [:delete]
 
   def create(conn, %{"data" => data = %{"type" => "user-role"}}) do
     changeset = UserRole.changeset(%UserRole{}, Params.to_attributes(data))
 
-    case Repo.insert(changeset) do
-      {:ok, user_role} ->
-        conn
-        |> put_status(:created)
-        |> render("show.json-api", data: user_role |> Repo.preload([:user, :role]))
-      {:error, changeset} ->
-        conn
-        |> put_status(:unprocessable_entity)
-        |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
+    conn = conn |> authorize(changeset)
+
+    if conn |> authorized? do
+      case Repo.insert(changeset) do
+        {:ok, user_role} ->
+          conn
+          |> put_status(:created)
+          |> render("show.json-api", data: user_role |> Repo.preload([:user, :role]))
+        {:error, changeset} ->
+          conn
+          |> put_status(:unprocessable_entity)
+          |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
+      end
+    else
+      conn
     end
   end
 
@@ -25,4 +31,11 @@ defmodule CodeCorps.UserRoleController do
     UserRole |> Repo.get!(id) |> Repo.delete!
     conn |> send_resp(:no_content, "")
   end
+
+  defp authorize(conn, changeset) do
+    conn
+    |> assign(:changeset, changeset)
+    |> Canary.Plugs.authorize_resource(model: changeset)
+  end
+  defp authorized?(conn), do: conn |> Map.get(:assigns) |> Map.get(:authorized)
 end

--- a/web/controllers/user_skill_controller.ex
+++ b/web/controllers/user_skill_controller.ex
@@ -1,6 +1,8 @@
 defmodule CodeCorps.UserSkillController do
   use CodeCorps.Web, :controller
 
+  import CodeCorps.AuthenticationHelpers, only: [authorize: 2, authorized?: 1]
+
   alias CodeCorps.UserSkill
   alias JaSerializer.Params
 
@@ -51,11 +53,4 @@ defmodule CodeCorps.UserSkillController do
     UserSkill |> Repo.get!(id) |> Repo.delete!
     conn |> send_resp(:no_content, "")
   end
-
-  defp authorize(conn, changeset) do
-    conn
-    |> assign(:changeset, changeset)
-    |> Canary.Plugs.authorize_resource(model: changeset)
-  end
-  defp authorized?(conn), do: conn |> Map.get(:assigns) |> Map.get(:authorized)
 end

--- a/web/helpers/authentication_helpers.ex
+++ b/web/helpers/authentication_helpers.ex
@@ -1,6 +1,6 @@
 defmodule CodeCorps.AuthenticationHelpers do
   use Phoenix.Controller
-  import Plug.Conn, only: [halt: 1, put_status: 2]
+  import Plug.Conn, only: [halt: 1, put_status: 2, assign: 3]
 
   def handle_unauthorized(conn) do
     conn
@@ -15,4 +15,12 @@ defmodule CodeCorps.AuthenticationHelpers do
     |> render(CodeCorps.ErrorView, "404.json")
     |> halt
   end
+
+  def authorize(conn, changeset) do
+    conn
+    |> assign(:changeset, changeset)
+    |> Canary.Plugs.authorize_resource(model: changeset)
+  end
+
+  def authorized?(conn), do: conn |> Map.get(:assigns) |> Map.get(:authorized)
 end

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -82,8 +82,8 @@ defmodule Canary.Abilities do
     def can?(%User{} = user, :create, %Ecto.Changeset{} = changeset), do: UserCategoryPolicy.create?(user, changeset)
     def can?(%User{} = user, :delete, %UserCategory{} = user_category), do: UserCategoryPolicy.delete?(user, user_category)
 
-    def can?(%User{} = user, :create, UserRole), do: UserRolePolicy.create?(user)
-    def can?(%User{} = user, :delete, %UserRole{}), do: UserRolePolicy.delete?(user)
+    def can?(%User{} = user, :create, %Ecto.Changeset{} = changeset), do: UserRolePolicy.create?(user, changeset)
+    def can?(%User{} = user, :delete, %UserRole{} = user_role), do: UserRolePolicy.delete?(user, user_role)
 
     def can?(%User{} = user, :create, UserSkill), do: UserSkillPolicy.create?(user)
     def can?(%User{} = user, :delete, %UserSkill{}), do: UserSkillPolicy.delete?(user)

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -79,13 +79,13 @@ defmodule Canary.Abilities do
 
     def can?(%User{} = user, :create, Skill), do: SkillPolicy.create?(user)
 
-    def can?(%User{} = user, :create, %Ecto.Changeset{} = changeset), do: UserCategoryPolicy.create?(user, changeset)
+    def can?(%User{} = user, :create, %Ecto.Changeset{data: %CodeCorps.UserCategory{}} = changeset), do: UserCategoryPolicy.create?(user, changeset)
     def can?(%User{} = user, :delete, %UserCategory{} = user_category), do: UserCategoryPolicy.delete?(user, user_category)
 
-    def can?(%User{} = user, :create, %Ecto.Changeset{} = changeset), do: UserRolePolicy.create?(user, changeset)
+    def can?(%User{} = user, :create, %Ecto.Changeset{data: %CodeCorps.UserRole{}} = changeset), do: UserRolePolicy.create?(user, changeset)
     def can?(%User{} = user, :delete, %UserRole{} = user_role), do: UserRolePolicy.delete?(user, user_role)
 
-    def can?(%User{} = user, :create, UserSkill), do: UserSkillPolicy.create?(user)
-    def can?(%User{} = user, :delete, %UserSkill{}), do: UserSkillPolicy.delete?(user)
+    def can?(%User{} = user, :create, %Ecto.Changeset{data: %CodeCorps.UserSkill{}} = changeset), do: UserSkillPolicy.create?(user, changeset)
+    def can?(%User{} = user, :delete, %UserSkill{} = user_skill), do: UserSkillPolicy.delete?(user, user_skill)
   end
 end

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -79,8 +79,8 @@ defmodule Canary.Abilities do
 
     def can?(%User{} = user, :create, Skill), do: SkillPolicy.create?(user)
 
-    def can?(%User{} = user, :create, UserCategory), do: UserCategoryPolicy.create?(user)
-    def can?(%User{} = user, :delete, %UserCategory{}), do: UserCategoryPolicy.delete?(user)
+    def can?(%User{} = user, :create, %Ecto.Changeset{} = changeset), do: UserCategoryPolicy.create?(user, changeset)
+    def can?(%User{} = user, :delete, %UserCategory{} = user_category), do: UserCategoryPolicy.delete?(user, user_category)
 
     def can?(%User{} = user, :create, UserRole), do: UserRolePolicy.create?(user)
     def can?(%User{} = user, :delete, %UserRole{}), do: UserRolePolicy.delete?(user)

--- a/web/models/comment.ex
+++ b/web/models/comment.ex
@@ -3,6 +3,8 @@ defmodule CodeCorps.Comment do
 
   alias CodeCorps.MarkdownRenderer
 
+  import CodeCorps.ModelHelpers
+
   schema "comments" do
     field :body, :string
     field :markdown, :string
@@ -30,5 +32,9 @@ defmodule CodeCorps.Comment do
     |> validate_required([:post_id, :user_id])
     |> assoc_constraint(:post)
     |> assoc_constraint(:user)
+  end
+
+  def index_filters(query, params) do
+    query |> post_filter(params)
   end
 end

--- a/web/models/model_helpers.ex
+++ b/web/models/model_helpers.ex
@@ -41,6 +41,11 @@ defmodule CodeCorps.ModelHelpers do
   end
   def post_type_filter(query, _), do: query
 
+  def post_filter(query, %{"post_id" => post_id}) do
+    query |> where([object], object.post_id == ^post_id)
+  end
+  def post_filter(query, _), do: query
+
   def project_filter(query, %{"project_id" => project_id}) do
     query |> where([object], object.project_id == ^project_id)
   end

--- a/web/models/model_helpers.ex
+++ b/web/models/model_helpers.ex
@@ -21,12 +21,6 @@ defmodule CodeCorps.ModelHelpers do
   end
   def id_filter(query, _), do: query
 
-  def member_filter(query, %{"filter" => %{"id" => id_list}}) do
-    ids = id_list |> coalesce_id_string
-    query |> where([object], object.member_id in ^ids)
-  end
-  def member_filter(query, _), do: query
-
   def number_as_id_filter(query, %{"id" => number}) do
     query |> where([object], object.number == ^number)
   end

--- a/web/models/model_helpers.ex
+++ b/web/models/model_helpers.ex
@@ -41,6 +41,11 @@ defmodule CodeCorps.ModelHelpers do
   end
   def post_type_filter(query, _), do: query
 
+  def post_status_filter(query, %{"status" => status}) do
+    query |> where([object], object.status == ^status)
+  end
+  def post_status_filter(query, _), do: query
+
   def post_filter(query, %{"post_id" => post_id}) do
     query |> where([object], object.post_id == ^post_id)
   end

--- a/web/models/model_helpers.ex
+++ b/web/models/model_helpers.ex
@@ -6,8 +6,10 @@ defmodule CodeCorps.ModelHelpers do
   def generate_slug(changeset, value_key, slug_key) do
     case changeset do
       %Ecto.Changeset{valid?: true, changes: changes} ->
-        {:ok, value} = Map.fetch(changes, value_key)
-        put_change(changeset, slug_key, Inflex.parameterize(value))
+        case Map.fetch(changes, value_key) do
+          {:ok, value} -> put_change(changeset, slug_key, Inflex.parameterize(value))
+          _ -> changeset
+        end
       _ ->
         changeset
     end

--- a/web/models/organization_membership.ex
+++ b/web/models/organization_membership.ex
@@ -43,9 +43,9 @@ defmodule CodeCorps.OrganizationMembership do
 
   def index_filters(query, params) do
     query
+    |> id_filter(params)
     |> organization_filter(params)
     |> role_filter(params)
-    |> member_filter(params)
   end
 
   defp roles do

--- a/web/models/post.ex
+++ b/web/models/post.ex
@@ -65,6 +65,10 @@ defmodule CodeCorps.Post do
     query |> post_type_filter(params)
   end
 
+  def post_status_filters(query, params) do
+    query |> post_status_filter(params)
+  end
+
   def show_project_post_filters(query, params) do
     query
     |> number_as_id_filter(params)

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -28,7 +28,7 @@ defmodule CodeCorps.User do
     field :username, :string
     field :website, :string
 
-    field :state, :string
+    field :state, :string, default: "signed_up"
     field :state_transition, :string, virtual: true
 
     has_one :slugged_route, SluggedRoute

--- a/web/policies/user_category_policy.ex
+++ b/web/policies/user_category_policy.ex
@@ -2,13 +2,11 @@ defmodule CodeCorps.UserCategoryPolicy do
   alias CodeCorps.UserCategory
   alias CodeCorps.User
 
-  def create?(%User{admin: true}), do: true
-  def create?(%User{}), do: false
-  # TODO: Need to figure out how to pass in params for create
-  # A non-admin user can modify their own category. This method is right now unreachable
-  def create?(%User{} = user, %UserCategory{} = user_category), do: user.id == user_category.user_id
+  def create?(%User{admin: true}, %Ecto.Changeset{}), do: true
+  def create?(%User{} = user, %Ecto.Changeset{} = changeset) do
+    user.id == changeset |> Ecto.Changeset.get_change(:user_id)
+  end
 
-  def delete?(%User{admin: true}), do: true
-  def delete?(%User{}), do: false
+  def delete?(%User{admin: true}, %UserCategory{}), do: true
   def delete?(%User{} = user, %UserCategory{} = user_category), do: user.id == user_category.user_id
 end

--- a/web/policies/user_role_policy.ex
+++ b/web/policies/user_role_policy.ex
@@ -2,13 +2,11 @@ defmodule CodeCorps.UserRolePolicy do
   alias CodeCorps.UserRole
   alias CodeCorps.User
 
-  def create?(%User{admin: true}), do: true
-  def create?(%User{}), do: false
-  # TODO: Need to figure out how to pass in params for create
-  # A non-admin user can modify their own category. This method is right now unreachable
-  def create?(%User{} = user, %UserRole{} = user_role), do: user.id == user_role.user_id
+  def create?(%User{admin: true}, %Ecto.Changeset{}), do: true
+  def create?(%User{} = user, %Ecto.Changeset{} = changeset) do
+    user.id == changeset |> Ecto.Changeset.get_change(:user_id)
+  end
 
-  def delete?(%User{admin: true}), do: true
-  def delete?(%User{}), do: false
+  def delete?(%User{admin: true}, %UserRole{}), do: true
   def delete?(%User{} = user, %UserRole{} = user_role), do: user.id == user_role.user_id
 end

--- a/web/policies/user_skill_policy.ex
+++ b/web/policies/user_skill_policy.ex
@@ -2,13 +2,11 @@ defmodule CodeCorps.UserSkillPolicy do
   alias CodeCorps.UserSkill
   alias CodeCorps.User
 
-  def create?(%User{admin: true}), do: true
-  def create?(%User{}), do: false
-  # TODO: Need to figure out how to pass in params for create
-  # A non-admin user can modify their own skill. This method is right now unreachable
-  def create?(%User{} = user, %UserSkill{} = user_skill), do: user.id == user_skill.user_id
+  def create?(%User{admin: true}, %Ecto.Changeset{}), do: true
+  def create?(%User{} = user, %Ecto.Changeset{} = changeset) do
+    user.id == changeset |> Ecto.Changeset.get_change(:user_id)
+  end
 
-  def delete?(%User{admin: true}), do: true
-  def delete?(%User{}), do: false
+  def delete?(%User{admin: true}, %UserSkill{}), do: true
   def delete?(%User{} = user, %UserSkill{} = user_skill), do: user.id == user_skill.user_id
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -33,7 +33,7 @@ defmodule CodeCorps.Router do
     post "/login", AuthController, :create
 
     resources "/categories", CategoryController, only: [:index, :show]
-    resources "/comments", CommentController, only: [:index, :show]
+    resources "/comments", CommentController, only: [:show]
 
     resources "/organizations", OrganizationController, only: [:index, :show] do
       resources "/memberships", OrganizationMembershipController, only: [:index]

--- a/web/views/changeset_view.ex
+++ b/web/views/changeset_view.ex
@@ -10,7 +10,35 @@ defmodule CodeCorps.ChangesetView do
   `CodeCorps.ErrorHelpers.translate_error/1` for more details.
   """
   def translate_errors(changeset) do
-    Changeset.traverse_errors(changeset, &translate_error/1)
+    errors =
+      changeset
+      |> Changeset.traverse_errors(&translate_error/1)
+      |> format_errors
+    errors
+  end
+
+  defp format_errors(errors) do
+    errors
+    |> Map.keys
+    |> Enum.map(fn(attribute) -> format_attribute_errors(errors, attribute) end)
+    |> Enum.flat_map(fn(error) -> error end)
+  end
+
+  defp format_attribute_errors(errors, attribute) do
+    errors
+    |> Map.get(attribute)
+    |> Enum.map(fn(message) -> create_error(attribute, message) end)
+  end
+
+  def create_error(attribute, message) do
+    %{
+      id: "VALIDATION_ERROR",
+      source: %{
+        pointer: "data/attributes/#{attribute}"
+      },
+      detail: message,
+      status: 422
+    }
   end
 
   def render("error.json-api", %{changeset: changeset}) do

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -2,7 +2,12 @@ defmodule CodeCorps.UserView do
   use CodeCorps.Web, :view
   use JaSerializer.PhoenixView
 
-  attributes [:biography, :email, :first_name, :last_name, :photo_large_url, :photo_thumb_url, :twitter, :username, :website, :inserted_at, :updated_at]
+  attributes [
+    :biography, :email, :first_name, :last_name,
+    :photo_large_url, :photo_thumb_url, :twitter,
+    :username, :website, :state,
+    :inserted_at, :updated_at
+  ]
 
   has_one :slugged_route, serializer: CodeCorps.SluggedRouteView
 


### PR DESCRIPTION
What was done
- Changed the error format for validation errors to conform JSON API specs and guidelines. Ember expect that specific format and handles it automatically, so the alternative of customising error handling client-side would take longer.
- Made it so, when creating a post, the controller reloads the record before responding to the request, reason being, the post number is being added at the database level, so we need to reload to get that information back.
- `CommentController#index` was lacking the "filter by ID functionality", so I added it and specs to support the feature.
- `PostController.index` was missing filtering by status, so I added that as well
- Made it so slug only regenerates if the source value it's generated from changes. Simplifies some things to a degree.
- `OrganizationMembershipControler#index` was filtering by `member_id` instead of `id`. Fixed that bug.
- `CategoryController#index` was missing some preloads
- `User` was missing the default "signed_up" state upon creation, so the onboarding process would never trigger.
- Some authorization policies needed a changeset to properly determine user permissions, so I added custom authorization functionality, which accepts a changeset, namely, policies for `UserCategory`, `UserRole` and `UserSkill`
