### PR TITLE
Fix comment endpoints to match ember

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -150,49 +150,6 @@ The Category resource allows us to categorize projects (Project Category), as we
 
 This endpoint is for creating and returning comments.
 
-## Task Comments [/tasks/{task_id}/comments]
-
-You can list all comments or retrieve individual comments for a single task.
-
-### List all of a task's comments [GET]
-
-+ Parameters
-
-    + task_id (number) - Id of a task.
-
-+ Request
-
-    + Headers
-
-            Accept: application/vnd.api+json
-
-+ Response 200 (application/vnd.api+json; charset=utf-8)
-
-    + Attributes (Comments Response)
-
-## Task Comment [/tasks/{task_id}/comments/{id}]
-
-### Retrieve a task's comment [GET]
-
-+ Parameters
-
-    + task_id (number) - Id of a task.
-    + id (number) - The `id` of a comment.
-
-+ Request
-
-    + Headers
-
-            Accept: application/vnd.api+json
-
-+ Response 200 (application/vnd.api+json; charset=utf-8)
-
-    + Attributes (Comment Response)
-
-+ Response 404 (application/vnd.api+json; charset=utf-8)
-
-    + Attributes (Record Not Found Response)
-
 ## Comments [/comments]
 
 You can list all comments or retrieve individual comments, as well as create and update comments.
@@ -215,22 +172,6 @@ You can list all comments or retrieve individual comments, as well as create and
 + Response 422 (application/vnd.api+json; charset=utf-8)
 
     + Attributes (Unprocessable Entity Response)
-
-## List comments for a specified task [GET /tasks/{task_id}/comments]
-
-+ Parameters
-
-    + task_id: 1 (number, required) - Task id, uniquely identifying a task
-
-+ Request
-
-    + Headers
-
-            Accept: application/vnd.api+json
-
-+ Response 200 (application/vnd.api+json; charset=utf-8)
-
-    + Attributes (Comments Response)
 
 ### Filter comments by list of ids [GET /comments{?filter[id]}]
 

--- a/lib/code_corps/helpers/query.ex
+++ b/lib/code_corps/helpers/query.ex
@@ -46,6 +46,14 @@ defmodule CodeCorps.Helpers.Query do
 
   # end task queries
 
+  # def comment queries
+
+  def task_filter(query, task_id) do
+    query |> where([object], object.task_id == ^task_id)
+  end
+
+  # end comment queries
+
   # sorting
 
   def sort_by_newest_first(query), do: query |> order_by([desc: :inserted_at])

--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -10,11 +10,24 @@ defmodule CodeCorps.CommentControllerTest do
   defp build_payload, do: %{ "data" => %{"type" => "comment"}}
 
   describe "index" do
-    test "lists all entries for specified task on index", %{conn: conn} do
-      task = insert(:task)
-      path = conn |> task_comment_path(:index, task)
+    test "lists all entries on index", %{conn: conn} do
+      path = conn |> comment_path(:index)
       conn = conn |> get(path)
+
       assert json_response(conn, 200)["data"] == []
+    end
+
+    test "filters resources on index", %{conn: conn} do
+      first_comment = insert(:comment)
+      second_comment = insert(:comment)
+      insert(:comment)
+
+      path = "comments/?filter[id]=#{first_comment.id},#{second_comment.id}"
+
+      conn
+      |> get(path)
+      |> json_response(200)
+      |> assert_ids_from_response([first_comment.id, second_comment.id])
     end
   end
 

--- a/web/controllers/comment_controller.ex
+++ b/web/controllers/comment_controller.ex
@@ -2,11 +2,17 @@ defmodule CodeCorps.CommentController do
   use CodeCorps.Web, :controller
   use JaResource
 
+  import CodeCorps.Helpers.Query, only: [id_filter: 2]
+
   alias CodeCorps.Comment
 
   plug :load_and_authorize_changeset, model: Comment, only: [:create]
   plug :load_and_authorize_resource, model: Comment, only: [:update]
   plug JaResource
+
+  def filter(_conn, query, "id", id_list) do
+    query |> id_filter(id_list)
+  end
 
   def handle_create(conn, attributes) do
     %Comment{}

--- a/web/router.ex
+++ b/web/router.ex
@@ -44,7 +44,7 @@ defmodule CodeCorps.Router do
     post "/token/refresh", TokenController, :refresh
 
     resources "/categories", CategoryController, only: [:index, :show]
-    resources "/comments", CommentController, only: [:show]
+    resources "/comments", CommentController, only: [:index, :show]
     resources "/donation-goals", DonationGoalController, only: [:index, :show]
     resources "/organizations", OrganizationController, only: [:index, :show]
     resources "/organization-memberships", OrganizationMembershipController, only: [:index, :show]
@@ -56,9 +56,7 @@ defmodule CodeCorps.Router do
     resources "/roles", RoleController, only: [:index, :show]
     resources "/role-skills", RoleSkillController, only: [:index, :show]
     resources "/skills", SkillController, only: [:index, :show]
-    resources "/tasks", TaskController, only: [:index, :show] do
-      resources "/comments", CommentController, only: [:index, :show]
-    end
+    resources "/tasks", TaskController, only: [:index, :show]
     get "/users/email_available", UserController, :email_available
     get "/users/username_available", UserController, :username_available
     resources "/users", UserController, only: [:index, :show, :create]


### PR DESCRIPTION
This should resolve #340 

This one eliminates the `tasks/:task_id/comments/:comment_id` endpoint, since we don't really need it.

It also fixes the `tasks/:task_id/comments` endpoint to return all comments for the specified task. Additionally, this change eliminates the `comments` endpoint (the one that returns all comments for all tasks) by not defining a catch all `handle_index` function for it. We should not be needing that one..

However, I'm not sure we should merge this. This is what our model hook looks like on the task route in ember:

``` Javascript
model(params) {
  let projectId = this.modelFor('project').id;
  let queryParams = {
    projectId,
    number: params.number
  };

  let userId = this.get('currentUser.user.id');

  return RSVP.hash({
    task: this.store.queryRecord('task', queryParams),
    user: isPresent(userId) ? this.store.find('user', userId) : null
  }).then((result) => {
    return RSVP.hash({
      task: result.task,
      comment: this.store.createRecord('comment', { task: result.task, user: result.user }),
      comments: this.store.query('comment', { taskId: result.task.id })
    });
  });
},
```

So, there are two steps here

Step 1:  
- Fetch the task by `projectId` and `number`
- Reload the current user, if one already exists - should be no need for that; pass through `null` otherwise

Step 2
- Pass through the fetched task
- Fetch all comments for fetched task
- Init a new, unsaved comment, and assign it to fetched user

This is atypical behaviour we have here. A simpler approach would be to 
- Fetch task by `projectId` and `number`
- Later, asynchronously fetch comments using coalesced ids from `task.comments` relationship, same as any other place we do it in.
- Use current user to init new comment. Can do it via a promise as well, if needed. 
- Template can hide new comment form if there is no current user.

Due to all this, I propose that we
- Eliminate the filtering by task id from comments endpoint
- Add filtering by coalesced ids
- Simplify ember so the task route works similarly to other routes that handle relationships (as described above).

@JoshSmith Let me know what you think about it. If you don't think such a simplification is needed, then this PR is mergeable.
