### PR TITLE
Add remaining policy tests

### DIFF
--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -57,14 +57,13 @@ defmodule CodeCorps.CommentControllerTest do
 
   describe "create" do
     @tag :authenticated
-    test "creates and renders resource when data is valid", %{conn: conn} do
-      user = insert(:user)
-      task = insert(:task, user: user)
+    test "creates and renders resource when data is valid", %{conn: conn, current_user: current_user} do
+      task = insert(:task, user: current_user)
 
       payload =
         build_payload
         |> put_attributes(@valid_attrs)
-        |> put_relationships(user, task)
+        |> put_relationships(current_user, task)
 
       path = conn |> comment_path(:create)
       conn = conn |> post(path, payload)
@@ -74,8 +73,13 @@ defmodule CodeCorps.CommentControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-      payload = build_payload |> put_attributes(@invalid_attrs)
+    test "does not create resource and renders errors when data is invalid", %{conn: conn, current_user: current_user} do
+      task = insert(:task, user: current_user)
+
+      payload =
+        build_payload
+        |> put_attributes(@invalid_attrs)
+        |> put_relationships(current_user, task)
 
       path = conn |> comment_path(:create)
       conn = conn |> post(path, payload)

--- a/test/controllers/preview_controller_test.exs
+++ b/test/controllers/preview_controller_test.exs
@@ -4,13 +4,22 @@ defmodule CodeCorps.PreviewControllerTest do
   alias CodeCorps.Preview
 
   defp build_payload do
-    %{"data" => %{"type" => "preview","attributes" => %{markdown: "A **strong** element"}}}
+    %{"data" => %{"type" => "preview", "attributes" => %{markdown: "A **strong** element"}}}
+  end
+  defp put_relationships(payload, user) do
+    relationships = build_relationships(user)
+    payload |> put_in(["data", "relationships"], relationships)
+  end
+  defp build_relationships(user) do
+    %{
+      user: %{data: %{id: user.id}}
+    }
   end
 
   describe "create" do
     @tag :authenticated
-    test "creates and renders resource, with body containing markdown rendered to html", %{conn: conn} do
-      payload = build_payload
+    test "creates and renders resource, with body containing markdown rendered to html", %{conn: conn, current_user: current_user} do
+      payload = build_payload |> put_relationships(current_user)
       path = conn |> preview_path(:create)
       json = conn |> post(path, payload) |> json_response(201)
 
@@ -31,7 +40,7 @@ defmodule CodeCorps.PreviewControllerTest do
 
     @tag :authenticated
     test "it assigns current user as owner of preview, if available", %{conn: conn, current_user: current_user} do
-      payload = build_payload
+      payload = build_payload |> put_relationships(current_user)
       path = conn |> preview_path(:create)
       json = conn |> post(path, payload) |> json_response(201)
 

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -139,8 +139,7 @@ defmodule CodeCorps.UserControllerTest do
     end
 
     test "does not update when authorized as different user", %{conn: conn} do
-      user = insert(:user)
-      another_user = insert(:user)
+      [user, another_user] = insert_pair(:user)
 
       attrs = Map.put(@valid_attrs, :password, "password")
 

--- a/test/models/preview_test.exs
+++ b/test/models/preview_test.exs
@@ -3,22 +3,21 @@ defmodule CodeCorps.PreviewTest do
 
   alias CodeCorps.Preview
 
-  test "changeset renders body html from markdown" do
-    changeset = Preview.changeset(%Preview{}, %{markdown: "A **strong** element"}, nil)
-    assert changeset.valid?
-    assert changeset |> get_change(:body) == "<p>A <strong>strong</strong> element</p>\n"
-  end
+  describe "create_changeset/2" do
+    test "renders body html from markdown" do
+      user = insert(:user)
+      changeset = Preview.create_changeset(%Preview{}, %{
+        markdown: "A **strong** element",
+        user_id: user.id
+      })
+      assert changeset.valid?
+      assert changeset |> get_change(:body) == "<p>A <strong>strong</strong> element</p>\n"
+    end
 
-  test "changeset requires markdown change" do
-    changeset = Preview.changeset(%Preview{}, %{}, nil)
-    refute changeset.valid?
-    assert changeset.errors[:markdown] == {"can't be blank", []}
-  end
-
-  test "assigns user_id if present" do
-    user = insert(:user)
-    changeset = Preview.changeset(%Preview{}, %{markdown: "A **strong** element"}, user)
-    assert changeset.valid?
-    assert Ecto.Changeset.get_change(changeset, :user).data == user
+    test "requires markdown change" do
+      changeset = Preview.create_changeset(%Preview{}, %{})
+      refute changeset.valid?
+      assert changeset.errors[:markdown] == {"can't be blank", []}
+    end
   end
 end

