### PR TITLE
Migrate more data for deployment

### DIFF
--- a/priv/repo/migrations/20160815125009_create_preview.exs
+++ b/priv/repo/migrations/20160815125009_create_preview.exs
@@ -2,7 +2,7 @@ defmodule CodeCorps.Repo.Migrations.CreatePreview do
   use Ecto.Migration
 
   def change do
-    create table(:preview) do
+    create table(:previews) do
       add :markdown, :text, null: false
       add :body, :text, null: false
 

--- a/priv/repo/migrations/20160911233738_remove_icon_urls_from_projects.exs
+++ b/priv/repo/migrations/20160911233738_remove_icon_urls_from_projects.exs
@@ -1,0 +1,10 @@
+defmodule CodeCorps.Repo.Migrations.RemoveIconUrlsFromProjects do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      remove :icon_large_url
+      remove :icon_thumb_url
+    end
+  end
+end

--- a/priv/repo/migrations/20160912002705_change_string_to_text_where_needed.exs
+++ b/priv/repo/migrations/20160912002705_change_string_to_text_where_needed.exs
@@ -1,0 +1,65 @@
+defmodule CodeCorps.Repo.Migrations.ChangeStringToTextWhereNeeded do
+  use Ecto.Migration
+
+  def up do
+    alter table(:categories) do
+      modify :description, :text
+    end
+
+    alter table(:organizations) do
+      modify :name, :text
+      modify :description, :text
+    end
+
+    alter table(:posts) do
+      modify :body, :text
+      modify :markdown, :text
+      modify :title, :text
+    end
+
+    alter table(:projects) do
+      modify :description, :text
+      modify :long_description_body, :text
+      modify :long_description_markdown, :text
+    end
+
+    alter table(:skills) do
+      modify :description, :text
+    end
+
+    alter table(:users) do
+      modify :biography, :text
+    end
+  end
+
+  def down do
+    alter table(:categories) do
+      modify :description, :string
+    end
+
+    alter table(:organizations) do
+      modify :name, :string
+      modify :description, :string
+    end
+
+    alter table(:posts) do
+      modify :body, :string
+      modify :markdown, :string
+      modify :title, :string
+    end
+
+    alter table(:projects) do
+      modify :description, :string
+      modify :long_description_body, :string
+      modify :long_description_markdown, :string
+    end
+
+    alter table(:skills) do
+      modify :description, :string
+    end
+
+    alter table(:users) do
+      modify :biography, :string
+    end
+  end
+end

--- a/web/models/preview.ex
+++ b/web/models/preview.ex
@@ -7,7 +7,7 @@ defmodule CodeCorps.Preview do
 
   alias CodeCorps.MarkdownRenderer
 
-  schema "preview" do
+  schema "previews" do
     field :body, :string
     field :markdown, :string
 


### PR DESCRIPTION
This changes `preview` to `previews` (an old migration).

Removes unnecessary icon URL fields.
