### PR TITLE
Add authorization based on changeset, for resources that need it

### DIFF
--- a/test/controllers/task_controller_test.exs
+++ b/test/controllers/task_controller_test.exs
@@ -12,7 +12,7 @@ defmodule CodeCorps.TaskControllerTest do
   }
 
   @invalid_attrs %{
-    task_type: "nonexistent",
+    task_type: "issue",
     status: "nonexistent"
   }
 
@@ -160,14 +160,13 @@ defmodule CodeCorps.TaskControllerTest do
 
   describe "create" do
     @tag :authenticated
-    test "creates and renders resource when data is valid", %{conn: conn} do
-      user = insert(:user)
+    test "creates and renders resource when data is valid", %{conn: conn, current_user: current_user} do
       project = insert(:project)
 
       payload =
         build_payload
         |> put_attributes(@valid_attrs)
-        |> put_relationships(user, project)
+        |> put_relationships(current_user, project)
 
       path = conn |> task_path(:create)
       json = conn |> post(path, payload) |> json_response(201)
@@ -181,8 +180,13 @@ defmodule CodeCorps.TaskControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 422 when data is invalid", %{conn: conn} do
-      payload = build_payload |> put_attributes(@invalid_attrs)
+    test "does not create resource and renders 422 when data is invalid", %{conn: conn, current_user: current_user} do
+      project = insert(:project)
+
+      payload =
+        build_payload
+        |> put_attributes(@invalid_attrs)
+        |> put_relationships(current_user, project)
 
       path = conn |> task_path(:create)
       json = conn |> post(path, payload) |> json_response(422)

--- a/test/controllers/user_category_controller_test.exs
+++ b/test/controllers/user_category_controller_test.exs
@@ -64,9 +64,8 @@ defmodule CodeCorps.UserCategoryControllerTest do
     end
 
     test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
-      assert_error_sent 404, fn ->
-        get conn, user_category_path(conn, :show, -1)
-      end
+      path = conn |> user_category_path(:show, -1)
+      assert conn |> get(path) |> json_response(:not_found)
     end
   end
 

--- a/test/controllers/user_skill_controller_test.exs
+++ b/test/controllers/user_skill_controller_test.exs
@@ -61,9 +61,8 @@ defmodule CodeCorps.UserSkillControllerTest do
     end
 
     test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
-      assert_error_sent 404, fn ->
-        get conn, user_skill_path(conn, :show, -1)
-      end
+      path = conn |> user_skill_path(:show, -1)
+      assert conn |> get(path) |> json_response(:not_found)
     end
   end
 

--- a/test/models/project_skill_test.exs
+++ b/test/models/project_skill_test.exs
@@ -7,14 +7,14 @@ defmodule CodeCorps.ProjectSkillTest do
     project_id = insert(:project).id
     skill_id = insert(:skill).id
 
-    changeset = ProjectSkill.changeset(%ProjectSkill{}, %{project_id: project_id, skill_id: skill_id})
+    changeset = ProjectSkill.create_changeset(%ProjectSkill{}, %{project_id: project_id, skill_id: skill_id})
     assert changeset.valid?
   end
 
   test "changeset requires project_id" do
     skill_id = insert(:skill).id
 
-    changeset = ProjectSkill.changeset(%ProjectSkill{}, %{skill_id: skill_id})
+    changeset = ProjectSkill.create_changeset(%ProjectSkill{}, %{skill_id: skill_id})
 
     refute changeset.valid?
     assert changeset.errors[:project_id] == {"can't be blank", []}
@@ -23,7 +23,7 @@ defmodule CodeCorps.ProjectSkillTest do
   test "changeset requires skill_id" do
     project_id = insert(:project).id
 
-    changeset = ProjectSkill.changeset(%ProjectSkill{}, %{project_id: project_id})
+    changeset = ProjectSkill.create_changeset(%ProjectSkill{}, %{project_id: project_id})
 
     refute changeset.valid?
     assert changeset.errors[:skill_id] == {"can't be blank", []}
@@ -34,7 +34,7 @@ defmodule CodeCorps.ProjectSkillTest do
     skill_id = insert(:skill).id
 
     { result, changeset } =
-      ProjectSkill.changeset(%ProjectSkill{}, %{project_id: project_id, skill_id: skill_id})
+      ProjectSkill.create_changeset(%ProjectSkill{}, %{project_id: project_id, skill_id: skill_id})
       |> Repo.insert
 
     assert result == :error
@@ -47,7 +47,7 @@ defmodule CodeCorps.ProjectSkillTest do
     skill_id = -1
 
     { result, changeset } =
-      ProjectSkill.changeset(%ProjectSkill{}, %{project_id: project_id, skill_id: skill_id})
+      ProjectSkill.create_changeset(%ProjectSkill{}, %{project_id: project_id, skill_id: skill_id})
       |> Repo.insert
 
     assert result == :error

--- a/test/models/user_category_test.exs
+++ b/test/models/user_category_test.exs
@@ -7,14 +7,14 @@ defmodule CodeCorps.UserCategoryTest do
       user_id = insert(:user).id
       category_id = insert(:category).id
 
-      changeset = UserCategory.changeset(%UserCategory{}, %{user_id: user_id, category_id: category_id})
+      changeset = UserCategory.create_changeset(%UserCategory{}, %{user_id: user_id, category_id: category_id})
       assert changeset.valid?
     end
 
     test "changeset requires user_id" do
       category_id = insert(:category).id
 
-      changeset = UserCategory.changeset(%UserCategory{}, %{category_id: category_id})
+      changeset = UserCategory.create_changeset(%UserCategory{}, %{category_id: category_id})
 
       refute changeset.valid?
       assert changeset.errors[:user_id] == {"can't be blank", []}
@@ -23,7 +23,7 @@ defmodule CodeCorps.UserCategoryTest do
     test "changeset requires category_id" do
       user_id = insert(:user).id
 
-      changeset = UserCategory.changeset(%UserCategory{}, %{user_id: user_id})
+      changeset = UserCategory.create_changeset(%UserCategory{}, %{user_id: user_id})
 
       refute changeset.valid?
       assert changeset.errors[:category_id] == {"can't be blank", []}
@@ -34,7 +34,7 @@ defmodule CodeCorps.UserCategoryTest do
       category_id = insert(:category).id
 
       { result, changeset } =
-        UserCategory.changeset(%UserCategory{}, %{user_id: user_id, category_id: category_id})
+        UserCategory.create_changeset(%UserCategory{}, %{user_id: user_id, category_id: category_id})
         |> Repo.insert
 
       assert result == :error
@@ -47,7 +47,7 @@ defmodule CodeCorps.UserCategoryTest do
       category_id = -1
 
       { result, changeset } =
-        UserCategory.changeset(%UserCategory{}, %{user_id: user_id, category_id: category_id})
+        UserCategory.create_changeset(%UserCategory{}, %{user_id: user_id, category_id: category_id})
         |> Repo.insert
 
       assert result == :error

--- a/test/models/user_role_test.exs
+++ b/test/models/user_role_test.exs
@@ -7,14 +7,14 @@ defmodule CodeCorps.UserRoleTest do
     user_id = insert(:user).id
     role_id = insert(:role).id
 