--- a/test/policies/category_policy_test.exs
+++ b/test/policies/category_policy_test.exs
@@ -1,0 +1,29 @@
+defmodule CodeCorps.CategoryPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.CategoryPolicy, only: [create?: 1, update?: 1]
+
+  describe "create?" do
+    test "returns true when user is an admin" do
+      user = build(:user, admin: true)
+      assert create?(user)
+    end
+
+    test "returns false if user is not an admin" do
+      user = build(:user, admin: false)
+      refute create?(user) 
+    end
+  end
+
+  describe "update?" do
+    test "returns true when user is an admin" do
+      user = build(:user, admin: true)
+      assert update?(user)
+    end
+
+    test "returns false if user is not an admin" do
+      user = build(:user, admin: false)
+      refute update?(user)
+    end
+  end
+end

--- a/test/policies/comment_policy_test.exs
+++ b/test/policies/comment_policy_test.exs
@@ -1,0 +1,42 @@
+defmodule CodeCorps.CommentPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.CommentPolicy, only: [create?: 2, update?: 2]
+  import CodeCorps.Comment, only: [create_changeset: 2]
+
+  alias CodeCorps.Comment
+
+  describe "create?" do
+    test "returns true if own record" do
+      user = insert(:user)
+      changeset = %Comment{} |> create_changeset(%{user_id: user.id})
+      assert create?(user, changeset)
+    end
+
+    test "returns false if someone else's record" do
+      [user, another_user] = insert_pair(:user)
+      changeset = %Comment{} |> create_changeset(%{user_id: another_user.id})
+      refute create?(user, changeset)
+    end
+
+    test "returns false if changeset is empty" do
+      user = insert(:user)
+      changeset = %Comment{} |> create_changeset(%{})
+      refute create?(user, changeset)
+    end
+  end
+
+  describe "update?" do
+    test "returns true if own record" do
+      user = insert(:user)
+      comment = insert(:comment, user: user)
+      assert update?(user, comment)
+    end
+
+    test "returns false if someone else's record" do
+      [user, another_user] = insert_pair(:user)
+      comment = insert(:comment, user: user)
+      refute update?(another_user, comment)
+    end
+  end
+end

--- a/test/policies/organization_membership_policy_test.exs
+++ b/test/policies/organization_membership_policy_test.exs
@@ -7,36 +7,36 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
   alias CodeCorps.OrganizationMembership
 
   describe "create" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       changeset = %OrganizationMembership{} |> create_changeset(%{})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns true when user is creating their own membership" do
       user = insert(:user, admin: true)
       changeset = %OrganizationMembership{} |> create_changeset(%{member_id: user.id})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns false for normal user, creating someone else's membership" do
       user = build(:user, admin: true)
       changeset = %OrganizationMembership{} |> create_changeset(%{member_id: "someone_else"})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
   end
 
   describe "update" do
-    test "retuns true when user is site admin" do
+    test "returns true when user is site admin" do
       user = build(:user, admin: true)
       membership = build(:organization_membership)
 
       changeset = membership |> update_changeset(%{})
 
-      assert update?(user, changeset) == true
+      assert update?(user, changeset) 
     end
 
     test "returns false when user is non-member" do
@@ -45,7 +45,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       changeset = membership |> update_changeset(%{})
 
-      assert update?(user, changeset) == false
+      refute update?(user, changeset) 
     end
 
     test "returns false when user is pending" do
@@ -57,7 +57,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       changeset = membership |> update_changeset(%{})
 
-      assert update?(user, changeset) == false
+      refute update?(user, changeset) 
     end
 
     test "returns false when user is contributor" do
@@ -69,7 +69,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       changeset = membership |> update_changeset(%{})
 
-      assert update?(user, changeset) == false
+      refute update?(user, changeset) 
     end
 
     test "returns true when user is admin, approving a pending membership" do
@@ -81,7 +81,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       changeset = membership |> update_changeset(%{role: "contributor"})
 
-      assert update?(user, changeset) == true
+      assert update?(user, changeset) 
     end
 
     test "returns false when user is admin, doing something other than approving a pending membership" do
@@ -93,7 +93,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       changeset = membership |> update_changeset(%{})
 
-      assert update?(user, changeset) == false
+      refute update?(user, changeset) 
     end
 
     test "returns true when user is owner and is changing a role other than owner" do
@@ -105,7 +105,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       changeset = membership |> update_changeset(%{})
 
-      assert update?(user, changeset) == true
+      assert update?(user, changeset) 
     end
 
     test "returns false when user is owner and is changing another owner" do
@@ -117,16 +117,16 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       changeset = membership |> update_changeset(%{})
 
-      assert update?(user, changeset) == false
+      refute update?(user, changeset) 
     end
   end
 
   describe "delete" do
-    test "retuns true when user is site admin" do
+    test "returns true when user is site admin" do
       user = build(:user, admin: true)
       membership = build(:organization_membership)
 
-      assert delete?(user, membership) == true
+      assert delete?(user, membership) 
     end
 
     test "returns true when contributor is deleting their own membership" do
@@ -135,7 +135,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       membership = insert(:organization_membership, organization: organization, member: user, role: "contributor")
 
-      assert delete?(user, membership) == true
+      assert delete?(user, membership) 
     end
 
     test "returns true when admin is deleting a pending membership" do
@@ -145,7 +145,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       membership = insert(:organization_membership, organization: organization, role: "pending")
 
