### PR TITLE
Hide email from response for all but authenticated user

### DIFF
--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -55,7 +55,7 @@ defmodule CodeCorps.UserControllerTest do
       assert data["id"] == "#{user.id}"
       assert data["type"] == "user"
       assert data["attributes"]["username"] == user.username
-      assert data["attributes"]["email"] == user.email
+      assert data["attributes"]["email"] == ""
       assert data["attributes"]["password"] == nil
     end
 

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -40,7 +40,8 @@ defmodule CodeCorps.UserController do
       User
       |> preload([:slugged_route, :categories, :organizations, :roles, :skills])
       |> Repo.get!(id)
-  render(conn, "show.json-api", data: user)
+
+    render(conn, "show.json-api", data: user)
   end
 
   def update(conn, %{"id" => id, "data" => data = %{"type" => "user", "attributes" => _user_params}}) do

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -31,4 +31,19 @@ defmodule CodeCorps.UserView do
   def photo_thumb_url(user, _conn) do
     CodeCorps.UserPhoto.url({user.photo, user}, :thumb)
   end
+
+  @doc """
+  Returns the user email or an empty string, depending on the user
+  being rendered is the authenticated user, or some other user.
+
+  Users can only see their own emails. Everyone else's are private.
+  """
+  def email(user, %Plug.Conn{assigns: %{current_user: current_user}}) do
+    cond do
+      user.id == current_user.id -> user.email
+      user.id != current_user.id -> ""
+    end
+  end
+
+  def email(_user, _conn), do: ""
 end


### PR DESCRIPTION
Closes #194 

I implemented this at the view level.

We can override record attributes by defining functions of the same name as the attribute. This function then receives the record as the first parameter and the `conn` as the second, so it's simple to compare the user being serialised with the `current_user` assign in the `conn`. 

Took me a while to figure out this is possible, though.
