### PR TITLE
add test helper for building relationships

### DIFF
--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -8,19 +8,6 @@ defmodule CodeCorps.CommentControllerTest do
   @invalid_attrs %{markdown: ""}
 
   defp build_payload, do: %{ "data" => %{"type" => "comment"}}
-  defp put_id(payload, id), do: payload |> put_in(["data", "id"], id)
-  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
-  defp put_relationships(payload, user, task) do
-    relationships = build_relationships(user, task)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-
-  defp build_relationships(user, task) do
-    %{
-      user: %{data: %{id: user.id}},
-      task: %{data: %{id: task.id}}
-    }
-  end
 
   describe "index" do
     test "lists all entries for specified task on index", %{conn: conn} do

--- a/test/controllers/organization_controller_test.exs
+++ b/test/controllers/organization_controller_test.exs
@@ -9,8 +9,6 @@ defmodule CodeCorps.OrganizationControllerTest do
   @invalid_attrs %{name: ""}
 
   defp build_payload, do: %{ "data" => %{"type" => "organization"}}
-  defp put_id(payload, id), do: payload |> put_in(["data", "id"], id)
-  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/controllers/organization_membership_controller_test.exs
+++ b/test/controllers/organization_membership_controller_test.exs
@@ -9,9 +9,7 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
   @invalid_attrs %{role: "invalid_role"}
 
   defp build_payload, do: %{ "data" => %{"type" => "organization-membership"}}
-  defp put_id(payload, id), do: payload |> put_in(["data", "id"], id)
-  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
-  defp put_relationships(payload, organization, member) do
+  defp put_relationships_with_member(payload, organization, member) do
     relationships = build_relationships(organization, member)
     payload |> put_in(["data", "relationships"], relationships)
   end
@@ -79,7 +77,7 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
     test "creates and renders resource when data is valid", %{conn: conn, current_user: member} do
       organization = insert(:organization)
 
-      payload = build_payload |> put_relationships(organization, member)
+      payload = build_payload |> put_relationships_with_member(organization, member)
 
       path = conn |> organization_membership_path(:create)
       response =
@@ -103,7 +101,7 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
       # only way to trigger a validation error is to provide a non-existant organization
       # anything else will fail on authorization level
       organization = build(:organization)
-      payload = build_payload |> put_relationships(organization, member)
+      payload = build_payload |> put_relationships_with_member(organization, member)
 
       path = conn |> organization_membership_path(:create)
       data = conn |> post(path, payload) |> json_response(422)

--- a/test/controllers/preview_controller_test.exs
+++ b/test/controllers/preview_controller_test.exs
@@ -6,15 +6,6 @@ defmodule CodeCorps.PreviewControllerTest do
   defp build_payload do
     %{"data" => %{"type" => "preview", "attributes" => %{markdown: "A **strong** element"}}}
   end
-  defp put_relationships(payload, user) do
-    relationships = build_relationships(user)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-  defp build_relationships(user) do
-    %{
-      user: %{data: %{id: user.id}}
-    }
-  end
 
   describe "create" do
     @tag :authenticated

--- a/test/controllers/project_category_controller_test.exs
+++ b/test/controllers/project_category_controller_test.exs
@@ -9,17 +9,6 @@ defmodule CodeCorps.ProjectCategoryControllerTest do
   @attrs %{}
 
   defp build_payload, do: %{ "data" => %{"type" => "project-category", "attributes" => %{}}}
-  defp put_relationships(payload, project, category) do
-    relationships = build_relationships(project, category)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-
-  defp build_relationships(project, category) do
-    %{
-      project: %{data: %{id: project.id}},
-      category: %{data: %{id: category.id}}
-    }
-  end
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -14,18 +14,6 @@ defmodule CodeCorps.ProjectControllerTest do
   }
 
   defp build_payload, do: %{ "data" => %{"type" => "project"}}
-  defp put_id(payload, id), do: payload |> put_in(["data", "id"], id)
-  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
-  defp put_relationships(payload, organization) do
-    relationships = build_relationships(organization)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-
-  defp build_relationships(organization) do
-    %{
-      organization: %{data: %{id: organization.id}}
-    }
-  end
 
   describe "#index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/controllers/project_skill_controller_test.exs
+++ b/test/controllers/project_skill_controller_test.exs
@@ -7,17 +7,6 @@ defmodule CodeCorps.ProjectSkillControllerTest do
   @attrs %{}
 
   defp build_payload, do: %{ "data" => %{"type" => "project-skill", "attributes" => %{}}}
-  defp put_relationships(payload, project, skill) do
-    relationships = build_relationships(project, skill)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-
-  defp build_relationships(project, skill) do
-    %{
-      project: %{data: %{id: project.id}},
-      skill: %{data: %{id: skill.id}}
-    }
-  end
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/controllers/role_controller_test.exs
+++ b/test/controllers/role_controller_test.exs
@@ -8,7 +8,6 @@ defmodule CodeCorps.RoleControllerTest do
   @invalid_attrs %{ability: "Juggling", kind: "circus", name: "Juggler"}
 
   defp build_payload, do: %{ "data" => %{"type" => "role"}}