-    changeset = UserRole.changeset(%UserRole{}, %{user_id: user_id, role_id: role_id})
+    changeset = UserRole.create_changeset(%UserRole{}, %{user_id: user_id, role_id: role_id})
     assert changeset.valid?
   end
 
   test "changeset requires user_id" do
     role_id = insert(:role).id
 
-    changeset = UserRole.changeset(%UserRole{}, %{role_id: role_id})
+    changeset = UserRole.create_changeset(%UserRole{}, %{role_id: role_id})
 
     refute changeset.valid?
     assert changeset.errors[:user_id] == {"can't be blank", []}
@@ -23,7 +23,7 @@ defmodule CodeCorps.UserRoleTest do
   test "changeset requires role_id" do
     user_id = insert(:user).id
 
-    changeset = UserRole.changeset(%UserRole{}, %{user_id: user_id})
+    changeset = UserRole.create_changeset(%UserRole{}, %{user_id: user_id})
 
     refute changeset.valid?
     assert changeset.errors[:role_id] == {"can't be blank", []}
@@ -34,7 +34,7 @@ defmodule CodeCorps.UserRoleTest do
     role_id = insert(:role).id
 
     { result, changeset } =
-      UserRole.changeset(%UserRole{}, %{user_id: user_id, role_id: role_id})
+      UserRole.create_changeset(%UserRole{}, %{user_id: user_id, role_id: role_id})
       |> Repo.insert
 
     assert result == :error
@@ -47,7 +47,7 @@ defmodule CodeCorps.UserRoleTest do
     role_id = -1
 
     { result, changeset } =
-      UserRole.changeset(%UserRole{}, %{user_id: user_id, role_id: role_id})
+      UserRole.create_changeset(%UserRole{}, %{user_id: user_id, role_id: role_id})
       |> Repo.insert
 
     assert result == :error

--- a/test/models/user_skill_test.exs
+++ b/test/models/user_skill_test.exs
@@ -7,14 +7,14 @@ defmodule CodeCorps.UserSkillTest do
     user_id = insert(:user).id
     skill_id = insert(:skill).id
 
-    changeset = UserSkill.changeset(%UserSkill{}, %{user_id: user_id, skill_id: skill_id})
+    changeset = UserSkill.create_changeset(%UserSkill{}, %{user_id: user_id, skill_id: skill_id})
     assert changeset.valid?
   end
 
   test "changeset requires user_id" do
     skill_id = insert(:skill).id
 
-    changeset = UserSkill.changeset(%UserSkill{}, %{skill_id: skill_id})
+    changeset = UserSkill.create_changeset(%UserSkill{}, %{skill_id: skill_id})
 
     refute changeset.valid?
     assert changeset.errors[:user_id] == {"can't be blank", []}
@@ -23,7 +23,7 @@ defmodule CodeCorps.UserSkillTest do
   test "changeset requires skill_id" do
     user_id = insert(:user).id
 
-    changeset = UserSkill.changeset(%UserSkill{}, %{user_id: user_id})
+    changeset = UserSkill.create_changeset(%UserSkill{}, %{user_id: user_id})
 
     refute changeset.valid?
     assert changeset.errors[:skill_id] == {"can't be blank", []}
@@ -34,7 +34,7 @@ defmodule CodeCorps.UserSkillTest do
     skill_id = insert(:skill).id
 
     { result, changeset } =
-      UserSkill.changeset(%UserSkill{}, %{user_id: user_id, skill_id: skill_id})
+      UserSkill.create_changeset(%UserSkill{}, %{user_id: user_id, skill_id: skill_id})
       |> Repo.insert
 
     assert result == :error
@@ -47,7 +47,7 @@ defmodule CodeCorps.UserSkillTest do
     skill_id = -1
 
     { result, changeset } =
-      UserSkill.changeset(%UserSkill{}, %{user_id: user_id, skill_id: skill_id})
+      UserSkill.create_changeset(%UserSkill{}, %{user_id: user_id, skill_id: skill_id})
       |> Repo.insert
 
     assert result == :error

--- a/test/policies/organization_membership_policy_test.exs
+++ b/test/policies/organization_membership_policy_test.exs
@@ -1,0 +1,191 @@
+defmodule CodeCorps.OrganizationMembershipPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.OrganizationMembershipPolicy, only: [create?: 2, update?: 2, delete?: 2]
+  import CodeCorps.OrganizationMembership, only: [create_changeset: 2, update_changeset: 2]
+
+  alias CodeCorps.OrganizationMembership
+
+  describe "create" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      changeset = %OrganizationMembership{} |> create_changeset(%{})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns true when user is creating their own membership" do
+      user = insert(:user, admin: true)
+      changeset = %OrganizationMembership{} |> create_changeset(%{member_id: user.id})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns false for normal user, creating someone else's membership" do
+      user = build(:user, admin: true)
+      changeset = %OrganizationMembership{} |> create_changeset(%{member_id: "someone_else"})
+
+      assert create?(user, changeset) == true
+    end
+  end
+
+  describe "update" do
+    test "retuns true when user is site admin" do
+      user = build(:user, admin: true)
+      membership = build(:organization_membership)
+
+      changeset = membership |> update_changeset(%{})
+
+      assert update?(user, changeset) == true
+    end
+
+    test "returns false when user is non-member" do
+      user = insert(:user)
+      membership = insert(:organization_membership)
+
+      changeset = membership |> update_changeset(%{})
+
+      assert update?(user, changeset) == false
+    end
+
+    test "returns false when user is pending" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "pending", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization)
+
+      changeset = membership |> update_changeset(%{})
+
+      assert update?(user, changeset) == false
+    end
+
+    test "returns false when user is contributor" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "contributor", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization)
+
+      changeset = membership |> update_changeset(%{})
+
+      assert update?(user, changeset) == false
+    end
+
+    test "returns true when user is admin, approving a pending membership" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization, role: "pending")
+
+      changeset = membership |> update_changeset(%{role: "contributor"})
+
+      assert update?(user, changeset) == true
+    end
+
+    test "returns false when user is admin, doing something other than approving a pending membership" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization, role: "contributor")
+
+      changeset = membership |> update_changeset(%{})
+
+      assert update?(user, changeset) == false
+    end
+
+    test "returns true when user is owner and is changing a role other than owner" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization, role: "admin")
+
+      changeset = membership |> update_changeset(%{})
+
+      assert update?(user, changeset) == true
+    end
+
+    test "returns false when user is owner and is changing another owner" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization, role: "owner")
+
+      changeset = membership |> update_changeset(%{})
+
+      assert update?(user, changeset) == false
+    end
+  end
+
+  describe "delete" do
+    test "retuns true when user is site admin" do
+      user = build(:user, admin: true)
+      membership = build(:organization_membership)
+
+      assert delete?(user, membership) == true
+    end
+
+    test "returns true when contributor is deleting their own membership" do
+      user = insert(:user)
+      organization = insert(:organization)
+
+      membership = insert(:organization_membership, organization: organization, member: user, role: "contributor")
+
+      assert delete?(user, membership) == true
+    end
+
+    test "returns true when admin is deleting a pending membership" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization, role: "pending")
+
+      assert delete?(user, membership) == true
+    end
+
+    test "returns true when admin is deleting a contributor" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization, role: "contributor")
+
+      assert delete?(user, membership) == true
+    end
+
+    test "returns false when admin is deleting another admin" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization, role: "admin")
+
+      assert delete?(user, membership) == false
+    end
+
+    test "returns false when admin is deleting an owner" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization, role: "owner")
+
+      assert delete?(user, membership) == false
+    end
+
+    test "returns true when owner is deleting an admin" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      membership = insert(:organization_membership, organization: organization, role: "admin")
+
+      assert delete?(user, membership) == true
+    end
+  end
+end