-      assert delete?(user, membership) == true
+      assert delete?(user, membership) 
     end
 
     test "returns true when admin is deleting a contributor" do
@@ -155,7 +155,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       membership = insert(:organization_membership, organization: organization, role: "contributor")
 
-      assert delete?(user, membership) == true
+      assert delete?(user, membership) 
     end
 
     test "returns false when admin is deleting another admin" do
@@ -165,7 +165,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       membership = insert(:organization_membership, organization: organization, role: "admin")
 
-      assert delete?(user, membership) == false
+      refute delete?(user, membership) 
     end
 
     test "returns false when admin is deleting an owner" do
@@ -175,7 +175,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       membership = insert(:organization_membership, organization: organization, role: "owner")
 
-      assert delete?(user, membership) == false
+      refute delete?(user, membership) 
     end
 
     test "returns true when owner is deleting an admin" do
@@ -185,7 +185,7 @@ defmodule CodeCorps.OrganizationMembershipPolicyTest do
 
       membership = insert(:organization_membership, organization: organization, role: "admin")
 
-      assert delete?(user, membership) == true
+      assert delete?(user, membership) 
     end
   end
 end

--- a/test/policies/organization_policy_test.exs
+++ b/test/policies/organization_policy_test.exs
@@ -1,0 +1,58 @@
+defmodule CodeCorps.OrganizationPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.OrganizationPolicy, only: [create?: 1, update?: 2]
+
+  defp setup_user_organization_by_role(role) do
+    user = insert(:user)
+    organization = insert(:organization)
+    insert(:organization_membership, role: role, member: user, organization: organization)
+    [user, organization]
+  end
+
+  describe "create" do
+    test "returns true when user is an admin" do
+      user = build(:user, admin: true)
+      assert create?(user)
+    end
+
+    test "returns false when user is not an admin" do
+      user = build(:user, admin: false)
+      refute create?(user)
+    end
+  end
+
+  describe "update" do
+    test "returns true when user is an admin" do
+      user = insert(:user, admin: true)
+      organization = insert(:organization)
+      assert update?(user, organization)
+    end
+
+    test "returns false when user is not member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      refute update?(user, organization)
+    end
+
+    test "returns false when user is pending member of organization" do
+      [user, organization] = setup_user_organization_by_role("pending")
+      refute update?(user, organization)
+    end
+
+    test "returns false when user is contributor of organization" do
+      [user, organization] = setup_user_organization_by_role("contributor")
+      refute update?(user, organization)
+    end
+
+    test "returns true when user is admin of organization" do
+      [user, organization] = setup_user_organization_by_role("admin")
+      assert update?(user, organization)
+    end
+
+    test "returns true when user is owner of organization" do
+      [user, organization] = setup_user_organization_by_role("owner")
+      assert update?(user, organization)
+    end
+  end
+end

--- a/test/policies/preview_policy_test.exs
+++ b/test/policies/preview_policy_test.exs
@@ -1,0 +1,22 @@
+defmodule CodeCorps.PreviewPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.PreviewPolicy, only: [create?: 2]
+  import CodeCorps.Preview, only: [create_changeset: 2]
+
+  alias CodeCorps.Preview
+
+  describe "create?" do
+    test "returns true if user is creating their own record" do
+      user = insert(:user)
+      changeset = %Preview{} |> create_changeset(%{markdown: "markdown", user_id: user.id})
+      assert create?(user, changeset)
+    end
+
+    test "returns false if user is creating someone else's record" do
+      [user, another_user] = insert_pair(:user)
+      changeset = %Preview{} |> create_changeset(%{markdown: "markdown", user_id: another_user.id})
+      refute create?(user, changeset)
+    end
+  end
+end

--- a/test/policies/project_category_policy_test.exs
+++ b/test/policies/project_category_policy_test.exs
@@ -7,11 +7,11 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
   alias CodeCorps.ProjectCategory
 
   describe "create?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       changeset = %ProjectCategory{} |> create_changeset(%{})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns false when user is not member of organization" do
@@ -20,7 +20,7 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
       project = insert(:project, organization: organization)
 
       changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns false when user is pending member of organization" do
@@ -31,7 +31,7 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
       insert(:organization_membership, role: "pending", member: user, organization: organization)
 
       changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns false when user is contributor of organization" do
@@ -42,7 +42,7 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
       insert(:organization_membership, role: "contributor", member: user, organization: organization)
 
       changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns true when user is admin of organization" do
@@ -53,7 +53,7 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
       insert(:organization_membership, role: "admin", member: user, organization: organization)
 
       changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns true when user is owner of organization" do
