### PR TITLE
Redirect to API docs from root and remove warning for CORS from tests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -61,6 +61,9 @@ config :segment,
 # Configures random icon color generator
 config :code_corps, :icon_color_generator, CodeCorps.RandomIconColor.Generator
 
+# Set Corsica logging to output a console warning when rejecting a request
+config :code_corps, :corsica_log_level, [rejected: :warn]
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,3 +31,6 @@ config :guardian, Guardian,
 config :code_corps, :analytics, CodeCorps.Analytics.InMemory
 
 config :code_corps, :icon_color_generator, CodeCorps.RandomIconColor.TestGenerator
+
+# Set Corsica logging to output no console warning when rejecting a request
+config :code_corps, :corsica_log_level, [rejected: :debug]

--- a/lib/code_corps/endpoint.ex
+++ b/lib/code_corps/endpoint.ex
@@ -40,7 +40,8 @@ defmodule CodeCorps.Endpoint do
 
   plug Corsica, [
     origins: Application.get_env(:code_corps, :allowed_origins),
-    allow_headers: ["accept", "authorization", "content-type"]
+    allow_headers: ["accept", "authorization", "content-type"],
+    log: Application.get_env(:code_corps, :corsica_log_level)
   ]
   plug CodeCorps.Router
 end

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -3,7 +3,7 @@ defmodule CodeCorps.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert redirected_to(conn, 302) =~ "http://docs.codecorpsapi.apiary.io/"
   end
 
   test "allows CORS from http://localhost:4200" do

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -2,6 +2,6 @@ defmodule CodeCorps.PageController do
   use CodeCorps.Web, :controller
 
   def index(conn, _params) do
-    render conn, "index.html"
+    redirect conn, external: "http://docs.codecorpsapi.apiary.io/"
   end
 end


### PR DESCRIPTION
Closes #198.

@noslouch instead of removing entirely or replacing with some random root response, I figured it would be a good opportunity to redirect from the root to our API docs.

Thoughts?