--- a/test/policies/project_category_policy_test.exs
+++ b/test/policies/project_category_policy_test.exs
@@ -1,0 +1,132 @@
+defmodule CodeCorps.ProjectCategoryPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.ProjectCategoryPolicy, only: [create?: 2, delete?: 2]
+  import CodeCorps.ProjectCategory, only: [create_changeset: 2]
+
+  alias CodeCorps.ProjectCategory
+
+  describe "create?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      changeset = %ProjectCategory{} |> create_changeset(%{})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns false when user is not member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == false
+    end
+
+    test "returns false when user is pending member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "pending", member: user, organization: organization)
+
+      changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == false
+    end
+
+    test "returns false when user is contributor of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "contributor", member: user, organization: organization)
+
+      changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == false
+    end
+
+    test "returns true when user is admin of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == true
+    end
+
+    test "returns true when user is owner of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == true
+    end
+  end
+
+  describe "delete?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      project_category = insert(:project_category)
+
+      assert delete?(user, project_category) == true
+    end
+
+    test "returns false when user is not member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_category = insert(:project_category, project: project)
+
+      assert delete?(user, project_category) == false
+    end
+
+    test "returns false when user is pending member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_category = insert(:project_category, project: project)
+
+      insert(:organization_membership, role: "pending", member: user, organization: organization)
+
+      assert delete?(user, project_category) == false
+    end
+
+    test "returns false when user is contributor of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_category = insert(:project_category, project: project)
+
+      insert(:organization_membership, role: "contributor", member: user, organization: organization)
+
+      assert delete?(user, project_category) == false
+    end
+
+    test "returns true when user is admin of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_category = insert(:project_category, project: project)
+
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      assert delete?(user, project_category) == true
+    end
+
+    test "returns true when user is owner of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_category = insert(:project_category, project: project)
+
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      assert delete?(user, project_category) == true
+    end
+  end
+end

--- a/test/policies/project_policy_test.exs
+++ b/test/policies/project_policy_test.exs
@@ -1,0 +1,122 @@
+defmodule CodeCorps.ProjectPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.ProjectPolicy, only: [create?: 2, update?: 2]
+  import CodeCorps.Project, only: [create_changeset: 2]
+
+  alias CodeCorps.Project
+
+  describe "create" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      changeset = %Project{} |> create_changeset(%{})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns false when user is not member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+
+      changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
+      assert create?(user, changeset) == false
+    end
+
+    test "returns false when user is pending member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+
+      insert(:organization_membership, role: "pending", member: user, organization: organization)
+
+      changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
+      assert create?(user, changeset) == false
+    end
+
+    test "returns false when user is contributor of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+
+      insert(:organization_membership, role: "contributor", member: user, organization: organization)
+
+      changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
+      assert create?(user, changeset) == false
+    end
+
+    test "returns true when user is admin of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
+      assert create?(user, changeset) == true
+    end
+
+    test "returns true when user is owner of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
+      assert create?(user, changeset) == true
+    end
+  end
+
+  describe "update" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      project = build(:project)
+
+      assert update?(user, project) == true
+    end
+
+    test "returns false when user is not member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      assert update?(user, project) == false
+    end
+
+    test "returns false when user is pending member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "pending", member: user, organization: organization)
+
+      assert update?(user, project) == false
+    end
+
+    test "returns false when user is contributor of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "contributor", member: user, organization: organization)
+
+      assert update?(user, project) == false
+    end
+
+    test "returns true when user is admin of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      assert update?(user, project) == true
+    end
+
+    test "returns true when user is owner of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      assert update?(user, project) == true
+    end
+  end
+end

--- a/test/policies/project_skill_policy_test.exs
+++ b/test/policies/project_skill_policy_test.exs
@@ -1,0 +1,132 @@
+defmodule CodeCorps.ProjectSkillPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.ProjectSkillPolicy, only: [create?: 2, delete?: 2]
+  import CodeCorps.ProjectSkill, only: [create_changeset: 2]
+
+  alias CodeCorps.ProjectSkill
+
+  describe "create?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      changeset = %ProjectSkill{} |> create_changeset(%{})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns false when user is not member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == false
+    end
+
+    test "returns false when user is pending member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "pending", member: user, organization: organization)
+
+      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == false
+    end
+
+    test "returns false when user is contributor of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "contributor", member: user, organization: organization)
+
+      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == false
+    end
+
+    test "returns true when user is admin of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == true
+    end
+
+    test "returns true when user is owner of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset) == true
+    end
+  end
+
+  describe "delete?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      project_skill = insert(:project_skill)
+
+      assert delete?(user, project_skill) == true
+    end
+
+    test "returns false when user is not member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_skill = insert(:project_skill, project: project)
+
+      assert delete?(user, project_skill) == false
+    end
+
+    test "returns false when user is pending member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_skill = insert(:project_skill, project: project)
+
+      insert(:organization_membership, role: "pending", member: user, organization: organization)
+
+      assert delete?(user, project_skill) == false
+    end
+
+    test "returns false when user is contributor of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_skill = insert(:project_skill, project: project)
+
+      insert(:organization_membership, role: "contributor", member: user, organization: organization)
+
+      assert delete?(user, project_skill) == false
+    end
+
+    test "returns true when user is admin of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_skill = insert(:project_skill, project: project)
+
+      insert(:organization_membership, role: "admin", member: user, organization: organization)
+
+      assert delete?(user, project_skill) == true
+    end
+
+    test "returns true when user is owner of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+      project_skill = insert(:project_skill, project: project)
+
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      assert delete?(user, project_skill) == true
+    end
+  end
+end

--- a/test/policies/task_policy_test.exs
+++ b/test/policies/task_policy_test.exs
@@ -1,0 +1,69 @@
+defmodule CodeCorps.TaskPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.TaskPolicy, only: [create?: 2, update?: 2]
+  import CodeCorps.Task, only: [create_changeset: 2]
+
+  alias CodeCorps.Task
+
+  describe "create" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      changeset = %Task{} |> create_changeset(%{})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns false when user is not the author" do
+      user = build(:user)
+      changeset = %Task{} |> create_changeset(%{task_type: "issue", user_id: "other"})
+
+      assert create?(user, changeset) == false
+    end
+
+    test "returns true when task is an issue" do
+      user = insert(:user)
+      changeset = %Task{} |> create_changeset(%{task_type: "issue", user_id: user.id})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns true when task is an idea" do
+      user = insert(:user)
+      changeset = %Task{} |> create_changeset(%{task_type: "idea", user_id: user.id})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns true when user is at least contributor of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      insert(:organization_membership, role: "contributor", member: user, organization: organization)
+
+      changeset = %Task{} |> create_changeset(%{project_id: project.id, task_type: "task", user_id: user.id})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns false when user is not contributor and type is 'task'" do
+      user = insert(:user)
+      organization = insert(:organization)
+      project = insert(:project, organization: organization)
+
+      changeset = %Task{} |> create_changeset(%{project_id: project.id, task_type: "task", user_id: user.id})
+
+      assert create?(user, changeset) == false
+    end
+  end
+
+  describe "update" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      task = build(:task)
+
+      assert update?(user, task) == true
+    end
+  end
+end

