### PR TITLE
Fix seeds.exs to meet not null contraints

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -41,7 +41,8 @@ end
 
 organizations = [
   %{
-    name: "Code Corps"
+    name: "Code Corps",
+    description: "Help build and fund public software projects for social good"
   },
 ]
 


### PR DESCRIPTION
5e6b235c3078f9dbacfa5295e27b5b3fc770a1d0 introduced a not null constraint for the organization description.

This adds a description to the seeded org to meet that constraint.
## 

While investigating this I noticed that the organization model doesn't require a description on the changeset. Is that intentional?
