### PR TITLE
Make it so tasks can be filtered by project and number only in conjunction

### DIFF
--- a/lib/code_corps/helpers/query.ex
+++ b/lib/code_corps/helpers/query.ex
@@ -32,10 +32,10 @@ defmodule CodeCorps.Helpers.Query do
 
   # task queries
 
-  def number_as_id_filter(query, %{"id" => number}) do
-    query |> where([object], object.number == ^number)
+  def project_id_with_number_filter(query, %{"id" => number, "project_id" => project_id}) do
+    query |> where([object], object.number == ^number and object.project_id == ^project_id)
   end
-  def number_as_id_filter(query, _), do: query
+  def project_id_with_number_filter(query, _), do: query
 
   def project_filter(query, %{"project_id" => project_id}) do
     query |> where([object], object.project_id == ^project_id)

--- a/web/controllers/task_controller.ex
+++ b/web/controllers/task_controller.ex
@@ -3,7 +3,7 @@ defmodule CodeCorps.TaskController do
   use JaResource
 
   import CodeCorps.Helpers.Query, only: [
-    project_filter: 2, number_as_id_filter: 2, sort_by_newest_first: 1,
+    project_filter: 2, project_id_with_number_filter: 2, sort_by_newest_first: 1,
     task_type_filter: 2, task_status_filter: 2
   ]
 
@@ -41,8 +41,7 @@ defmodule CodeCorps.TaskController do
 
   def record(%Plug.Conn{params: %{"project_id" => _project_id} = params}, _number_as_id) do
     Task
-    |> project_filter(params)
-    |> number_as_id_filter(params)
+    |> project_id_with_number_filter(params)
     |> Repo.one
   end
   def record(_conn, id), do: Task |> Repo.get(id)


### PR DESCRIPTION
Closes #339 

From my experience, the issue described in #339 is not _exactly_ what was happening.
- We query by id as number, but do not provide a project id - the catchall handler will trigger and query by id.
- We query by id as number, and the query also contains a project id - it will work as expected, since normal handler will trigger

What this PR does is that it doesn't fix that much, but it does merge the two filters on the show endpoint into one (one that fetches at the same time by project id and number), since it should only ever be used as one. It's technically more correct that way.

However, if ember is exhibiting buggy behaviour, then this is because of a bug on the ember side. We should look into it. I did some looking, but I'm not really seeing a problem.
