### PR TITLE
Eliminate many to many from views

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,2 @@
 erlang_version=19.1
-elixir_version=1.3.3
+elixir_version=1.3.2

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CodeCorps.Mixfile do
   def project do
     [app: :code_corps,
      version: "0.0.1",
-     elixir: "~> 1.3.3",
+     elixir: "1.3.2",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      build_embedded: Mix.env == :prod,

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -85,9 +85,6 @@ defmodule CodeCorps.ProjectControllerTest do
       assert data["attributes"]["description"] == "Test project description"
       assert data["attributes"]["long-description-markdown"] == "A markdown **description**"
       assert data["relationships"]["organization"]["data"]["id"] == Integer.to_string(project.organization_id)
-      assert data["relationships"]["project-categories"]["data"] == []
-      assert data["relationships"]["project-skills"]["data"] == []
-      assert data["relationships"]["skills"]["data"] == []
     end
 
     test "shows chosen resource retrieved by slug", %{conn: conn} do

--- a/test/views/category_view_test.exs
+++ b/test/views/category_view_test.exs
@@ -12,7 +12,7 @@ defmodule CodeCorps.CategoryViewTest do
     category =
       CodeCorps.Category
       |> Repo.get(project_category.category_id)
-      |> CodeCorps.Repo.preload([:project_categories, :projects])
+      |> CodeCorps.Repo.preload([:project_categories])
 
     rendered_json =  render(CodeCorps.CategoryView, "show.json-api", data: category)
 
@@ -28,11 +28,6 @@ defmodule CodeCorps.CategoryViewTest do
           "project-categories" => %{
             data: [
               %{id: project_category.id |> Integer.to_string, type: "project-category"}
-            ]
-          },
-          "projects" => %{
-            data: [
-              %{id: project_category.project_id |> Integer.to_string, type: "project"}
             ]
           }
         },

--- a/test/views/organization_view_test.exs
+++ b/test/views/organization_view_test.exs
@@ -15,7 +15,7 @@ defmodule CodeCorps.OrganizationViewTest do
     organization =
       CodeCorps.Organization
       |> Repo.get(organization.id)
-      |> CodeCorps.Repo.preload([:members, :projects, :slugged_route])
+      |> CodeCorps.Repo.preload([:organization_memberships, :projects, :slugged_route])
 
     rendered_json =  render(CodeCorps.OrganizationView, "show.json-api", data: organization)
 
@@ -32,11 +32,6 @@ defmodule CodeCorps.OrganizationViewTest do
         },
         id: organization.id |> Integer.to_string,
         relationships: %{
-          "members" => %{
-            data: [
-              %{id: user.id |> Integer.to_string, type: "user"}
-            ]
-          },
           "organization-memberships" => %{
             data: [
               %{id: organization_membership.id |> Integer.to_string, type: "organization-membership"}

--- a/test/views/project_view_test.exs
+++ b/test/views/project_view_test.exs
@@ -16,7 +16,7 @@ defmodule CodeCorps.ProjectViewTest do
     project =
       CodeCorps.Project
       |> Repo.get(project.id)
-      |> CodeCorps.Repo.preload([:categories, :organization, :posts, :skills])
+      |> CodeCorps.Repo.preload([:organization, :posts, :project_categories, :project_skills])
 
     rendered_json =  render(CodeCorps.ProjectView, "show.json-api", data: project)
 
@@ -35,14 +35,6 @@ defmodule CodeCorps.ProjectViewTest do
         },
         id: project.id |> Integer.to_string,
         relationships: %{
-          "categories" => %{
-            data: [
-              %{
-                id: project_category.category_id |> Integer.to_string,
-                type: "category"
-              }
-            ]
-          },
           "organization" => %{
             data: %{
               id: organization.id |> Integer.to_string,
@@ -72,15 +64,7 @@ defmodule CodeCorps.ProjectViewTest do
                 type: "project-skill"
               }
             ]
-          },
-          "skills" => %{
-            data: [
-              %{
-                id: project_skill.skill_id |> Integer.to_string,
-                type: "skill"
-              }
-            ]
-          },
+          }
         },
         type: "project",
       },

