### PR TITLE
Made searching by slug case insensitive

### DIFF
--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -61,6 +61,13 @@ defmodule CodeCorps.ProjectControllerTest do
 
       assert expected_ids == actual_ids
     end
+
+    test "listing by organization slug is case insensitive", %{conn: conn} do
+      organization = insert(:organization)
+      insert(:slugged_route, slug: "codecorps", organization: organization)
+
+      assert conn |> get("/codeCorps/projects") |> json_response(200)
+    end
   end
 
   describe "#show" do
@@ -103,6 +110,13 @@ defmodule CodeCorps.ProjectControllerTest do
       assert data["attributes"]["description"] == "Test project description"
       assert data["attributes"]["long-description-markdown"] == "A markdown **description**"
       assert data["relationships"]["organization"]["data"]["id"] == Integer.to_string(project.organization_id)
+    end
+
+    test "retrieval by slug is case insensitive", %{conn: conn} do
+      organization = insert(:organization, slug: "codecorps")
+      insert(:project, slug: "codecorpsproject", organization: organization)
+
+      assert conn |> get("codeCorps/codeCorpsProject") |> json_response(200)
     end
   end
 

--- a/test/controllers/slugged_route_controller_test.exs
+++ b/test/controllers/slugged_route_controller_test.exs
@@ -1,15 +1,12 @@
 defmodule CodeCorps.SluggedRouteControllerTest do
   use CodeCorps.ApiCase
 
-  alias CodeCorps.SluggedRoute
-  alias CodeCorps.Repo
-
   @valid_attrs %{organization_id: 42, slug: "some content", user_id: 42}
   @invalid_attrs %{}
 
   test "shows chosen resource", %{conn: conn} do
     slug = "test-slug"
-    slugged_route = Repo.insert! %SluggedRoute{slug: slug}
+    slugged_route = insert(:slugged_route, slug: slug)
     conn = get conn, "/#{slug}"
     data = json_response(conn, 200)["data"]
     assert data["id"] == "#{slugged_route.id}"
@@ -17,6 +14,14 @@ defmodule CodeCorps.SluggedRouteControllerTest do
     assert data["attributes"]["slug"] == slugged_route.slug
     assert data["attributes"]["organization_id"] == slugged_route.organization_id
     assert data["attributes"]["user_id"] == slugged_route.user_id
+  end
+
+  test "is case insensitive", %{conn: conn} do
+    slug = "test"
+    insert(:slugged_route, slug: slug)
+
+    assert conn |> get("/test") |> json_response(200)
+    assert conn |> get("/tEst") |> json_response(200)
   end
 
   test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -10,7 +10,7 @@ defmodule CodeCorps.ProjectController do
   def index(conn, %{"slug" => slug}) do
     slugged_route =
       CodeCorps.SluggedRoute
-      |> Repo.get_by!(slug: slug)
+      |> CodeCorps.ModelHelpers.slug_finder(slug)
 
     projects =
       Project
@@ -32,7 +32,7 @@ defmodule CodeCorps.ProjectController do
   def show(conn, %{"slug" => _slug, "project_slug" => project_slug}) do
     project =
       Project
-      |> Repo.get_by!(slug: project_slug)
+      |> CodeCorps.ModelHelpers.slug_finder(project_slug)
       |> Repo.preload([:categories, :organization, :posts, :skills])
 
     render(conn, "show.json-api", data: project)

--- a/web/controllers/slugged_route_controller.ex
+++ b/web/controllers/slugged_route_controller.ex
@@ -7,7 +7,8 @@ defmodule CodeCorps.SluggedRouteController do
     slugged_route =
       SluggedRoute
       |> preload([:organization, :user])
-      |> Repo.get_by!(slug: slug)
+      |> CodeCorps.ModelHelpers.slug_finder(slug)
+
     render(conn, "show.json-api", data: slugged_route)
   end
 end

--- a/web/models/model_helpers.ex
+++ b/web/models/model_helpers.ex
@@ -15,6 +15,8 @@ defmodule CodeCorps.ModelHelpers do
     end
   end
 
+  # filters
+
   def id_filter(query, %{"filter" => %{"id" => id_list}}) do
     ids = id_list |> coalesce_id_string
     query |> where([object], object.id in ^ids)
@@ -64,4 +66,14 @@ defmodule CodeCorps.ModelHelpers do
     query |> where([object], ilike(object.title, ^"%#{title}%"))
   end
   def title_filter(query, _), do: query
+
+  # end filters
+
+  # finders
+
+  def slug_finder(query, slug) do
+    query |> CodeCorps.Repo.get_by!(slug: slug |> String.downcase)
+  end
+
+  # end finders
 end


### PR DESCRIPTION
Closes #203 

I could use ideas on how to organize this a bit better, but I think we might wanna do it in a separate issue, since a lot of current PRs touch on filtering.

I'm still using `Repo.get_by!`, but since the generated slug is always downcased (parametrized), I also downcase the filter.

I'm not really sure that's what we want, though. Do we want to parametrize the filter as well?