--- a/test/policies/user_category_policy_test.exs
+++ b/test/policies/user_category_policy_test.exs
@@ -1,0 +1,54 @@
+defmodule CodeCorps.UserCategoryPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.UserCategoryPolicy, only: [create?: 2, delete?: 2]
+  import CodeCorps.UserCategory, only: [create_changeset: 2]
+
+  alias CodeCorps.UserCategory
+
+  describe "create?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      changeset = %UserCategory{} |> create_changeset(%{})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns true if user is creating their own record" do
+      user = insert(:user)
+      changeset = %UserCategory{} |> create_changeset(%{user_id: user.id})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns false if user is creating someone else's record" do
+      user = build(:user)
+      changeset = %UserCategory{} |> create_changeset(%{user_id: "someone-else"})
+
+      assert create?(user, changeset) == false
+    end
+  end
+
+  describe "delete?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      user_category = insert(:user_category)
+
+      assert delete?(user, user_category) == true
+    end
+
+    test "returns true if user is creating their own record" do
+      user = insert(:user)
+      user_category = insert(:user_category, user: user)
+
+      assert delete?(user, user_category) == true
+    end
+
+    test "returns false if user is creating someone else's record" do
+      user = build(:user)
+      user_category = insert(:user_category)
+
+      assert delete?(user, user_category) == false
+    end
+  end
+end

--- a/test/policies/user_role_policy_test.exs
+++ b/test/policies/user_role_policy_test.exs
@@ -1,0 +1,54 @@
+defmodule CodeCorps.UserRolePolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.UserRolePolicy, only: [create?: 2, delete?: 2]
+  import CodeCorps.UserRole, only: [create_changeset: 2]
+
+  alias CodeCorps.UserRole
+
+  describe "create?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      changeset = %UserRole{} |> create_changeset(%{})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns true if user is creating their own record" do
+      user = insert(:user)
+      changeset = %UserRole{} |> create_changeset(%{user_id: user.id})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns false if user is creating someone else's record" do
+      user = build(:user)
+      changeset = %UserRole{} |> create_changeset(%{user_id: "someone-else"})
+
+      assert create?(user, changeset) == false
+    end
+  end
+
+  describe "delete?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      user_role = insert(:user_role)
+
+      assert delete?(user, user_role) == true
+    end
+
+    test "returns true if user is creating their own record" do
+      user = insert(:user)
+      user_role = insert(:user_role, user: user)
+
+      assert delete?(user, user_role) == true
+    end
+
+    test "returns false if user is creating someone else's record" do
+      user = build(:user)
+      user_role = insert(:user_role)
+
+      assert delete?(user, user_role) == false
+    end
+  end
+end

--- a/test/policies/user_skill_policy_test.exs
+++ b/test/policies/user_skill_policy_test.exs
@@ -1,0 +1,54 @@
+defmodule CodeCorps.UserSkillPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.UserSkillPolicy, only: [create?: 2, delete?: 2]
+  import CodeCorps.UserSkill, only: [create_changeset: 2]
+
+  alias CodeCorps.UserSkill
+
+  describe "create?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      changeset = %UserSkill{} |> create_changeset(%{})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns true if user is creating their own record" do
+      user = insert(:user)
+      changeset = %UserSkill{} |> create_changeset(%{user_id: user.id})
+
+      assert create?(user, changeset) == true
+    end
+
+    test "returns false if user is creating someone else's record" do
+      user = build(:user)
+      changeset = %UserSkill{} |> create_changeset(%{user_id: "someone-else"})
+
+      assert create?(user, changeset) == false
+    end
+  end
+
+  describe "delete?" do
+    test "retuns true when user is an admin" do
+      user = build(:user, admin: true)
+      user_skill = insert(:user_skill)
+
+      assert delete?(user, user_skill) == true
+    end
+
+    test "returns true if user is creating their own record" do
+      user = insert(:user)
+      user_skill = insert(:user_skill, user: user)
+
+      assert delete?(user, user_skill) == true
+    end
+
+    test "returns false if user is creating someone else's record" do
+      user = build(:user)
+      user_skill = insert(:user_skill)
+
+      assert delete?(user, user_skill) == false
+    end
+  end
+end