@@ -64,16 +64,16 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
       insert(:organization_membership, role: "owner", member: user, organization: organization)
 
       changeset = %ProjectCategory{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
   end
 
   describe "delete?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       project_category = insert(:project_category)
 
-      assert delete?(user, project_category) == true
+      assert delete?(user, project_category) 
     end
 
     test "returns false when user is not member of organization" do
@@ -82,7 +82,7 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
       project = insert(:project, organization: organization)
       project_category = insert(:project_category, project: project)
 
-      assert delete?(user, project_category) == false
+      refute delete?(user, project_category) 
     end
 
     test "returns false when user is pending member of organization" do
@@ -93,7 +93,7 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
 
       insert(:organization_membership, role: "pending", member: user, organization: organization)
 
-      assert delete?(user, project_category) == false
+      refute delete?(user, project_category) 
     end
 
     test "returns false when user is contributor of organization" do
@@ -104,7 +104,7 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
 
       insert(:organization_membership, role: "contributor", member: user, organization: organization)
 
-      assert delete?(user, project_category) == false
+      refute delete?(user, project_category) 
     end
 
     test "returns true when user is admin of organization" do
@@ -115,7 +115,7 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
 
       insert(:organization_membership, role: "admin", member: user, organization: organization)
 
-      assert delete?(user, project_category) == true
+      assert delete?(user, project_category) 
     end
 
     test "returns true when user is owner of organization" do
@@ -126,7 +126,7 @@ defmodule CodeCorps.ProjectCategoryPolicyTest do
 
       insert(:organization_membership, role: "owner", member: user, organization: organization)
 
-      assert delete?(user, project_category) == true
+      assert delete?(user, project_category) 
     end
   end
 end

--- a/test/policies/project_policy_test.exs
+++ b/test/policies/project_policy_test.exs
@@ -7,11 +7,11 @@ defmodule CodeCorps.ProjectPolicyTest do
   alias CodeCorps.Project
 
   describe "create" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       changeset = %Project{} |> create_changeset(%{})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns false when user is not member of organization" do
@@ -19,7 +19,7 @@ defmodule CodeCorps.ProjectPolicyTest do
       organization = insert(:organization)
 
       changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns false when user is pending member of organization" do
@@ -29,7 +29,7 @@ defmodule CodeCorps.ProjectPolicyTest do
       insert(:organization_membership, role: "pending", member: user, organization: organization)
 
       changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns false when user is contributor of organization" do
@@ -39,7 +39,7 @@ defmodule CodeCorps.ProjectPolicyTest do
       insert(:organization_membership, role: "contributor", member: user, organization: organization)
 
       changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns true when user is admin of organization" do
@@ -49,7 +49,7 @@ defmodule CodeCorps.ProjectPolicyTest do
       insert(:organization_membership, role: "admin", member: user, organization: organization)
 
       changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns true when user is owner of organization" do
@@ -59,16 +59,16 @@ defmodule CodeCorps.ProjectPolicyTest do
       insert(:organization_membership, role: "owner", member: user, organization: organization)
 
       changeset = %Project{} |> create_changeset(%{organization_id: organization.id})
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
   end
 
   describe "update" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       project = build(:project)
 
-      assert update?(user, project) == true
+      assert update?(user, project) 
     end
 
     test "returns false when user is not member of organization" do
@@ -76,7 +76,7 @@ defmodule CodeCorps.ProjectPolicyTest do
       organization = insert(:organization)
       project = insert(:project, organization: organization)
 
-      assert update?(user, project) == false
+      refute update?(user, project) 
     end
 
     test "returns false when user is pending member of organization" do
@@ -86,7 +86,7 @@ defmodule CodeCorps.ProjectPolicyTest do
 
       insert(:organization_membership, role: "pending", member: user, organization: organization)
 
-      assert update?(user, project) == false
+      refute update?(user, project) 
     end
 
     test "returns false when user is contributor of organization" do
@@ -96,7 +96,7 @@ defmodule CodeCorps.ProjectPolicyTest do
 
       insert(:organization_membership, role: "contributor", member: user, organization: organization)
 
-      assert update?(user, project) == false
+      refute update?(user, project) 
     end
 
     test "returns true when user is admin of organization" do
@@ -106,7 +106,7 @@ defmodule CodeCorps.ProjectPolicyTest do
 
       insert(:organization_membership, role: "admin", member: user, organization: organization)
 
-      assert update?(user, project) == true
+      assert update?(user, project) 
     end
 
     test "returns true when user is owner of organization" do
@@ -116,7 +116,7 @@ defmodule CodeCorps.ProjectPolicyTest do
 
       insert(:organization_membership, role: "owner", member: user, organization: organization)
 
-      assert update?(user, project) == true
+      assert update?(user, project) 
     end
   end
 end

--- a/test/policies/project_skill_policy_test.exs
+++ b/test/policies/project_skill_policy_test.exs
@@ -7,11 +7,11 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
   alias CodeCorps.ProjectSkill
 
   describe "create?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       changeset = %ProjectSkill{} |> create_changeset(%{})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns false when user is not member of organization" do
@@ -20,7 +20,7 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
       project = insert(:project, organization: organization)
 
       changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns false when user is pending member of organization" do
@@ -31,7 +31,7 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
       insert(:organization_membership, role: "pending", member: user, organization: organization)
 
       changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns false when user is contributor of organization" do
@@ -42,7 +42,7 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
       insert(:organization_membership, role: "contributor", member: user, organization: organization)
 
       changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns true when user is admin of organization" do
@@ -53,7 +53,7 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
       insert(:organization_membership, role: "admin", member: user, organization: organization)
 
       changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns true when user is owner of organization" do
@@ -64,16 +64,16 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
       insert(:organization_membership, role: "owner", member: user, organization: organization)
 
       changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
   end
 
   describe "delete?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       project_skill = insert(:project_skill)
 
-      assert delete?(user, project_skill) == true
+      assert delete?(user, project_skill) 
     end
 
     test "returns false when user is not member of organization" do
@@ -82,7 +82,7 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
       project = insert(:project, organization: organization)
       project_skill = insert(:project_skill, project: project)
 
-      assert delete?(user, project_skill) == false
+      refute delete?(user, project_skill) 
     end
 
     test "returns false when user is pending member of organization" do
@@ -93,7 +93,7 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
 
       insert(:organization_membership, role: "pending", member: user, organization: organization)
 
-      assert delete?(user, project_skill) == false
+      refute delete?(user, project_skill) 
     end
 
     test "returns false when user is contributor of organization" do
@@ -104,7 +104,7 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
 
       insert(:organization_membership, role: "contributor", member: user, organization: organization)
 
-      assert delete?(user, project_skill) == false
+      refute delete?(user, project_skill) 
     end
 
     test "returns true when user is admin of organization" do
@@ -115,7 +115,7 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
 
       insert(:organization_membership, role: "admin", member: user, organization: organization)
 
-      assert delete?(user, project_skill) == true
+      assert delete?(user, project_skill) 
     end
 
     test "returns true when user is owner of organization" do
@@ -126,7 +126,7 @@ defmodule CodeCorps.ProjectSkillPolicyTest do
 
       insert(:organization_membership, role: "owner", member: user, organization: organization)
 
-      assert delete?(user, project_skill) == true
+      assert delete?(user, project_skill) 
     end
   end
 end

--- a/test/policies/role_policy_test.exs
+++ b/test/policies/role_policy_test.exs
@@ -1,0 +1,17 @@
+defmodule CodeCorps.RolePolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.RolePolicy, only: [create?: 1]
+
+  describe "create?" do
+    test "returns true when user is an admin" do
+      user = build(:user, admin: true)
+      assert create?(user) 
+    end
+
+    test "returns false if user is not an admin" do
+      user = build(:user, admin: false)
+      refute create?(user) 
+    end
+  end
+end

--- a/test/policies/role_skill_policy_test.exs
+++ b/test/policies/role_skill_policy_test.exs
@@ -1,0 +1,29 @@
+defmodule CodeCorps.RoleSkillPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.RoleSkillPolicy, only: [create?: 1, delete?: 1]
+
+  describe "create?" do
+    test "returns true when user is an admin" do
+      user = build(:user, admin: true)
+      assert create?(user) 
+    end
+
+    test "returns false if user is not an admin" do
+      user = build(:user, admin: false)
+      refute create?(user) 
+    end
+  end
+
+  describe "delete?" do
+    test "returns true when user is an admin" do
+      user = build(:user, admin: true)
+      assert delete?(user) 
+    end
+
+    test "returns false if user is not an admin" do
+      user = build(:user, admin: false)
+      refute delete?(user) 
+    end
+  end
+end

--- a/test/policies/skill_policy_test.exs
+++ b/test/policies/skill_policy_test.exs
@@ -1,0 +1,17 @@
+defmodule CodeCorps.SkillPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.SkillPolicy, only: [create?: 1]
+
+  describe "create?" do
+    test "returns true when user is an admin" do
+      user = build(:user, admin: true)
+      assert create?(user) 
+    end
+
+    test "returns false if user is not an admin" do
+      user = build(:user, admin: false)
+      refute create?(user) 
+    end
+  end
+end

--- a/test/policies/task_policy_test.exs
+++ b/test/policies/task_policy_test.exs
@@ -7,32 +7,32 @@ defmodule CodeCorps.TaskPolicyTest do
   alias CodeCorps.Task
 
   describe "create" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       changeset = %Task{} |> create_changeset(%{})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns false when user is not the author" do
       user = build(:user)
       changeset = %Task{} |> create_changeset(%{task_type: "issue", user_id: "other"})
 
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
 
     test "returns true when task is an issue" do
       user = insert(:user)
       changeset = %Task{} |> create_changeset(%{task_type: "issue", user_id: user.id})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns true when task is an idea" do
       user = insert(:user)
       changeset = %Task{} |> create_changeset(%{task_type: "idea", user_id: user.id})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns true when user is at least contributor of organization" do
@@ -44,7 +44,7 @@ defmodule CodeCorps.TaskPolicyTest do
 
       changeset = %Task{} |> create_changeset(%{project_id: project.id, task_type: "task", user_id: user.id})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns false when user is not contributor and type is 'task'" do
@@ -54,16 +54,16 @@ defmodule CodeCorps.TaskPolicyTest do
 
       changeset = %Task{} |> create_changeset(%{project_id: project.id, task_type: "task", user_id: user.id})
 
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
   end
 
   describe "update" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       task = build(:task)
 
-      assert update?(user, task) == true
+      assert update?(user, task) 
     end
   end
 end

--- a/test/policies/user_category_policy_test.exs
+++ b/test/policies/user_category_policy_test.exs
@@ -7,48 +7,48 @@ defmodule CodeCorps.UserCategoryPolicyTest do
   alias CodeCorps.UserCategory
 
   describe "create?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       changeset = %UserCategory{} |> create_changeset(%{})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns true if user is creating their own record" do
       user = insert(:user)
       changeset = %UserCategory{} |> create_changeset(%{user_id: user.id})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns false if user is creating someone else's record" do
       user = build(:user)
       changeset = %UserCategory{} |> create_changeset(%{user_id: "someone-else"})
 
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
   end
 
   describe "delete?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       user_category = insert(:user_category)
 
-      assert delete?(user, user_category) == true
+      assert delete?(user, user_category) 
     end
 
     test "returns true if user is creating their own record" do
       user = insert(:user)
       user_category = insert(:user_category, user: user)
 
-      assert delete?(user, user_category) == true
+      assert delete?(user, user_category) 
     end
 
     test "returns false if user is creating someone else's record" do
       user = build(:user)
       user_category = insert(:user_category)
 
-      assert delete?(user, user_category) == false
+      refute delete?(user, user_category) 
     end
   end
 end

--- a/test/policies/user_policy_test.exs
+++ b/test/policies/user_policy_test.exs
@@ -1,0 +1,17 @@
+defmodule CodeCorps.UserPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.UserPolicy, only: [update?: 2]
+
+  describe "update?" do
+    test "returns true if user is updating their own record" do
+      user = insert(:user)
+      assert update?(user, user) 
+    end
+
+    test "returns false if user is updating someone else's record" do
+      [user, another_user] = insert_pair(:user)
+      refute update?(another_user, user)
+    end
+  end
+end

--- a/test/policies/user_role_policy_test.exs
+++ b/test/policies/user_role_policy_test.exs
@@ -7,48 +7,48 @@ defmodule CodeCorps.UserRolePolicyTest do
   alias CodeCorps.UserRole
 
   describe "create?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       changeset = %UserRole{} |> create_changeset(%{})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns true if user is creating their own record" do
       user = insert(:user)
       changeset = %UserRole{} |> create_changeset(%{user_id: user.id})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns false if user is creating someone else's record" do
       user = build(:user)
       changeset = %UserRole{} |> create_changeset(%{user_id: "someone-else"})
 
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
   end
 
   describe "delete?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       user_role = insert(:user_role)
 
-      assert delete?(user, user_role) == true
+      assert delete?(user, user_role) 
     end
 
     test "returns true if user is creating their own record" do
       user = insert(:user)
       user_role = insert(:user_role, user: user)
 
-      assert delete?(user, user_role) == true
+      assert delete?(user, user_role) 
     end
 
     test "returns false if user is creating someone else's record" do
       user = build(:user)
       user_role = insert(:user_role)
 
-      assert delete?(user, user_role) == false
+      refute delete?(user, user_role) 
     end
   end
 end

--- a/test/policies/user_skill_policy_test.exs
+++ b/test/policies/user_skill_policy_test.exs
@@ -7,48 +7,48 @@ defmodule CodeCorps.UserSkillPolicyTest do
   alias CodeCorps.UserSkill
 
   describe "create?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       changeset = %UserSkill{} |> create_changeset(%{})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns true if user is creating their own record" do
       user = insert(:user)
       changeset = %UserSkill{} |> create_changeset(%{user_id: user.id})
 
-      assert create?(user, changeset) == true
+      assert create?(user, changeset) 
     end
 
     test "returns false if user is creating someone else's record" do
       user = build(:user)
       changeset = %UserSkill{} |> create_changeset(%{user_id: "someone-else"})
 
-      assert create?(user, changeset) == false
+      refute create?(user, changeset) 
     end
   end
 
   describe "delete?" do
-    test "retuns true when user is an admin" do
+    test "returns true when user is an admin" do
       user = build(:user, admin: true)
       user_skill = insert(:user_skill)
 
-      assert delete?(user, user_skill) == true
+      assert delete?(user, user_skill) 
     end
 
     test "returns true if user is creating their own record" do
       user = insert(:user)
       user_skill = insert(:user_skill, user: user)
 
-      assert delete?(user, user_skill) == true
+      assert delete?(user, user_skill) 
     end
 
     test "returns false if user is creating someone else's record" do
       user = build(:user)
       user_skill = insert(:user_skill)
 
-      assert delete?(user, user_skill) == false
+      refute delete?(user, user_skill) 
     end
   end
 end

--- a/web/controllers/comment_controller.ex
+++ b/web/controllers/comment_controller.ex
@@ -6,7 +6,8 @@ defmodule CodeCorps.CommentController do
   alias CodeCorps.Comment
   alias JaSerializer.Params
 
-  plug :load_and_authorize_resource, model: Comment, only: [:create, :update]
+  plug :load_and_authorize_changeset, model: Comment, only: [:create]
+  plug :load_and_authorize_resource, model: Comment, only: [:update]
 
   plug :scrub_params, "data" when action in [:create, :update]
 

--- a/web/controllers/preview_controller.ex
+++ b/web/controllers/preview_controller.ex
@@ -4,14 +4,10 @@ defmodule CodeCorps.PreviewController do
   alias CodeCorps.Preview
   alias JaSerializer.Params
 
-  plug :load_and_authorize_resource, model: Preview, only: [:create]
+  plug :load_and_authorize_changeset, model: Preview, only: [:create]
 
-  def create(conn, %{"data" => data = %{"type" => "preview", "attributes" => _project_params}}) do
-    user =
-      conn
-      |> Guardian.Plug.current_resource
-
-    changeset = Preview.changeset(%Preview{}, Params.to_attributes(data), user)
+  def create(conn, %{"data" => data = %{"type" => "preview", "attributes" => _preview_params}}) do
+    changeset = Preview.create_changeset(%Preview{}, Params.to_attributes(data))
 
     case Repo.insert(changeset) do
       {:ok, preview} ->

--- a/web/helpers/authentication_helpers.ex
+++ b/web/helpers/authentication_helpers.ex
@@ -28,16 +28,21 @@ defmodule CodeCorps.AuthenticationHelpers do
   # This is partially adjusted code, taken from canary
   def load_and_authorize_changeset(conn, options) do
     action = conn.private.phoenix_action
-
     cond do
-      action in options[:only] -> conn |> load_resource(options) |> do_init_and_authorize_changeset(options[:model], action)
-      true -> conn
+      action in options[:only] ->
+        conn
+        |> load_resource(options)
+        |> do_init_and_authorize_changeset(options[:model], action)
+      true ->
+        conn
     end
   end
 
   defp do_init_and_authorize_changeset(conn, model, action) do
     changeset = init_changeset(conn, model, action)
-    conn |> assign(:changeset, changeset) |> authorize(changeset, action)
+    conn
+    |> assign(:changeset, changeset)
+    |> authorize(changeset, action)
   end
 
   defp init_changeset(conn, model, action) do
@@ -51,15 +56,23 @@ defmodule CodeCorps.AuthenticationHelpers do
   defp do_init_changeset(model, method, params), do: apply(model, method, params)
 
   defp get_resource(conn, model, :update) do
-    resource_name = model |> Module.split |> List.last |> Macro.underscore |> String.to_atom
+    resource_name =
+      model
+      |> Module.split
+      |> List.last
+      |> Macro.underscore
+      |> String.to_atom
+
     conn.assigns |> Map.get(resource_name)
   end
   defp get_resource(_conn, model, :create), do: model.__struct__
 
   defp get_changeset_method(action), do: "#{action}_changeset" |> String.to_atom
 
-  def authorize(conn, changeset, action) do
+  defp authorize(conn, changeset, action) do
     current_user = conn.assigns |> Map.get(:current_user)
-    conn |> assign(:authorized, can?(current_user, action, changeset)) |> handle_unauthorized
+    conn
+    |> assign(:authorized, can?(current_user, action, changeset))
+    |> handle_unauthorized
   end
 end

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -50,7 +50,7 @@ defmodule Canary.Abilities do
     def can?(%User{} = user, :create, Category), do: CategoryPolicy.create?(user)
     def can?(%User{} = user, :update, %Category{}), do: CategoryPolicy.update?(user)
 
-    def can?(%User{} = user, :create, Comment), do: CommentPolicy.create?(user)
+    def can?(%User{} = user, :create, %Changeset{data: %Comment{}} = changeset), do: CommentPolicy.create?(user, changeset)
     def can?(%User{} = user, :update, %Comment{} = comment), do: CommentPolicy.update?(user, comment)
 
     def can?(%User{} = user, :create, Organization), do: OrganizationPolicy.create?(user)
@@ -63,7 +63,7 @@ defmodule Canary.Abilities do
     def can?(%User{} = user, :create, %Changeset{data: %Task{}} = changeset), do: TaskPolicy.create?(user, changeset)
     def can?(%User{} = user, :update, %Task{} = task), do: TaskPolicy.update?(user, task)
 
-    def can?(%User{} = user, :create, Preview), do: PreviewPolicy.create?(user)
+    def can?(%User{} = user, :create, %Changeset{data: %Preview{}} = changeset), do: PreviewPolicy.create?(user, changeset)
 
     def can?(%User{} = user, :create, %Changeset{data: %Project{}} = changeset), do: ProjectPolicy.create?(user, changeset)
     def can?(%User{} = user, :update, %Project{} = project), do: ProjectPolicy.update?(user, project)

--- a/web/models/preview.ex
+++ b/web/models/preview.ex
@@ -19,17 +19,11 @@ defmodule CodeCorps.Preview do
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
-  def changeset(struct, params \\ %{}, user) do
+  def create_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:markdown])
-    |> validate_required([:markdown])
-    |> assign_user(user)
+    |> cast(params, [:markdown, :user_id])
+    |> validate_required([:markdown, :user_id])
+    |> assoc_constraint(:user)
     |> MarkdownRenderer.render_markdown_to_html(:markdown, :body)
