### PR TITLE
run mix.deps before building the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM elixir:1.3.3
+ENV APP_HOME /code-corps-api
+RUN mkdir $APP_HOME
 
 RUN apt-get update -qq && apt-get install -y build-essential
 
@@ -9,19 +11,18 @@ RUN apt-get install -y -q inotify-tools
 # PostgreSQL
 RUN apt-get install -y libpq-dev
 
-# Install hex
-RUN mix local.hex --force
-
-# Install rebar
-RUN mix local.rebar --force
-
 # Install the Phoenix framework itself
 RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez
 
 # Set directory for our app
-ENV APP_HOME /code-corps-api
-RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
+COPY mix.exs mix.lock $APP_HOME/
+
+# Install hex
+RUN mix local.hex --force && \
+    mix local.rebar --force && \
+    mix deps.clean --all && \
+    mix deps.get
 
 # Copy code
 ADD . $APP_HOME


### PR DESCRIPTION
Hi there!

First PR for this repo 😸  I'm eager to help resolve some of the issues I've encountered when trying to run this application locally with Docker and docker-compose. This PR is limited to Dockerfile changes as I'm still reading the docker-compose docs to identify the ideal way to use `volumes` (aka, mapping to include local file changes).

Why:
I ran into a number of errors when running docker-compose up and then
running the command 'docker-compose run test mix test'. The most common
error being 'could not compile dependency :dependency_name, "mix compile"
failed'.

This PR:
Copies the necessary mix files into the app directory and then fetches
all the dependencies.

Detailed error message referenced above:

```
==> arc
could not compile dependency :arc, "mix compile" failed. You can recompile this dependency with "mix deps.compile arc", update it with "mix deps.update arc" or clean it with "mix deps.clean arc"
==> code_corps
** (Mix) Failed to open Hex registry (file does not exist, run `mix hex.info` to fetch it)
```
