### PR TITLE
Add show and index actions to ProjectCategory

### DIFF
--- a/web/controllers/project_category_controller.ex
+++ b/web/controllers/project_category_controller.ex
@@ -1,11 +1,30 @@
 defmodule CodeCorps.ProjectCategoryController do
   use CodeCorps.Web, :controller
 
+  import CodeCorps.ControllerHelpers
+
   alias JaSerializer.Params
   alias CodeCorps.ProjectCategory
 
   plug :load_and_authorize_resource, model: ProjectCategory, only: [:create, :delete]
   plug :scrub_params, "data" when action in [:create]
+
+  def index(conn, params) do
+    project_categories =
+      case params do
+        %{"filter" => %{"id" => id_list}} ->
+          ids = id_list |> coalesce_id_string
+          ProjectCategory
+          |> preload([:project, :category])
+          |> where([p], p.id in ^ids)
+          |> Repo.all
+        %{} ->
+          ProjectCategory
+          |> preload([:user, :category])
+          |> Repo.all
+      end
+    render(conn, "index.json-api", data: project_categories)
+  end
 
   def create(conn, %{"data" => data = %{"type" => "project-category"}}) do
     changeset = %ProjectCategory{} |> ProjectCategory.create_changeset(Params.to_attributes(data))
@@ -22,6 +41,14 @@ defmodule CodeCorps.ProjectCategoryController do
         |> put_status(:unprocessable_entity)
         |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
     end
+  end
+
+  def show(conn, %{"id" => id}) do
+    project_category =
+      ProjectCategory
+      |> preload([:project, :category])
+      |> Repo.get!(id)
+    render(conn, "show.json-api", data: project_category)
   end
 
   def delete(conn, %{"id" => id}) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -61,6 +61,7 @@ defmodule CodeCorps.Router do
       resources "/posts", PostController, only: [:index, :show]
     end
 
+    resources "/project-categories", ProjectCategoryController, only: [:index, :show]
     resources "/project-skills", ProjectSkillController, only: [:index, :show]
     resources "/roles", RoleController, only: [:index, :show]
     resources "/skills", SkillController, only: [:index, :show]


### PR DESCRIPTION
This fixes an issue whereby we had no `ProjectCategory` `show` and `index` actions.