-  end
-
-  defp assign_user(changeset, nil), do: changeset
-  defp assign_user(changeset, user) do
-    changeset
-    |> put_assoc(:user, user)
   end
 end

--- a/web/policies/category_policy.ex
+++ b/web/policies/category_policy.ex
@@ -3,6 +3,7 @@ defmodule CodeCorps.CategoryPolicy do
 
   def create?(%User{admin: true}), do: true
   def create?(%User{admin: false}), do: false
+
   def update?(%User{admin: true}), do: true
   def update?(%User{admin: false}), do: false
 end

--- a/web/policies/comment_policy.ex
+++ b/web/policies/comment_policy.ex
@@ -1,8 +1,10 @@
 defmodule CodeCorps.CommentPolicy do
   alias CodeCorps.Comment
   alias CodeCorps.User
+  alias Ecto.Changeset
 
-  def create?(%User{}), do: true
+  def create?(%User{} = user, %Changeset{changes: %{user_id: creator_id}}), do: user.id == creator_id
+  def create?(%User{}, %Changeset{}), do: false
 
   def update?(%User{} = user, %Comment{} = comment), do: user.id == comment.user_id
 end

--- a/web/policies/organization_membership_policy.ex
+++ b/web/policies/organization_membership_policy.ex
@@ -11,7 +11,6 @@ defmodule CodeCorps.OrganizationMembershipPolicy do
   def create?(%User{id: user_id}, %Changeset{changes: %{member_id: member_id}}), do:  user_id == member_id
   def create?(%User{}, %Changeset{}), do: false
 