--- a/test/views/role_view_test.exs
+++ b/test/views/role_view_test.exs
@@ -7,14 +7,12 @@ defmodule CodeCorps.RoleViewTest do
   import Phoenix.View
 
   test "renders all attributes and relationships properly" do
-    role = insert(:role)
-    skill = insert(:skill)
-    role_skill = insert(:role_skill, role: role, skill: skill)
+    role_skill = insert(:role_skill)
 
     role =
       CodeCorps.Role
-      |> Repo.get(role.id)
-      |> Repo.preload([:skills])
+      |> Repo.get(role_skill.role_id)
+      |> Repo.preload([:role_skills])
 
     rendered_json =  render(CodeCorps.RoleView, "show.json-api", data: role)
 
@@ -32,11 +30,6 @@ defmodule CodeCorps.RoleViewTest do
           "role-skills" => %{
             data: [
               %{id: role_skill.id |> Integer.to_string, type: "role-skill"}
-            ]
-          },
-          "skills" => %{
-            data: [
-              %{id: skill.id |> Integer.to_string, type: "skill"}
             ]
           }
         },

--- a/test/views/user_view_test.exs
+++ b/test/views/user_view_test.exs
@@ -15,8 +15,8 @@ defmodule CodeCorps.UserViewTest do
 
     user =
       CodeCorps.User
+      |> preload([:slugged_route, :organization_memberships, :user_categories, :user_roles, :user_skills])
       |> Repo.get(db_user.id)
-      |> CodeCorps.Repo.preload([:categories, :organizations, :roles, :skills, :slugged_route])
 
     rendered_json = render(CodeCorps.UserView, "show.json-api", data: user)
 
