### PR TITLE
Automatically set pending role on membership creation. Allow update of role

### DIFF
--- a/test/models/organization_membership_test.exs
+++ b/test/models/organization_membership_test.exs
@@ -3,25 +3,40 @@ defmodule CodeCorps.OrganizationMembershipTest do
 
   alias CodeCorps.OrganizationMembership
 
-  describe "update_changeset" do
-    @valid_attrs %{role: "admin"}
-    @invalid_attrs %{}
-
-    test "changeset with valid attributes" do
-      changeset = OrganizationMembership.update_changeset(%OrganizationMembership{}, @valid_attrs)
+  describe "update_changeset role validation" do
+    test "includes pending" do
+      attrs = %{role: "pending"}
+      changeset = OrganizationMembership.update_changeset(%OrganizationMembership{}, attrs)
       assert changeset.valid?
     end
 
-    test "changeset with invalid attributes" do
-      changeset = OrganizationMembership.update_changeset(%OrganizationMembership{}, @invalid_attrs)
+    test "includes contributor" do
+      attrs = %{role: "contributor"}
+      changeset = OrganizationMembership.update_changeset(%OrganizationMembership{}, attrs)
+      assert changeset.valid?
+    end
 
+    test "includes admin" do
+      attrs = %{role: "admin"}
+      changeset = OrganizationMembership.update_changeset(%OrganizationMembership{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "includes owner" do
+      attrs = %{role: "owner"}
+      changeset = OrganizationMembership.update_changeset(%OrganizationMembership{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "does not include invalid values" do
+      attrs = %{role: "invalid"}
+      changeset = OrganizationMembership.update_changeset(%OrganizationMembership{}, attrs)
       refute changeset.valid?
-      assert changeset.errors[:role] == {"can't be blank", []}
     end
   end
 
   describe "create_changeset" do
-    @valid_attrs %{role: "admin", member_id: 1, organization_id: 2}
+    @valid_attrs %{member_id: 1, organization_id: 2}
     @invalid_attrs %{}
 
     test "changeset with valid attributes" do
@@ -33,7 +48,6 @@ defmodule CodeCorps.OrganizationMembershipTest do
       changeset = OrganizationMembership.create_changeset(%OrganizationMembership{}, @invalid_attrs)
       refute changeset.valid?
 
-      assert changeset.errors[:role] == {"can't be blank", []}
       assert changeset.errors[:member_id] == {"can't be blank", []}
       assert changeset.errors[:organization_id] == {"can't be blank", []}
     end
@@ -55,38 +69,6 @@ defmodule CodeCorps.OrganizationMembershipTest do
 
       assert result == :error
       assert changeset.errors[:member] == {"does not exist", []}
-    end
-  end
-
-  describe "role validation" do
-    test "includes pending" do
-      attrs = Map.merge(@valid_attrs, %{role: "pending"})
-      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
-      assert changeset.valid?
-    end
-
-    test "includes contributor" do
-      attrs = Map.merge(@valid_attrs, %{role: "contributor"})
-      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
-      assert changeset.valid?
-    end
-
-    test "includes admin" do
-      attrs = Map.merge(@valid_attrs, %{role: "admin"})
-      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
-      assert changeset.valid?
-    end
-
-    test "includes owner" do
-      attrs = Map.merge(@valid_attrs, %{role: "owner"})
-      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
-      assert changeset.valid?
-    end
-
-    test "does not include invalid values" do
-      attrs = Map.merge(@valid_attrs, %{role: "invalid"})
-      changeset = OrganizationMembership.changeset(%OrganizationMembership{}, attrs)
-      refute changeset.valid?
     end
   end
 end

--- a/web/controllers/organization_membership_controller.ex
+++ b/web/controllers/organization_membership_controller.ex
@@ -26,7 +26,7 @@ defmodule CodeCorps.OrganizationMembershipController do
     render(conn, "show.json-api", data: membership)
   end
 
-  def create(conn, %{"data" => data = %{"type" => "organization-membership", "attributes" => _params}}) do
+  def create(conn, %{"data" => data = %{"type" => "organization-membership"}}) do
     changeset = %OrganizationMembership{} |> OrganizationMembership.create_changeset(Params.to_attributes(data))
 
     case Repo.insert(changeset) do

--- a/web/models/organization_membership.ex
+++ b/web/models/organization_membership.ex
@@ -20,25 +20,15 @@ defmodule CodeCorps.OrganizationMembership do
   end
 
   @doc """
-  Builds a changeset based on the `struct` and `params`.
-  """
-  def changeset(struct, params \\ %{}) do
-    struct
-    |> cast(params, [:role])
-    |> validate_required([:role])
-    |> validate_inclusion(:role, roles)
-  end
-
-  @doc """
   Builds a changeset based on the `struct` and `params`, for creating a record.
   """
   def create_changeset(struct, params \\ %{}) do
     struct
-    |> changeset(params)
     |> cast(params, [:member_id, :organization_id])
     |> validate_required([:member_id, :organization_id])
     |> assoc_constraint(:member)
     |> assoc_constraint(:organization)
+    |> put_change(:role, "pending")
   end
 
   @doc """
@@ -46,7 +36,9 @@ defmodule CodeCorps.OrganizationMembership do
   """
   def update_changeset(struct, params \\ %{}) do
     struct
-    |> changeset(params)
+    |> cast(params, [:role])
+    |> validate_required([:role])
+    |> validate_inclusion(:role, roles)
   end
 
   def index_filters(query, params) do


### PR DESCRIPTION
Closes #158 

Had to rewrite the model specs, due to updated changesets
- Now, `create_changeset` sets new membership role to "pending" automatically.
- `update_changeset` allows setting of membership role to one of predefined values only
