### PR TITLE
Fix remote-development CORS issues

### DIFF
--- a/config/remote-development.exs
+++ b/config/remote-development.exs
@@ -24,12 +24,7 @@ config :code_corps, CodeCorps.Repo,
   ssl: true
 
 # CORS allowed origins
-config :code_corps, allowed_origins: [
-  "http://pbqrpbecf-qri.org",
-  "http://www.pbqrpbecf-qri.org",
-  "https://pbqrpbecf-qri.org",
-  "https://www.pbqrpbecf-qri.org"
-]
+config :code_corps, allowed_origins: "*"
 
 config :guardian, Guardian,
   secret_key: System.get_env("GUARDIAN_SECRET_KEY")


### PR DESCRIPTION
Simply sets allowed origins to `*`.
