### PR TITLE
Add test helpers to reduce duplicated assertions

### DIFF
--- a/test/controllers/task_controller_test.exs
+++ b/test/controllers/task_controller_test.exs
@@ -252,9 +252,7 @@ defmodule CodeCorps.TaskControllerTest do
     test "specifying a page size works", %{conn: conn} do
       project_1 = insert(:project)
       user = insert(:user)
-      insert(:task, project: project_1, user: user)
-      insert(:task, project: project_1, user: user)
-      insert(:task, project: project_1, user: user)
+      insert_list(3, :task, project: project_1, user: user)
 
       path = conn |> task_path(:index)
       json =
@@ -268,8 +266,8 @@ defmodule CodeCorps.TaskControllerTest do
     test "specifying a page number works", %{conn: conn} do
       project_1 = insert(:project)
       user = insert(:user)
-      insert(:task, project: project_1, user: user)
-      insert(:task, project: project_1, user: user)
+
+      insert_list(2, :task, project: project_1, user: user)
       task_to_test = insert(:task, project: project_1, user: user)
       insert(:task, project: project_1, user: user)
 
@@ -287,12 +285,7 @@ defmodule CodeCorps.TaskControllerTest do
     test "paginated results include a valid meta key", %{conn: conn} do
       project_1 = insert(:project)
       user = insert(:user)
-      insert(:task, project: project_1, user: user)
-      insert(:task, project: project_1, user: user)
-      insert(:task, project: project_1, user: user)
-      insert(:task, project: project_1, user: user)
-      insert(:task, project: project_1, user: user)
-      insert(:task, project: project_1, user: user)
+      insert_list(6, :task, project: project_1, user: user)
 
       meta = %{
         "total_records" => 6,

--- a/test/controllers/token_controller_test.exs
+++ b/test/controllers/token_controller_test.exs
@@ -34,9 +34,7 @@ defmodule CodeCorps.TokenControllerTest do
       response = json_response(conn, 401)
       [error | _] = response["errors"]
       assert error["detail"] == "Your password doesn't match the email #{user.email}."
-      assert error["id"] == "UNAUTHORIZED"
-      assert error["title"] == "401 Unauthorized"
-      assert error["status"] == 401
+      assert is_unauthorized?(error)
       refute response["token"]
       refute response["user_id"]
     end
@@ -47,9 +45,7 @@ defmodule CodeCorps.TokenControllerTest do
       response = json_response(conn, 401)
       [error | _] = response["errors"]
       assert error["detail"] == "We couldn't find a user with the email notauser@test.com."
-      assert error["id"] == "UNAUTHORIZED"
-      assert error["title"] == "401 Unauthorized"
-      assert error["status"] == 401
+      assert is_unauthorized?(error)
       refute response["token"]
       refute response["user_id"]
     end
@@ -77,10 +73,11 @@ defmodule CodeCorps.TokenControllerTest do
       refute response["token"]
       refute response["user_id"]
       [error | _] = response["errors"]
-      assert error["id"] == "UNAUTHORIZED"
-      assert error["title"] == "401 Unauthorized"
-      assert error["status"] == 401
+      assert is_unauthorized?(error)
       assert error["detail"] == "token_expired"
     end
   end
+
+  defp is_unauthorized?(%{"id" => "UNAUTHORIZED", "title" => "401 Unauthorized", "status" => 401}), do: true
+  defp is_unauthorized?(_), do: false
 end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -22,9 +22,7 @@ defmodule CodeCorps.UserControllerTest do
     twitter: " @ testuser"
   }
 
-  defp relationships do
-    %{}
-  end
+  defp relationships, do: %{}
 
   describe "index" do
 
@@ -34,8 +32,7 @@ defmodule CodeCorps.UserControllerTest do
     end
 
     test "filters resources on index", %{conn: conn} do
-      user_1 = insert(:user, username: "user_1", email: "user_1@mail.com")
-      user_2 = insert(:user, username: "user_2", email: "user_2@mail.com")
+      [user_1, user_2] = insert_pair(:user)
       insert(:user, username: "user_3", email: "user_3@mail.com")
       conn = get conn, "users/?filter[id]=#{user_1.id},#{user_2.id}"
       data = json_response(conn, 200)["data"]
@@ -233,7 +230,7 @@ defmodule CodeCorps.UserControllerTest do
       %{"data" => %{"id" => id}} = json_response(conn, 200)
       user = Repo.get(User, id)
       assert user.state == "edited_profile"
-      
+
       # Transition was successful, so we should unset it
       assert user.state_transition == nil
     end

--- a/test/support/api_case.ex
+++ b/test/support/api_case.ex
@@ -25,6 +25,7 @@ defmodule CodeCorps.ApiCase do
       import CodeCorps.AuthenticationTestHelpers
       import CodeCorps.Router.Helpers
       import CodeCorps.Factories
+      import CodeCorps.TestHelpers
 
       # The default endpoint for testing
       @endpoint CodeCorps.Endpoint

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,9 @@
+defmodule CodeCorps.TestHelpers do
+  use Phoenix.ConnTest
+
+  def ids_from_response(response) do
+    Enum.map response["data"], fn(attributes) ->
+      String.to_integer(attributes["id"])
+    end
+  end
+end


### PR DESCRIPTION
Why:
There seem to be quite a few duplicated assertions.  We should work on some test helpers to make these tests a bit more idiomatic and reduce some redundancy around what we are testing.

This PR:
Adds a test helper for asserting ids in a payload
Adds a helper for 401 responses
Leverages Ex-machina methods to reduce the number of inserts