--- a/test/support/policy_case.ex
+++ b/test/support/policy_case.ex
@@ -1,0 +1,33 @@
+defmodule CodeCorps.PolicyCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  policy tests.
+
+  You may define functions here to be used as helpers in
+  your model tests. See `errors_on/2`'s definition as reference.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import CodeCorps.Factories
+      import CodeCorps.PolicyCase
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(CodeCorps.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(CodeCorps.Repo, {:shared, self()})
+    end
+
+    :ok
+  end
+end

--- a/web/controllers/category_controller.ex
+++ b/web/controllers/category_controller.ex
@@ -28,11 +28,11 @@ defmodule CodeCorps.CategoryController do
     end
   end
 
-  def show(conn, %{"id" => id}) do
+  def show(conn, %{"id" => _id}) do
     render(conn, "show.json-api", data: conn.assigns.category)
   end
 
-  def update(conn, %{"id" => id, "data" => data = %{"type" => "category", "attributes" => _category_params}}) do
+  def update(conn, %{"id" => _id, "data" => data = %{"type" => "category", "attributes" => _category_params}}) do
     changeset = conn.assigns.category |> Category.changeset(Params.to_attributes(data))
 
     case Repo.update(changeset) do

--- a/web/controllers/task_controller.ex
+++ b/web/controllers/task_controller.ex
@@ -6,7 +6,8 @@ defmodule CodeCorps.TaskController do
   alias CodeCorps.Task
   alias JaSerializer.Params
 
-  plug :load_and_authorize_resource, model: Task, only: [:create, :update]
+  plug :load_and_authorize_changeset, model: Task, only: [:create]
+  plug :load_and_authorize_resource, model: Task, only: [:update]
   plug :scrub_params, "data" when action in [:create, :update]
 
   def index(conn, params) do

--- a/web/controllers/user_role_controller.ex
+++ b/web/controllers/user_role_controller.ex
@@ -3,11 +3,10 @@ defmodule CodeCorps.UserRoleController do
 
   use CodeCorps.Web, :controller
 
-  import CodeCorps.AuthenticationHelpers, only: [authorize: 2, authorized?: 1]
-
   alias CodeCorps.UserRole
-  alias JaSerializer.Params
 
+  plug :load_resource, model: UserRole, only: [:show], preload: [:user, :role]
+  plug :load_and_authorize_changeset, model: UserRole, only: [:create]
   plug :load_and_authorize_resource, model: UserRole, only: [:delete]
 
   def index(conn, params) do
@@ -19,43 +18,29 @@ defmodule CodeCorps.UserRoleController do
     render(conn, "index.json-api", data: user_roles)
   end
 
-  def create(conn, %{"data" => data = %{"type" => "user-role"}}) do
-    changeset = UserRole.changeset(%UserRole{}, Params.to_attributes(data))
-
-    conn = conn |> authorize(changeset)
-
-    if conn |> authorized? do
-      case Repo.insert(changeset) do
-        {:ok, user_role} ->
-          conn
-          |> @analytics.track(:added, user_role)
-          |> put_status(:created)
-          |> render("show.json-api", data: user_role)
-        {:error, changeset} ->
-          conn
-          |> put_status(:unprocessable_entity)
-          |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
-      end
-    else
-      conn
+  def create(conn, %{"data" => %{"type" => "user-role"}}) do
+    case Repo.insert(conn.assigns.changeset) do
+      {:ok, user_role} ->
+        conn
+        |> @analytics.track(:added, user_role)
+        |> put_status(:created)
+        |> render("show.json-api", data: user_role)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(CodeCorps.ChangesetView, "error.json-api", changeset: changeset)
     end
   end
 
-  def show(conn, %{"id" => id}) do
-    user_role =
-      UserRole
-      |> Repo.get!(id)
-    render(conn, "show.json-api", data: user_role)
+  def show(conn, %{"id" => _id}) do
+    render(conn, "show.json-api", data: conn.assigns.user_role)
   end
 
-  def delete(conn, %{"id" => id}) do
-    user_role =
-      UserRole
-      |> Repo.get!(id)
-      |> Repo.delete!
+  def delete(conn, %{"id" => _id}) do
+    conn.assigns.user_role |> Repo.delete!
 
     conn
-    |> @analytics.track(:removed, user_role)
+    |> @analytics.track(:removed, conn.assigns.user_role)
     |> send_resp(:no_content, "")
   end
 end

--- a/web/helpers/authentication_helpers.ex
+++ b/web/helpers/authentication_helpers.ex
@@ -1,8 +1,14 @@
 defmodule CodeCorps.AuthenticationHelpers do
   use Phoenix.Controller
+
+  import Canary.Plugs, only: [load_resource: 2]
+  import Canada.Can, only: [can?: 3]
   import Plug.Conn, only: [halt: 1, put_status: 2, assign: 3]
 
-  def handle_unauthorized(conn) do
+  alias JaSerializer.Params
+
+  def handle_unauthorized(conn = %{assigns: %{authorized: true}}), do: conn
+  def handle_unauthorized(conn = %{assigns: %{authorized: false}}) do
     conn
     |> put_status(401)
     |> render(CodeCorps.TokenView, "error.json", message: "Not authorized")
@@ -16,11 +22,44 @@ defmodule CodeCorps.AuthenticationHelpers do
     |> halt
   end
 
-  def authorize(conn, changeset) do
-    conn
-    |> assign(:changeset, changeset)
-    |> Canary.Plugs.authorize_resource(model: changeset)
+  # Used to authorize a resource we provide on our own
+  # We need this to authorize based on changeset, since on some
+  # records, some types of changes are valid while others are not
+  # This is partially adjusted code, taken from canary
+  def load_and_authorize_changeset(conn, options) do
+    action = conn.private.phoenix_action
+
+    cond do
+      action in options[:only] -> conn |> load_resource(options) |> do_init_and_authorize_changeset(options[:model], action)
+      true -> conn
+    end
   end
 
-  def authorized?(conn), do: conn |> Map.get(:assigns) |> Map.get(:authorized)
+  defp do_init_and_authorize_changeset(conn, model, action) do
+    changeset = init_changeset(conn, model, action)
+    conn |> assign(:changeset, changeset) |> authorize(changeset, action)
+  end
+
+  defp init_changeset(conn, model, action) do
+    params = Params.to_attributes(conn.params["data"])
+    resource = get_resource(conn, model, action)
+    changeset_method = get_changeset_method(action)
+
+    do_init_changeset(model, changeset_method, [resource, params])
+  end
+  defp do_init_changeset(_model, _method, [nil, _]), do: nil
+  defp do_init_changeset(model, method, params), do: apply(model, method, params)
+
+  defp get_resource(conn, model, :update) do
+    resource_name = model |> Module.split |> List.last |> Macro.underscore |> String.to_atom
+    conn.assigns |> Map.get(resource_name)
+  end
+  defp get_resource(_conn, model, :create), do: model.__struct__
+
+  defp get_changeset_method(action), do: "#{action}_changeset" |> String.to_atom
+
+  def authorize(conn, changeset, action) do
+    current_user = conn.assigns |> Map.get(:current_user)
+    conn |> assign(:authorized, can?(current_user, action, changeset)) |> handle_unauthorized
+  end
 end

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -33,6 +33,8 @@ defmodule Canary.Abilities do
   alias CodeCorps.UserRolePolicy
   alias CodeCorps.UserSkillPolicy
 
+  alias Ecto.Changeset
+
   defimpl Canada.Can, for: User do
     # NOTE: Canary sets an :unauthorized and a :not_found handler on a config level
     # The problem is, it will still go through the authorization process first and only call the
@@ -54,23 +56,23 @@ defmodule Canary.Abilities do
     def can?(%User{} = user, :create, Organization), do: OrganizationPolicy.create?(user)
     def can?(%User{} = user, :update, %Organization{} = organization), do: OrganizationPolicy.update?(user, organization)
 
-    def can?(%User{} = user, :create, OrganizationMembership), do: OrganizationMembershipPolicy.create?(user)
-    def can?(%User{} = user, :update, %OrganizationMembership{} = membership), do: OrganizationMembershipPolicy.update?(user, membership)
+    def can?(%User{} = user, :create, %Changeset{data: %OrganizationMembership{}} = changeset), do: OrganizationMembershipPolicy.create?(user, changeset)
+    def can?(%User{} = user, :update, %Changeset{data: %OrganizationMembership{}} = changeset), do: OrganizationMembershipPolicy.update?(user, changeset)
     def can?(%User{} = user, :delete, %OrganizationMembership{} = membership), do: OrganizationMembershipPolicy.delete?(user, membership)
 
-    def can?(%User{} = user, :create, Task), do: TaskPolicy.create?(user)
+    def can?(%User{} = user, :create, %Changeset{data: %Task{}} = changeset), do: TaskPolicy.create?(user, changeset)
     def can?(%User{} = user, :update, %Task{} = task), do: TaskPolicy.update?(user, task)
 
     def can?(%User{} = user, :create, Preview), do: PreviewPolicy.create?(user)
 
-    def can?(%User{} = user, :create, Project), do: ProjectPolicy.create?(user)
+    def can?(%User{} = user, :create, %Changeset{data: %Project{}} = changeset), do: ProjectPolicy.create?(user, changeset)
     def can?(%User{} = user, :update, %Project{} = project), do: ProjectPolicy.update?(user, project)
 
-    def can?(%User{} = user, :create, ProjectCategory), do: ProjectCategoryPolicy.create?(user)
-    def can?(%User{} = user, :delete, %ProjectCategory{}), do: ProjectCategoryPolicy.delete?(user)
+    def can?(%User{} = user, :create, %Changeset{data: %ProjectCategory{}} = changeset), do: ProjectCategoryPolicy.create?(user, changeset)
+    def can?(%User{} = user, :delete, %ProjectCategory{} = project_category), do: ProjectCategoryPolicy.delete?(user, project_category)
 
-    def can?(%User{} = user, :create, ProjectSkill), do: ProjectSkillPolicy.create?(user)
-    def can?(%User{} = user, :delete, %ProjectSkill{}), do: ProjectSkillPolicy.delete?(user)
+    def can?(%User{} = user, :create, %Changeset{data: %ProjectSkill{}} = changeset), do: ProjectSkillPolicy.create?(user, changeset)
+    def can?(%User{} = user, :delete, %ProjectSkill{} = project_skill), do: ProjectSkillPolicy.delete?(user, project_skill)
 
     def can?(%User{} = user, :create, Role), do: RolePolicy.create?(user)
 
@@ -79,13 +81,13 @@ defmodule Canary.Abilities do
 
     def can?(%User{} = user, :create, Skill), do: SkillPolicy.create?(user)
 
-    def can?(%User{} = user, :create, %Ecto.Changeset{data: %CodeCorps.UserCategory{}} = changeset), do: UserCategoryPolicy.create?(user, changeset)
+    def can?(%User{} = user, :create, %Changeset{data: %UserCategory{}} = changeset), do: UserCategoryPolicy.create?(user, changeset)
     def can?(%User{} = user, :delete, %UserCategory{} = user_category), do: UserCategoryPolicy.delete?(user, user_category)
 
-    def can?(%User{} = user, :create, %Ecto.Changeset{data: %CodeCorps.UserRole{}} = changeset), do: UserRolePolicy.create?(user, changeset)
+    def can?(%User{} = user, :create, %Changeset{data: %UserRole{}} = changeset), do: UserRolePolicy.create?(user, changeset)
     def can?(%User{} = user, :delete, %UserRole{} = user_role), do: UserRolePolicy.delete?(user, user_role)
 
-    def can?(%User{} = user, :create, %Ecto.Changeset{data: %CodeCorps.UserSkill{}} = changeset), do: UserSkillPolicy.create?(user, changeset)
+    def can?(%User{} = user, :create, %Changeset{data: %UserSkill{}} = changeset), do: UserSkillPolicy.create?(user, changeset)
     def can?(%User{} = user, :delete, %UserSkill{} = user_skill), do: UserSkillPolicy.delete?(user, user_skill)
   end
 end

--- a/web/models/organization_membership.ex
+++ b/web/models/organization_membership.ex
@@ -18,6 +18,7 @@ defmodule CodeCorps.OrganizationMembership do
 
   @doc """
   Builds a changeset based on the `struct` and `params`, for creating a record.
+  The membership role is strictly set to "pending" by the system, regardless of parameters
   """
   def create_changeset(struct, params \\ %{}) do
     struct

--- a/web/models/project_skill.ex
+++ b/web/models/project_skill.ex
@@ -11,7 +11,7 @@ defmodule CodeCorps.ProjectSkill do
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
-  def changeset(struct, params \\ %{}) do
+  def create_changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:project_id, :skill_id])
     |> validate_required([:project_id, :skill_id])

