### PR TITLE
Render state_transition for user

### DIFF
--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -233,6 +233,9 @@ defmodule CodeCorps.UserControllerTest do
       %{"data" => %{"id" => id}} = json_response(conn, 200)
       user = Repo.get(User, id)
       assert user.state == "edited_profile"
+      
+      # Transition was successful, so we should unset it
+      assert user.state_transition == nil
     end
   end
 

--- a/test/views/user_view_test.exs
+++ b/test/views/user_view_test.exs
@@ -36,7 +36,8 @@ defmodule CodeCorps.UserViewTest do
           "username" => user.username,
           "updated-at" => user.updated_at,
           "website" => user.website,
-          "state" => "signed_up"
+          "state" => "signed_up",
+          "state-transition" => nil
         },
         relationships: %{
           "organization-memberships" => %{

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -4,9 +4,8 @@ defmodule CodeCorps.UserView do
 
   attributes [
     :biography, :email, :first_name, :last_name,
-    :photo_large_url, :photo_thumb_url, :twitter,
-    :username, :website, :state,
-    :inserted_at, :updated_at
+    :photo_large_url, :photo_thumb_url, :state, :state_transition, :twitter,
+    :username, :website, :inserted_at, :updated_at
   ]
 
   has_one :slugged_route, serializer: CodeCorps.SluggedRouteView


### PR DESCRIPTION
Closes https://github.com/code-corps/code-corps-ember/issues/445

Simply renders the virtual attribute of `state_transition` which will tell the client we are no longer undergoing a transition.
