### PR TITLE
Fix Project Skill seeds using a non-existant changeset

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -318,7 +318,7 @@ cond do
     IO.puts "Project skills detected, aborting this seed."
   true ->
     %ProjectSkill{}
-    |> ProjectSkill.changeset(%{
+    |> ProjectSkill.create_changeset(%{
       project_id: 1,
       skill_id: 1
     })


### PR DESCRIPTION
This PR fixes the call to the non-existent `changeset` function by using the correct function `create_changeset`.

[This is the issue](https://github.com/code-corps/code-corps-api/issues/345) related to the PR.

Fixes #345.