@@ -39,11 +39,6 @@ defmodule CodeCorps.UserViewTest do
           "state" => "signed_up"
         },
         relationships: %{
-          "organizations" => %{
-            data: [
-              %{id: organization_membership.organization_id |> Integer.to_string, type: "organization"}
-            ]
-          },
           "organization-memberships" => %{
             data: [
               %{id: organization_membership.id |> Integer.to_string, type: "organization-membership"}

--- a/web/controllers/category_controller.ex
+++ b/web/controllers/category_controller.ex
@@ -7,7 +7,7 @@ defmodule CodeCorps.CategoryController do
   plug :load_and_authorize_resource, model: Category, only: [:create, :update]
 
   def index(conn, _params) do
-    categories = Category |> Repo.all |> Repo.preload([:project_categories, :projects])
+    categories = Category |> Repo.all |> Repo.preload([:project_categories])
     render(conn, "index.json-api", data: categories)
   end
 
@@ -18,7 +18,7 @@ defmodule CodeCorps.CategoryController do
       {:ok, category} ->
         category =
           category
-          |> Repo.preload([:projects])
+          |> Repo.preload([:project_categories])
 
         conn
         |> put_status(:created)
@@ -34,7 +34,7 @@ defmodule CodeCorps.CategoryController do
   def show(conn, %{"id" => id}) do
     category =
       Category
-      |> preload([:projects])
+      |> preload([:project_categories])
       |> Repo.get!(id)
 
     render(conn, "show.json-api", data: category)
@@ -43,7 +43,7 @@ defmodule CodeCorps.CategoryController do
   def update(conn, %{"id" => id, "data" => data = %{"type" => "category", "attributes" => _category_params}}) do
     changeset =
       Category
-      |> preload([:projects])
+      |> preload([:project_categories])
       |> Repo.get!(id)
       |> Category.changeset(Params.to_attributes(data))
 

--- a/web/controllers/organization_controller.ex
+++ b/web/controllers/organization_controller.ex
@@ -13,7 +13,7 @@ defmodule CodeCorps.OrganizationController do
     organizations =
       Organization
       |> Organization.index_filters(params)
-      |> preload([:members, :projects, :slugged_route])
+      |> preload([:organization_memberships, :projects, :slugged_route])
       |> Repo.all
 
     render(conn, "index.json-api", data: organizations)
@@ -40,7 +40,7 @@ defmodule CodeCorps.OrganizationController do
   def show(conn, %{"id" => id}) do
     organization =
       Organization
-      |> preload([:members, :projects, :slugged_route])
+      |> preload([:organization_memberships, :projects, :slugged_route])
       |> Repo.get!(id)
     render(conn, "show.json-api", data: organization)
   end
@@ -48,7 +48,7 @@ defmodule CodeCorps.OrganizationController do
   def update(conn, %{"id" => id, "data" => data = %{"type" => "organization", "attributes" => _organization_params}}) do
     changeset =
       Organization
-      |> preload([:members, :projects, :slugged_route])
+      |> preload([:organization_memberships, :projects, :slugged_route])
       |> Repo.get!(id)
       |> changeset(Params.to_attributes(data))
 

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -15,7 +15,7 @@ defmodule CodeCorps.ProjectController do
     projects =
       Project
       |> Repo.all(organization_id: slugged_route.organization_id)
-      |> Repo.preload([:categories, :organization, :posts, :skills])
+      |> Repo.preload([:organization, :posts, :project_categories, :project_skills])
 
     render(conn, "index.json-api", data: projects)
   end
@@ -24,7 +24,7 @@ defmodule CodeCorps.ProjectController do
     projects =
       Project
       |> Repo.all
-      |> Repo.preload([:categories, :organization, :posts, :skills])
+      |> Repo.preload([:organization, :posts, :project_categories, :project_skills])
 
     render(conn, "index.json-api", data: projects)
   end
@@ -33,7 +33,7 @@ defmodule CodeCorps.ProjectController do
     project =
       Project
       |> CodeCorps.ModelHelpers.slug_finder(project_slug)
-      |> Repo.preload([:categories, :organization, :posts, :skills])
+      |> Repo.preload([:organization, :posts, :project_categories, :project_skills])
 
     render(conn, "show.json-api", data: project)
   end
@@ -42,7 +42,7 @@ defmodule CodeCorps.ProjectController do
     project =
       Project
       |> Repo.get!(id)
-      |> Repo.preload([:categories, :organization, :posts, :skills])
+      |> Repo.preload([:organization, :posts, :project_categories, :project_skills])
 
     render(conn, "show.json-api", data: project)
   end
@@ -54,7 +54,7 @@ defmodule CodeCorps.ProjectController do
       {:ok, project} ->
         project =
           project
-          |> Repo.preload([:categories, :organization, :posts, :skills])
+          |> Repo.preload([:organization, :posts, :project_categories, :project_skills])
 
         conn
         |> put_status(:created)
@@ -77,7 +77,7 @@ defmodule CodeCorps.ProjectController do
       {:ok, project} ->
         project =
           project
-          |> Repo.preload([:categories, :organization, :posts, :skills])
+          |> Repo.preload([:organization, :posts, :project_categories, :project_skills])
 
         conn
         |> put_status(:created)

--- a/web/controllers/role_controller.ex
+++ b/web/controllers/role_controller.ex
@@ -11,7 +11,7 @@ defmodule CodeCorps.RoleController do
     roles =
       Role
       |> Repo.all
-      |> Repo.preload([:skills])
+      |> Repo.preload([:role_skills])
     render(conn, "index.json-api", data: roles)
   end
 
@@ -20,7 +20,7 @@ defmodule CodeCorps.RoleController do
 
     case Repo.insert(changeset) do
       {:ok, role} ->
-        role = Repo.preload(role, [:skills])
+        role = Repo.preload(role, [:role_skills])
 
         conn
         |> put_status(:created)

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -13,7 +13,7 @@ defmodule CodeCorps.UserController do
     users =
       User
       |> User.index_filters(params)
-      |> preload([:slugged_route, :categories, :organizations, :roles, :skills])
+      |> preload([:slugged_route, :organization_memberships, :user_categories, :user_roles, :user_skills])
       |> Repo.all
 
     render(conn, "index.json-api", data: users)
@@ -24,7 +24,7 @@ defmodule CodeCorps.UserController do
 
     case Repo.insert(changeset) do
       {:ok, user} ->
-        user = Repo.preload(user, [:slugged_route, :categories, :organizations, :roles, :skills])
+        user = Repo.preload(user, [:slugged_route, :organization_memberships, :user_categories, :user_roles, :user_skills])
 
         conn
         |> Plug.Conn.assign(:current_user, user)
@@ -42,7 +42,7 @@ defmodule CodeCorps.UserController do
   def show(conn, %{"id" => id}) do
     user =
       User
-      |> preload([:slugged_route, :categories, :organizations, :user_roles, :user_skills])
+      |> preload([:slugged_route, :organization_memberships, :user_categories, :user_roles, :user_skills])
       |> Repo.get!(id)
 
     render(conn, "show.json-api", data: user)
@@ -51,7 +51,7 @@ defmodule CodeCorps.UserController do
   def update(conn, %{"id" => id, "data" => data = %{"type" => "user", "attributes" => _user_params}}) do
     user =
       User
-      |> preload([:slugged_route, :categories, :organizations, :roles, :skills])
+      |> preload([:slugged_route, :organization_memberships, :user_categories, :user_roles, :user_skills])
       |> Repo.get!(id)
 
     changeset = User.update_changeset(user, Params.to_attributes(data))

--- a/web/views/category_view.ex
+++ b/web/views/category_view.ex
@@ -5,5 +5,4 @@ defmodule CodeCorps.CategoryView do
   attributes [:name, :slug, :description]
 
   has_many :project_categories, serializer: CodeCorps.ProjectCategoryView
-  has_many :projects, serializer: CodeCorps.ProjectView
 end

--- a/web/views/organization_view.ex
+++ b/web/views/organization_view.ex
@@ -6,9 +6,7 @@ defmodule CodeCorps.OrganizationView do
 
   has_one :slugged_route, serializer: CodeCorps.SluggedRouteView
 
-  has_many :members, serializer: CodeCorps.UserView
-  has_many :organization_memberships,
-    serializer: CodeCorps.OrganizationMembershipView
+  has_many :organization_memberships, serializer: CodeCorps.OrganizationMembershipView
   has_many :projects, serializer: CodeCorps.ProjectView
 
   def icon_large_url(organization, _conn) do

--- a/web/views/project_view.ex
+++ b/web/views/project_view.ex
@@ -12,9 +12,7 @@ defmodule CodeCorps.ProjectView do
   has_many :posts, serializer: CodeCorps.PostView
 
   has_many :project_categories, serializer: CodeCorps.ProjectCategoryView
-  has_many :categories, serializer: CodeCorps.CategoryView
   has_many :project_skills, serializer: CodeCorps.ProjectSkillView
-  has_many :skills, serializer: CodeCorps.SkillView
 
   def icon_large_url(project, _conn) do
     CodeCorps.ProjectIcon.url({project.icon, project}, :large)

--- a/web/views/role_view.ex
+++ b/web/views/role_view.ex
@@ -5,5 +5,4 @@ defmodule CodeCorps.RoleView do
   attributes [:name, :ability, :kind, :inserted_at, :updated_at]
 
   has_many :role_skills, serializer: CodeCorps.RoleSkillView
-  has_many :skills, serializer: CodeCorps.SkillView
 end

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -10,11 +10,7 @@ defmodule CodeCorps.UserView do
   ]
 
   has_one :slugged_route, serializer: CodeCorps.SluggedRouteView
-
-  has_many :organization_memberships,
-    serializer: CodeCorps.OrganizationMembershipView
-  has_many :organizations, serializer: CodeCorps.OrganizationView
-
+  has_many :organization_memberships, serializer: CodeCorps.OrganizationMembershipView
   has_many :user_categories, serializer: CodeCorps.UserCategoryView
   has_many :user_roles, serializer: CodeCorps.UserRoleView
   has_many :user_skills, serializer: CodeCorps.UserSkillView


### PR DESCRIPTION
Closes #273 

I've also updated preload calls on all affected controllers, so they match what the view requires. Since they all seem to be identical across all controller actions, we should consider moving them into a helper.

Something like

``` Elixir

def preload(query, _action), do: query |>preload([:slugged_route, :organization_memberships, :user_categories, :user_roles, :user_skills])

# user_controller.ex

def index(conn, params) do
  users =
    User
    |> User.index_filters(params)
    |> preload
    |> Repo.all

  render(conn, "index.json-api", data: users)
end
```

The unused action parameter is so that, in the future, if we need it, we can use separate preloads for different actions (if the actions start using different serializers). All that is for a separate issue, though.
