### PR TITLE
Add sentry user context plug

### DIFF
--- a/web/plugs/set_sentry_user_context.ex
+++ b/web/plugs/set_sentry_user_context.ex
@@ -1,0 +1,17 @@
+defmodule CodeCorps.Plug.SetSentryUserContext do
+  def init(opts), do: opts
+
+  def call(conn, _opts), do: conn |> set_context
+
+  defp set_context(%{assigns: %{current_user: user}} = conn) do
+    Sentry.Context.set_user_context(%{
+      id: user.id,
+      email: user.email,
+      first_name: user.first_name,
+      last_name: user.last_name
+    })
+    conn
+  end
+
+  defp set_context(conn), do: conn
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -27,9 +27,7 @@ defmodule CodeCorps.Router do
 
   pipeline :current_user do
     plug CodeCorps.Plug.CurrentUser
-  end
-
-  pipeline :analytics_identify do
+    plug CodeCorps.Plug.SetSentryUserContext
     plug CodeCorps.Plug.AnalyticsIdentify
   end
 
@@ -40,7 +38,7 @@ defmodule CodeCorps.Router do
   end
 
   scope "/", CodeCorps, host: "api." do
-    pipe_through [:api, :bearer_auth, :current_user, :analytics_identify]
+    pipe_through [:api, :bearer_auth, :current_user]
 
     post "/token", TokenController, :create
     post "/token/refresh", TokenController, :refresh
@@ -79,7 +77,7 @@ defmodule CodeCorps.Router do
   end
 
   scope "/", CodeCorps, host: "api." do
-    pipe_through [:api, :bearer_auth, :ensure_auth, :current_user, :analytics_identify]
+    pipe_through [:api, :bearer_auth, :ensure_auth, :current_user]
 
     resources "/categories", CategoryController, only: [:create, :update]
     resources "/comments", CommentController, only: [:create, :update]


### PR DESCRIPTION
Closes #303 

Merging of pipelines (suggested in the issue) is done as a separate commit, so we can rollback if wanted. Outside of that, this ought to be ready for merge, unless we want to write tests for it? Not sure how we would go about that. Probably a unit test for the plug itself, providing a conn with or without a current user.
