### PR TITLE
add pipable test helpers for asserting relationship attrs

### DIFF
--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,9 +1,25 @@
 defmodule CodeCorps.TestHelpers do
   use Phoenix.ConnTest
+  import ExUnit.Assertions
 
   def ids_from_response(response) do
     Enum.map response["data"], fn(attributes) ->
       String.to_integer(attributes["id"])
     end
+  end
+
+  def assert_jsonapi_relationship(json = %{"relationships" => relationships}, relationship_name, id) do
+    assert relationships[relationship_name]["data"]["id"] == Integer.to_string(id)
+    json
+  end
+
+  def assert_jsonapi_relationship(json, relationship_name, id) do
+    assert json["data"]["relationships"][relationship_name]["data"]["id"] == Integer.to_string(id)
+    json
+  end
+
+  def assert_result_id(result, id) do
+    assert String.to_integer(result["id"]) == id
+    result
   end
 end


### PR DESCRIPTION
Addresses: https://github.com/code-corps/code-corps-api/issues/322

Wanted to add some more test helpers to help with test readability. The goal was to make pipeable assertion methods so we can chain responses and test everything we need in a block.