-
   def update?(%User{admin: true}, %Changeset{}), do: true
   def update?(%User{} = user, %Changeset{data: %OrganizationMembership{} = current_membership} = changeset) do
     user_membership = current_membership |> get_user_membership(user)

--- a/web/policies/organization_policy.ex
+++ b/web/policies/organization_policy.ex
@@ -8,6 +8,7 @@ defmodule CodeCorps.OrganizationPolicy do
   def create?(%User{admin: true}), do: true
   def create?(%User{admin: false}), do: false
 
+  def update?(%User{admin: true}, %Organization{}), do: true
   def update?(%User{} = user, %Organization{} = organization), do: user |> role_is_at_least_admin(organization)
 
   defp role_is_at_least_admin(%User{} = user, %Organization{} = organization) do

--- a/web/policies/preview_policy.ex
+++ b/web/policies/preview_policy.ex
@@ -1,5 +1,8 @@
 defmodule CodeCorps.PreviewPolicy do
   alias CodeCorps.User
 
-  def create?(%User{} = _user), do: true
+  alias Ecto.Changeset
+
+  def create?(%User{} = user, %Changeset{changes: %{user_id: author_id}} = changeset), do: user.id == author_id
+  def create?(%User{}, %Changeset{}), do: false
 end

--- a/web/policies/task_policy.ex
+++ b/web/policies/task_policy.ex
@@ -5,14 +5,15 @@ defmodule CodeCorps.TaskPolicy do
   alias CodeCorps.User
 
   alias CodeCorps.Repo