--- a/web/models/user_category.ex
+++ b/web/models/user_category.ex
@@ -13,7 +13,7 @@ defmodule CodeCorps.UserCategory do
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
-  def changeset(struct, params \\ %{}) do
+  def create_changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:user_id, :category_id])
     |> validate_required([:user_id, :category_id])

--- a/web/models/user_role.ex
+++ b/web/models/user_role.ex
@@ -13,7 +13,7 @@ defmodule CodeCorps.UserRole do
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
-  def changeset(struct, params \\ %{}) do
+  def create_changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:user_id, :role_id])
     |> validate_required([:user_id, :role_id])

--- a/web/models/user_skill.ex
+++ b/web/models/user_skill.ex
@@ -13,7 +13,7 @@ defmodule CodeCorps.UserSkill do
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
-  def changeset(struct, params \\ %{}) do
+  def create_changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:user_id, :skill_id])
     |> validate_required([:user_id, :skill_id])

--- a/web/policies/organization_membership_policy.ex
+++ b/web/policies/organization_membership_policy.ex
@@ -1,61 +1,65 @@
 defmodule CodeCorps.OrganizationMembershipPolicy do
-  alias CodeCorps.User
   alias CodeCorps.Organization
   alias CodeCorps.OrganizationMembership
-
   alias CodeCorps.Repo
+  alias CodeCorps.User
+  alias Ecto.Changeset
 
   import Ecto.Query
 
-  # TODO: Make it so validation handles the fact that membership role needs to be "pending" on create
-  def create?(%User{} = _user), do: true
+  def create?(%User{admin: true}, %Changeset{}), do: true
+  def create?(%User{id: user_id}, %Changeset{changes: %{member_id: member_id}}), do:  user_id == member_id
+  def create?(%User{}, %Changeset{}), do: false
 
-  def update?(%User{} = user, %OrganizationMembership{} = current_membership) do
-    current_organization = current_membership |> fetch_organization
-    user_membership = user |> fetch_membership(current_organization)
 
-    permitted? = case user_membership do
-      # owner can update any membership
-      %OrganizationMembership{role: "owner"} -> true
-      # admin can only update lower level roles
-      %OrganizationMembership{role: "admin"} -> current_membership.role in ["pending", "contributor"]
-      # all other members, or non-members, are not permitted
-      _ -> false
+  def update?(%User{admin: true}, %Changeset{}), do: true
+  def update?(%User{} = user, %Changeset{data: %OrganizationMembership{} = current_membership} = changeset) do
+    user_membership = current_membership |> get_user_membership(user)
+
+    user_role = user_membership |> get_role
+    old_role = current_membership |> get_role
+    new_role = changeset |> get_role
+
+    case [user_role, old_role, new_role] do
+      # Non-member, pending and contributors can't do anything
+      [nil, _, _] -> false
+      ["pending", _, _] -> false
+      ["contributor", _, _] -> false
+      # Admins can only approve pending memberships and nothing else
+      ["admin", "pending", "contributor"] -> true
+      ["admin", _, _] -> false
+      # Owners can do everything expect changing other owners
+      ["owner", "owner", _] -> false
+      ["owner", _, _] -> true
+      # No other role change is allowed
+      [_, _, _] -> false
     end
-
-    permitted?
   end
 
-  # user can always leave the organization on their own
+  def delete?(%User{admin: true}, %OrganizationMembership{}), do: true
   def delete?(%User{} = user, %OrganizationMembership{} = current_membership) do
-    user_membership = cond do
-      user.id == current_membership.member_id ->
-        current_membership
-      true ->
-        organization = current_membership |> fetch_organization
-        user |> fetch_membership(organization)
-    end
-
-    permitted? = case user_membership do
-      # owner can delete any membership
-      %OrganizationMembership{role: "owner"} -> true
-      # admin can only delete lower level roles
-      %OrganizationMembership{role: "admin"} -> user_membership.role in ["pending", "contributor"]
-      # all other members, or non-members, are not permitted
-      _ -> false
-    end
-
-    permitted?
+    current_membership |> get_user_membership(user) |> do_delete?(current_membership)
   end
 
