### PR TITLE
Determine reserved routes

### DIFF
--- a/lib/code_corps/validators/slug_validator.ex
+++ b/lib/code_corps/validators/slug_validator.ex
@@ -5,40 +5,68 @@ defmodule CodeCorps.Validators.SlugValidator do
 
   alias Ecto.Changeset
 
+  @doc """
+  Validates a slug.
+
+  Matches slugs with:
+  - only letters
+  - prefixed/suffixed underscores
+  - prefixed/suffixed numbers
+  - single inside dashes
+  - single/multiple inside underscores
+  - one character
+
+  Prevents slugs with:
+  - prefixed symbols
+  - prefixed/suffixed dashes
+  - multiple consecutive dashes
+  - single/multiple/multiple consecutive slashes
+
+  Also prevents slugs that conflict with reserved routes for either the API or the web.
+  """
   def validate_slug(changeset, field_name) do
-    # Matches slugs with:
-    # - only letters
-    # - prefixed/suffixed underscores
-    # - prefixed/suffixed numbers
-    # - single inside dashes
-    # - single/multiple inside underscores
-    # - one character
-    #
-    # Prevents slugs with:
-    # - prefixed symbols
-    # - prefixed/suffixed dashes
-    # - multiple consecutive dashes
-    # - single/multiple/multiple consecutive slashes
     valid_slug_pattern = ~r/\A((?:(?:(?:[^-\W]-?))*)(?:(?:(?:[^-\W]-?))*)\w+)\z/
 
-    # Prevents slugs that conflict with reserved routes
-    reserved_routes = ~w(
-      about account admin android api app apps blog bug bugs cache charter
-      comment comments contact contributor contributors cookies
-      developer developers discover donate engineering enterprise explore
-      facebook favorites feed followers following github help home image images
-      integration integrations invite invitations ios issue issues jobs learn
-      likes lists log-in log-out login logout mention mentions new news
-      notification notifications oauth oauth_clients organization organizations
-      ping popular
-      press pricing privacy
-      project projects repositories role roles rules search security session
-      sessions settings shop showcases sidekiq sign-in sign-out signin signout
-      signup sitemap slug slugs spotlight stars status tag tags
-      task-image task-images task-like task-likes task
-      tasks team teams terms token tokens training trends trust tour twitter
-      user-role user-roles user-skill user-skills user users watching year
+    # Routes for the API – api. subdomain
+    api_routes = ~w(
+      api
+      categories comments contributors
+      images issues
+      mentions
+      notifications
+      oauth oauth_clients organizations organization-memberships
+      ping projects project-categories
+      project-skills
+      repositories roles
+      skills slugged-route stars
+      tags tasks task-images task-likes
+      teams token tokens
+      user-roles user-skills user users
     )
+
+    # Routes for the web – www. subdomain
+    web_routes = ~w(
+      about account admin android app apps
+      blog
+      charter contact cookies
+      developer developers discover donate
+      engineering enterprise explore
+      facebook favorites feed followers following
+      github
+      help home
+      integrations invite invitations ios
+      jobs
+      learn likes lists log-in log-out login logout
+      news notifications
+      popular press pricing privacy projects
+      search security session sessions settings shop showcases
+      sign-in sign-out signin signout signup sitemap spotlight start
+      team terms training trends trust tour twitter
+      watching
+      year
+    )
+
+    reserved_routes = api_routes ++ web_routes
 
     changeset
     |> Changeset.validate_format(field_name, valid_slug_pattern)


### PR DESCRIPTION
Closes #14.
- Adds some documentation.
- Splits up routes into `api` and `web` so we can more easily determine what needs added
- Adds some new routes and removes some unnecessary ones we're likely not going to use
