### PR TITLE
Missing command fix in INSTALLING.md

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -31,7 +31,7 @@ Go to the `code-corps-phoenix` directory and copy the `.env.example` file:
 
 ```
 cd code-corps-phoenix
-cp .env.example
+cp .env.example .env
 ```
 
 Now, you can initialize docker, type:


### PR DESCRIPTION
The `cp .env.example .env` command was missing the `.env` part.