-  defp fetch_organization(membership) do
-    Organization
-    |> Repo.get(membership.organization_id)
-  end
-  defp fetch_membership(_user, nil), do: nil
-  defp fetch_membership(user, organization) do
+  defp do_delete?(%OrganizationMembership{} = user_m, %OrganizationMembership{} = current_m) when user_m == current_m, do: true
+  defp do_delete?(%OrganizationMembership{role: "owner"}, %OrganizationMembership{}), do: true
+  defp do_delete?(%OrganizationMembership{role: "admin"}, %OrganizationMembership{role: role}) when role in ~w(pending contributor), do: true
+  defp do_delete?(_, _), do: false
+
+  defp get_user_membership(%OrganizationMembership{member_id: nil}, %User{id: nil}), do: nil
+  defp get_user_membership(%OrganizationMembership{member_id: m_id} = membership, %User{id: u_id}) when m_id == u_id, do: membership
+  defp get_user_membership(%OrganizationMembership{} = membership, %User{} = user), do: membership |> get_organization |> get_membership(user)
+
+  defp get_organization(%OrganizationMembership{organization_id: organization_id}), do: Organization |> Repo.get(organization_id)
+
+  defp get_membership(nil, %User{}), do: nil
+  defp get_membership(%Organization{id: organization_id}, %User{id: user_id}) do
     OrganizationMembership
-    |> where([m], m.member_id == ^user.id and m.organization_id == ^organization.id)
+    |> where([m], m.member_id == ^user_id and m.organization_id == ^organization_id)
     |> Repo.one
   end
+
+  defp get_role(nil), do: nil
+  defp get_role(%OrganizationMembership{role: role} ), do: role
+  defp get_role(%Changeset{} = changeset), do: changeset |> Changeset.get_field(:role)
 end

--- a/web/policies/project_category_policy.ex
+++ b/web/policies/project_category_policy.ex
@@ -1,34 +1,35 @@
 defmodule CodeCorps.ProjectCategoryPolicy do
   alias CodeCorps.OrganizationMembership
+  alias CodeCorps.Project
   alias CodeCorps.ProjectCategory
-  alias CodeCorps.User
-
   alias CodeCorps.Repo
+  alias CodeCorps.User
+  alias Ecto.Changeset
 
   import Ecto.Query
 
-  # TODO: Need to figure out how to pass in params. We need to know
-  # if user is at least admin in organization, before they can assign
-  # a category to a project. Same goes for delete
-  def create?(%User{admin: true} = _user), do: true
-  def create?(%User{} = _user), do: false
-  def create?(%User{} = user, %ProjectCategory{} = project_category), do: user |> is_admin_or_higher(project_category)
-
-  def delete?(%User{admin: true} = _user), do: true
-  def delete?(%User{} = _user), do: false
-  def delete?(%User{} = user, %ProjectCategory{} = project_category), do: user |> is_admin_or_higher(project_category)
-
-  defp is_admin_or_higher(%User{} = user, %ProjectCategory{} = project_category) do
-    project = Project |> Repo.get(project_category.project_id)
-
-    membership =
-      OrganizationMembership
-      |> where([m], m.member_id == ^user.id and m.organization_id == ^project.organization_id)
-      |> Repo.one
-
-    membership |> is_admin_or_higher
+  def create?(%User{admin: true}, %Changeset{}), do: true
+  def create?(%User{} = user, %Changeset{} = changeset) do
+    changeset |> get_project |> get_membership(user) |> get_role |> admin_or_higher
   end
 
-  defp is_admin_or_higher(nil), do: false
-  defp is_admin_or_higher(%OrganizationMembership{} = membership), do: membership.role in ["admin", "owner"]
+  def delete?(%User{admin: true}, %ProjectCategory{}), do: true
+  def delete?(%User{} = user, %ProjectCategory{} = project_category) do
+    project_category |> get_project |> get_membership(user) |> get_role |> admin_or_higher
+  end
+
+  defp get_project(%ProjectCategory{project_id: project_id}), do: Project |> Repo.get(project_id)
+  defp get_project(%Changeset{changes: %{project_id: project_id}}), do: Project |> Repo.get(project_id)
+
+  defp get_membership(%Project{organization_id: organization_id}, %User{id: user_id}) do
+    OrganizationMembership
+    |> where([m], m.member_id == ^user_id and m.organization_id == ^organization_id)
+    |> Repo.one
+  end
+
+  defp get_role(nil), do: nil
+  defp get_role(%OrganizationMembership{role: role}), do: role
+
+  defp admin_or_higher(nil), do: false
+  defp admin_or_higher(role), do: role in ["admin", "owner"]
 end

--- a/web/policies/project_policy.ex
+++ b/web/policies/project_policy.ex
@@ -2,27 +2,35 @@ defmodule CodeCorps.ProjectPolicy do
   alias CodeCorps.OrganizationMembership
   alias CodeCorps.Project
   alias CodeCorps.User
-
   alias CodeCorps.Repo
+  alias Ecto.Changeset
 
   import Ecto.Query
 
   # TODO: ProjectPolicy needs testing for the case of user being at least admin
   # in project organization
 
-  def create?(%User{admin: true}), do: true
-  def create?(%User{}), do: false
-  def create?(%User{} = user, %Project{} = project), do: user |> fetch_membership(project) |> is_admin_or_higher
+  def create?(%User{admin: true}, %Changeset{}), do: true
+  def create?(%User{} = user, %Changeset{} = changeset), do: changeset |> get_membership(user) |> get_role |> admin_or_higher
 
   def update?(%User{admin: true}, %Project{}), do: true
-  def update?(%User{} = user, %Project{} = project), do: user |> fetch_membership(project) |> is_admin_or_higher
+  def update?(%User{} = user, %Project{} = project), do: project |> get_membership(user) |> get_role |> admin_or_higher
 
-  defp fetch_membership(%User{} = user, %Project{} = project) do
+  defp get_membership(%Changeset{changes: %{organization_id: organization_id}}, %User{id: user_id}) do
     OrganizationMembership
-    |> where([m], m.member_id == ^user.id and m.organization_id == ^project.organization_id)
+    |> where([m], m.member_id == ^user_id and m.organization_id == ^organization_id)
     |> Repo.one
   end
 
-  defp is_admin_or_higher(nil), do: false
-  defp is_admin_or_higher(%OrganizationMembership{} = membership), do: membership.role in ["admin", "owner"]
+  defp get_membership(%Project{organization_id: organization_id}, %User{id: user_id}) do
+    OrganizationMembership
+    |> where([m], m.member_id == ^user_id and m.organization_id == ^organization_id)
+    |> Repo.one
+  end
+
+  defp get_role(nil), do: nil
+  defp get_role(%OrganizationMembership{role: role}), do: role
+
+  defp admin_or_higher(nil), do: false
+  defp admin_or_higher(role), do: role in ["admin", "owner"]
 end