-  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/controllers/role_skill_controller_test.exs
+++ b/test/controllers/role_skill_controller_test.exs
@@ -8,17 +8,6 @@ defmodule CodeCorps.RoleSkillControllerTest do
   @invalid_attrs %{}
 
   defp build_payload, do: %{ "data" => %{"type" => "role-skill", "attributes" => %{}}}
-  defp put_relationships(payload, role, skill) do
-    relationships = build_relationships(role, skill)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-
-  defp build_relationships(role, skill) do
-    %{
-      role: %{data: %{id: role.id}},
-      skill: %{data: %{id: skill.id}}
-    }
-  end
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/controllers/skill_controller_test.exs
+++ b/test/controllers/skill_controller_test.exs
@@ -12,7 +12,6 @@ defmodule CodeCorps.SkillControllerTest do
   @invalid_attrs %{}
 
   defp build_payload, do: %{ "data" => %{"type" => "skill"}}
-  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/controllers/task_controller_test.exs
+++ b/test/controllers/task_controller_test.exs
@@ -17,19 +17,6 @@ defmodule CodeCorps.TaskControllerTest do
   }
 
   defp build_payload, do: %{ "data" => %{"type" => "task"}}
-  defp put_id(payload, id), do: payload |> put_in(["data", "id"], id)
-  defp put_attributes(payload, attributes), do: payload |> put_in(["data", "attributes"], attributes)
-  defp put_relationships(payload, user, project) do
-    relationships = build_relationships(user, project)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-
-  defp build_relationships(user, project) do
-    %{
-      user: %{data: %{id: user.id}},
-      project: %{data: %{id: project.id}}
-    }
-  end
 
   describe "index" do
     test "lists all entries", %{conn: conn} do

--- a/test/controllers/user_category_controller_test.exs
+++ b/test/controllers/user_category_controller_test.exs
@@ -7,17 +7,6 @@ defmodule CodeCorps.UserCategoryControllerTest do
   @attrs %{}
 
   defp build_payload, do: %{ "data" => %{"type" => "user-category", "attributes" => %{}}}
-  defp put_relationships(payload, user, category) do
-    relationships = build_relationships(user, category)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-
-  defp build_relationships(user, category) do
-    %{
-      user: %{data: %{id: user.id}},
-      category: %{data: %{id: category.id}}
-    }
-  end
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/controllers/user_role_controller_test.exs
+++ b/test/controllers/user_role_controller_test.exs
@@ -5,17 +5,6 @@ defmodule CodeCorps.UserRoleControllerTest do
   alias CodeCorps.Repo
 
   defp build_payload, do: %{ "data" => %{"type" => "user-role", "attributes" => %{}}}
-  defp put_relationships(payload, user, role) do
-    relationships = build_relationships(user, role)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-
-  defp build_relationships(user, role) do
-    %{
-      user: %{data: %{id: user.id}},
-      role: %{data: %{id: role.id}}
-    }
-  end
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/controllers/user_skill_controller_test.exs
+++ b/test/controllers/user_skill_controller_test.exs
@@ -5,17 +5,6 @@ defmodule CodeCorps.UserSkillControllerTest do
   alias CodeCorps.Repo
 
   defp build_payload, do: %{ "data" => %{"type" => "user-skill", "attributes" => %{}}}
-  defp put_relationships(payload, user, skill) do
-    relationships = build_relationships(user, skill)
-    payload |> put_in(["data", "relationships"], relationships)
-  end
-
-  defp build_relationships(user, skill) do
-    %{
-      user: %{data: %{id: user.id}},
-      skill: %{data: %{id: skill.id}}
-    }
-  end
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -22,4 +22,31 @@ defmodule CodeCorps.TestHelpers do
     assert String.to_integer(result["id"]) == id
     result
   end
+
+  def put_id(payload, id), do: put_in(payload, ["data", "id"], id)
+  def put_attributes(payload, attributes), do: put_in(payload, ["data", "attributes"], attributes)
+  def put_relationships(payload, record_1, record_2), do: put_relationships(payload, [record_1, record_2])
+
+  def put_relationships(payload, records) do
+    relationships = build_relationships(%{}, records)
+    payload |> put_in(["data", "relationships"], relationships)
+  end
+
+  defp build_relationships(relationship_map, []), do: relationship_map
+  defp build_relationships(relationship_map, [head | tail]) do
+    relationship_map
+    |> Map.put(get_record_name(head), %{data: %{id: head.id}})
+    |> build_relationships(tail)
+  end
+  defp build_relationships(relationship_map, single_param) do
+    build_relationships(relationship_map, [single_param])
+  end
+
+  defp get_record_name(record) do
+    record.__struct__
+    |> Module.split
+    |> List.last
+    |> Macro.underscore
+    |> String.to_existing_atom
+  end
 end


### PR DESCRIPTION
# What's in this PR?

There is a lot of repeated logic in our controller tests for how we build relationships. We only have a few models that relate to other models, but they seem to be used in quite a few tests. This PR should extract it to the test helpers and (hopefully) make it flexible.
## References

Fixes No existing issues for this yet.
