### PR TITLE
Remove /:organization_id/memberships path

### DIFF
--- a/lib/code_corps/helpers/query.ex
+++ b/lib/code_corps/helpers/query.ex
@@ -7,15 +7,6 @@ defmodule CodeCorps.Helpers.Query do
     query |> where([object], object.id in ^ids)
   end
 
-  def organization_filter(query, organization_id) do
-    query |> where([object], object.organization_id == ^organization_id)
-  end
-
-  def role_filter(query, roles_list) do
-    roles = roles_list |> coalesce_string
-    query |> where([object], object.role in ^roles)
-  end
-
   # skill queries
 
   def limit_filter(query, %{"limit" => count}) do

--- a/test/controllers/organization_membership_controller_test.exs
+++ b/test/controllers/organization_membership_controller_test.exs
@@ -38,18 +38,6 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
       assert ids_from_response(response) == [membership_1.id, membership_2.id]
     end
 
-    test "lists all resources for specified organization", %{conn: conn} do
-      organization = insert(:organization)
-      [membership_1, membership_2] = insert_pair(:organization_membership, organization: organization)
-      insert(:organization_membership)
-
-      path = conn |> organization_membership_path(:index)
-      params = %{"organization_id" => organization.id}
-      response = conn |> get(path, params) |> json_response(200)
-
-      assert ids_from_response(response) == [membership_1.id, membership_2.id]
-    end
-
     test "filters resources by membership id", %{conn: conn} do
       [membership_1, membership_2] = insert_pair(:organization_membership)
       insert(:organization_membership)
@@ -61,42 +49,6 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
         |> json_response(200)
 
       assert ids_from_response(response) == [membership_1.id, membership_2.id]
-    end
-
-    test "filters resources by role", %{conn: conn} do
-      [membership_1, membership_2] = insert_pair(:organization_membership, role: "admin")
-      insert(:organization_membership, role: "owner")
-
-      params = %{"filter" => %{"role" => "admin"}}
-      response =
-        conn
-        |> get(organization_membership_path(conn, :index, params))
-        |> json_response(200)
-
-      assert ids_from_response(response) == [membership_1.id, membership_2.id]
-    end
-
-    test "filters resources by role and id", %{conn: conn} do
-      [membership_1, _] = insert_pair(:organization_membership, role: "admin")
-      insert(:organization_membership, role: "owner")
-
-      params = %{"filter" => %{"id" => "#{membership_1.id}", "role" => "admin"}}
-      path = conn |> organization_membership_path(:index)
-      response = conn |> get(path, params) |> json_response(200)
-
-      assert ids_from_response(response) == [membership_1.id]
-    end
-
-    test "filters resources by role and id on specific organization", %{conn: conn} do
-      organization = insert(:organization)
-      [membership_1, _] = insert_pair(:organization_membership, organization: organization, role: "admin")
-      insert(:organization_membership, role: "owner")
-
-      params = %{"filter" => %{"id" => "#{membership_1.id}", "role" => "admin"}, "organization_id" => organization.id}
-      path = conn |> organization_membership_path(:index)
-      response = conn |> get(path, params) |> json_response(200)
-
-      assert ids_from_response(response) == [membership_1.id]
     end
   end
 

--- a/test/controllers/organization_membership_controller_test.exs
+++ b/test/controllers/organization_membership_controller_test.exs
@@ -43,8 +43,9 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
       [membership_1, membership_2] = insert_pair(:organization_membership, organization: organization)
       insert(:organization_membership)
 
-      path = conn |> organization_organization_membership_path(:index, organization)
-      response = conn |> get(path) |> json_response(200)
+      path = conn |> organization_membership_path(:index)
+      params = %{"organization_id" => organization.id}
+      response = conn |> get(path, params) |> json_response(200)
 
       assert ids_from_response(response) == [membership_1.id, membership_2.id]
     end
@@ -80,8 +81,8 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
       insert(:organization_membership, role: "owner")
 
       params = %{"filter" => %{"id" => "#{membership_1.id}", "role" => "admin"}}
-      path = conn |> organization_membership_path(:index, params)
-      response = conn |> get(path) |> json_response(200)
+      path = conn |> organization_membership_path(:index)
+      response = conn |> get(path, params) |> json_response(200)
 
       assert ids_from_response(response) == [membership_1.id]
     end
@@ -91,8 +92,8 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
       [membership_1, _] = insert_pair(:organization_membership, organization: organization, role: "admin")
       insert(:organization_membership, role: "owner")
 
-      params = %{"filter" => %{"id" => "#{membership_1.id}", "role" => "admin"}}
-      path = conn |> organization_organization_membership_path(:index, organization)
+      params = %{"filter" => %{"id" => "#{membership_1.id}", "role" => "admin"}, "organization_id" => organization.id}
+      path = conn |> organization_membership_path(:index)
       response = conn |> get(path, params) |> json_response(200)
 
       assert ids_from_response(response) == [membership_1.id]

--- a/web/controllers/organization_membership_controller.ex
+++ b/web/controllers/organization_membership_controller.ex
@@ -2,7 +2,7 @@ defmodule CodeCorps.OrganizationMembershipController do
   use CodeCorps.Web, :controller
   use JaResource
 
-  import CodeCorps.Helpers.Query, only: [id_filter: 2, organization_filter: 2, role_filter: 2]
+  import CodeCorps.Helpers.Query, only: [id_filter: 2]
 
   alias CodeCorps.OrganizationMembership
 
@@ -14,15 +14,6 @@ defmodule CodeCorps.OrganizationMembershipController do
   def filter(_conn, query, "id", id_list) do
     query |> id_filter(id_list)
   end
-
-  def filter(_conn, query, "role", roles_list) do
-    query |> role_filter(roles_list)
-  end
-
-  def handle_index(_conn, %{"organization_id" => organization_id}) do
-    OrganizationMembership |> organization_filter(organization_id)
-  end
-  def handle_index(_conn, _params), do: OrganizationMembership
 
   def handle_create(conn, attributes) do
     %OrganizationMembership{}

--- a/web/router.ex
+++ b/web/router.ex
@@ -45,9 +45,7 @@ defmodule CodeCorps.Router do
 
     resources "/categories", CategoryController, only: [:index, :show]
     resources "/comments", CommentController, only: [:show]
-    resources "/organizations", OrganizationController, only: [:index, :show] do
-      resources "/memberships", OrganizationMembershipController, only: [:index]
-    end
+    resources "/organizations", OrganizationController, only: [:index, :show]
     resources "/organization-memberships", OrganizationMembershipController, only: [:index, :show]
     resources "/projects", ProjectController, only: [:index, :show] do
       resources "/tasks", TaskController, only: [:index, :show]


### PR DESCRIPTION
As discussed in #341, it's not used at all.

I would like to look at other things here as well. We have tests for filtering by role level and organization id that are written as if they need to come in specific combinations. Migth be simpler to just loosen them up and simply apply supported filters "in order".