--- a/web/policies/task_policy.ex
+++ b/web/policies/task_policy.ex
@@ -1,7 +1,7 @@
 defmodule CodeCorps.TaskPolicy do
   alias CodeCorps.OrganizationMembership
-  alias CodeCorps.Task
   alias CodeCorps.Project
+  alias CodeCorps.Task
   alias CodeCorps.User
 
   alias CodeCorps.Repo
@@ -11,31 +11,47 @@ defmodule CodeCorps.TaskPolicy do
   # TODO: Need to be able to see what resource is being created here
   # Previously, any user could create issues and ideas, but only
   # approved members of organization could create other task types
-  def create?(%User{} = _user), do: true
-
-  def update?(%User{} = user, %Task{} = task) do
-    permitted? = cond do
-      # author can update own task
-      user.id == task.user_id -> true
+  def create?(%User{admin: true}, %Ecto.Changeset{}), do: true
+  def create?(%User{} = user, %Ecto.Changeset{changes: %{user_id: author_id, task_type: task_type}} = changeset) do
+    cond do
+      # can't create for some other user
+      user.id != author_id -> false
+      # any registered user can create ideas or issues
+      task_type in ["idea", "issue"] -> true
       # organization admin or higher can update other people's tasks
-      user |> is_admin_or_higher(task) -> true
+      changeset |> get_project |> get_membership(user) |> get_role |> contributor_or_higher -> true
       # do not permit for any other case
       true -> false
     end
+  end
+  def create?(%User{}, %Ecto.Changeset{}), do: false
 
-    permitted?
+  def update?(%User{} = user, %Task{user_id: author_id} = task) do
+    cond do
+      # author can update own task
+      user.id == author_id -> true
+      # organization admin or higher can update other people's tasks
+      task |> get_project |> get_membership(user) |> get_role |> admin_or_higher -> true
+      # do not permit for any other case
+      true -> false
+    end
   end
 
-  defp is_admin_or_higher(%User{} = user, %Task{} = task) do
-    project = Project |> Repo.get(task.project_id)
-    membership =
-      OrganizationMembership
-      |> where([m], m.member_id == ^user.id and m.organization_id == ^project.organization_id)
-      |> Repo.one
+  defp get_project(%Ecto.Changeset{changes: %{project_id: project_id}}), do: Project |> Repo.get(project_id)
+  defp get_project(%Task{project_id: project_id}), do: Project |> Repo.get(project_id)
 
-    membership |> is_admin_or_higher
+  defp get_membership(%Project{organization_id: organization_id}, %User{id: user_id}) do
+    OrganizationMembership
+    |> where([m], m.member_id == ^user_id and m.organization_id == ^organization_id)
+    |> Repo.one
   end
 
-  defp is_admin_or_higher(nil), do: false
-  defp is_admin_or_higher(%OrganizationMembership{} = membership), do: membership.role in ["admin", "owner"]
+  defp get_role(nil), do: nil
+  defp get_role(%OrganizationMembership{role: role}), do: role
+
+  defp contributor_or_higher(role) when role in ["contributor", "admin", "owner"], do: true
+  defp contributor_or_higher(_), do: false
+
+  defp admin_or_higher(role) when role in ["admin", "owner"], do: true
+  defp admin_or_higher(_), do: false
 end

--- a/web/policies/user_category_policy.ex
+++ b/web/policies/user_category_policy.ex
@@ -1,12 +1,13 @@
 defmodule CodeCorps.UserCategoryPolicy do
   alias CodeCorps.UserCategory
   alias CodeCorps.User
+  alias Ecto.Changeset
 
-  def create?(%User{admin: true}, %Ecto.Changeset{}), do: true
-  def create?(%User{} = user, %Ecto.Changeset{} = changeset) do
-    user.id == changeset |> Ecto.Changeset.get_change(:user_id)
-  end
+  def create?(%User{admin: true}, %Changeset{}), do: true
+  def create?(%User{id: id}, %Changeset{changes: %{user_id: user_id}}), do: id == user_id
+  def create?(%User{}, %Changeset{}), do: false
 
   def delete?(%User{admin: true}, %UserCategory{}), do: true
-  def delete?(%User{} = user, %UserCategory{} = user_category), do: user.id == user_category.user_id
+  def delete?(%User{id: id}, %UserCategory{user_id: user_id}), do: id == user_id
+  def delete?(%User{}, %UserCategory{}), do: false
 end

--- a/web/policies/user_role_policy.ex
+++ b/web/policies/user_role_policy.ex
@@ -1,12 +1,13 @@
 defmodule CodeCorps.UserRolePolicy do
   alias CodeCorps.UserRole
   alias CodeCorps.User
+  alias Ecto.Changeset
 
-  def create?(%User{admin: true}, %Ecto.Changeset{}), do: true
-  def create?(%User{} = user, %Ecto.Changeset{} = changeset) do
-    user.id == changeset |> Ecto.Changeset.get_change(:user_id)
-  end
+  def create?(%User{admin: true}, %Changeset{}), do: true
+  def create?(%User{id: id}, %Changeset{changes: %{user_id: user_id}}), do: id == user_id
+  def create?(%User{}, %Changeset{}), do: false
 
   def delete?(%User{admin: true}, %UserRole{}), do: true
-  def delete?(%User{} = user, %UserRole{} = user_role), do: user.id == user_role.user_id
+  def delete?(%User{id: id}, %UserRole{user_id: user_id}), do: id == user_id
+  def delete?(%User{}, %UserRole{}), do: false
 end

--- a/web/policies/user_skill_policy.ex
+++ b/web/policies/user_skill_policy.ex
@@ -1,12 +1,13 @@
 defmodule CodeCorps.UserSkillPolicy do
   alias CodeCorps.UserSkill
   alias CodeCorps.User
+  alias Ecto.Changeset
 
-  def create?(%User{admin: true}, %Ecto.Changeset{}), do: true
-  def create?(%User{} = user, %Ecto.Changeset{} = changeset) do
-    user.id == changeset |> Ecto.Changeset.get_change(:user_id)
-  end
+  def create?(%User{admin: true}, %Changeset{}), do: true
+  def create?(%User{id: id}, %Changeset{changes: %{user_id: user_id}}), do: id == user_id
+  def create?(%User{}, %Changeset{}), do: false
 
   def delete?(%User{admin: true}, %UserSkill{}), do: true
-  def delete?(%User{} = user, %UserSkill{} = user_skill), do: user.id == user_skill.user_id
+  def delete?(%User{id: id}, %UserSkill{user_id: user_id}), do: id == user_id
+  def delete?(%User{}, %UserSkill{}), do: false
 end

--- a/web/web.ex
+++ b/web/web.ex
@@ -38,6 +38,7 @@ defmodule CodeCorps.Web do
       import CodeCorps.Gettext
 
       import Canary.Plugs
+      import CodeCorps.AuthenticationHelpers, only: [load_and_authorize_changeset: 2]
     end
   end
 


### PR DESCRIPTION
Work in progress, closes #176 

This is definitely still a work in progress, but I've formulated a methodology for this, which allows us to just us a `load_and_authorize_changeset` plug. I'm still working out the details, but the tests pass and it seems to be working in the organization membership controller, so that would be the one I would look at.