+  alias Ecto.Changeset
 
   import Ecto.Query
 
   # TODO: Need to be able to see what resource is being created here
   # Previously, any user could create issues and ideas, but only
   # approved members of organization could create other task types
-  def create?(%User{admin: true}, %Ecto.Changeset{}), do: true
-  def create?(%User{} = user, %Ecto.Changeset{changes: %{user_id: author_id, task_type: task_type}} = changeset) do
+  def create?(%User{admin: true}, %Changeset{}), do: true
+  def create?(%User{} = user, %Changeset{changes: %{user_id: author_id, task_type: task_type}} = changeset) do
     cond do
       # can't create for some other user
       user.id != author_id -> false
@@ -24,7 +25,7 @@ defmodule CodeCorps.TaskPolicy do
       true -> false
     end
   end
-  def create?(%User{}, %Ecto.Changeset{}), do: false
+  def create?(%User{}, %Changeset{}), do: false
 
   def update?(%User{} = user, %Task{user_id: author_id} = task) do
     cond do
@@ -37,7 +38,7 @@ defmodule CodeCorps.TaskPolicy do
     end
   end
 
-  defp get_project(%Ecto.Changeset{changes: %{project_id: project_id}}), do: Project |> Repo.get(project_id)
+  defp get_project(%Changeset{changes: %{project_id: project_id}}), do: Project |> Repo.get(project_id)
   defp get_project(%Task{project_id: project_id}), do: Project |> Repo.get(project_id)
 
   defp get_membership(%Project{organization_id: organization_id}, %User{id: user_id}) do


### PR DESCRIPTION
Closes #174 by adding the remaining policy tests not addressed in #320.
- Add category policy test
- Add role policy test
- Add skill policy test
- Add role skill policy test
- Add comment policy test
- Add preview policy test
- Add user policy test
- Add organization policy test
- Update abilities
