### PR TITLE
Add :description to required fields on organisation changesets.

### DIFF
--- a/web/models/organization.ex
+++ b/web/models/organization.ex
@@ -35,7 +35,7 @@ defmodule CodeCorps.Organization do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:name, :description, :slug, :base64_icon_data])
-    |> validate_required([:name])
+    |> validate_required([:name, :description])
     |> upload_image(:base64_icon_data, :icon)
   end
 
@@ -46,7 +46,7 @@ defmodule CodeCorps.Organization do
     struct
     |> changeset(params)
     |> generate_slug(:name, :slug)
-    |> validate_required([:slug])
+    |> validate_required([:slug, :description])
     |> validate_slug(:slug)
     |> put_slugged_route()
   end


### PR DESCRIPTION
As mentioned in 5b951c1a510c86e4877b18c0766fc65c290c9e53 did 5e6b235c3078f9dbacfa5295e27b5b3fc770a1d0 introduce a not null contraint on the organization description.

This adds the description to the required fields on the organization changesets so it is possible to catch the constraint early.
