### PR TITLE
Test Segment tracking after user creation

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -28,7 +28,7 @@ config :code_corps, allowed_origins: ["http://localhost:4200"]
 config :guardian, Guardian,
   secret_key: "e62fb6e2746f6b1bf8b5b735ba816c2eae1d5d76e64f18f3fc647e308b0c159e"
 
-config :code_corps, :analytics, CodeCorps.Analytics.InMemoryAPI
+config :code_corps, :analytics, CodeCorps.Analytics.TestAPI
 
 config :code_corps, :icon_color_generator, CodeCorps.RandomIconColor.TestGenerator
 

--- a/lib/code_corps/analytics/test_api.ex
+++ b/lib/code_corps/analytics/test_api.ex
@@ -1,0 +1,18 @@
+defmodule CodeCorps.Analytics.TestAPI do
+  @moduledoc """
+  In-memory interface to simulate calling out to the Segment API,
+  sending back itself a message with passed parameters - they're used for assertions.
+
+  Each function should have the same signature as `CodeCorps.Analytics.SegmentAPI` and simply return `nil`.
+  """
+
+  def identify(user_id, traits) do
+    send self(), {:identify, user_id, traits}
+    nil
+  end
+
+  def track(user_id, event_name, properties) do
+    send self(), {:track, user_id, event_name, properties}
+    nil
+  end
+end


### PR DESCRIPTION
Tries to implement segment tracking testing requested in https://github.com/code-corps/code-corps-api/issues/350

Used some ideas from http://blog.plataformatec.com.br/2015/10/mocks-and-explicit-contracts/

I don't think that message sending to `self` is useful in development, so I've created a separate implementation to be plugged in for testing only. 
