### PR TITLE
Get rid of manual task reloading by using :read_after_writes option

### DIFF
--- a/test/controllers/task_controller_test.exs
+++ b/test/controllers/task_controller_test.exs
@@ -115,7 +115,6 @@ defmodule CodeCorps.TaskControllerTest do
       path = conn |> task_path(:show, task)
 
       data = conn |> get(path) |> json_response(200) |> Map.get("data")
-      task = Task |> Repo.get(task.id)
 
       assert data["id"] == "#{task.id}"
       assert data["type"] == "task"
@@ -129,7 +128,6 @@ defmodule CodeCorps.TaskControllerTest do
 
     test "shows task by number for project", %{conn: conn} do
       task = insert(:task)
-      task = Task |> Repo.get(task.id)
 
       path = conn |> project_task_path(:show, task.project_id, task.number)
       data = conn |> get(path) |> json_response(200) |> Map.get("data")
@@ -158,7 +156,6 @@ defmodule CodeCorps.TaskControllerTest do
       json = conn |> post(path, payload) |> json_response(201)
 
       assert json["data"]["id"]
-      assert Repo.get_by(Task, @valid_attrs)
 
       # ensure record is reloaded from database before serialized, since number is added
       # on database level upon insert

--- a/test/models/task_test.exs
+++ b/test/models/task_test.exs
@@ -68,7 +68,6 @@ defmodule CodeCorps.TaskTest do
       })
       changeset = Task.create_changeset(%Task{}, changes)
       {:ok, result} = Repo.insert(changeset)
-      result = Repo.get(Task, result.id)
       assert result.number == 3
 
       changes = Map.merge(@valid_attrs, %{
@@ -77,7 +76,6 @@ defmodule CodeCorps.TaskTest do
       })
       changeset = Task.create_changeset(%Task{}, changes)
       {:ok, result} = Repo.insert(changeset)
-      result = Repo.get(Task, result.id)
       assert result.number == 2
     end
 

--- a/web/controllers/task_controller.ex
+++ b/web/controllers/task_controller.ex
@@ -50,12 +50,8 @@ defmodule CodeCorps.TaskController do
     %Task{}
     |> Task.create_changeset(attributes)
     |> Repo.insert
-    |> reload_task # need to reload to get generated number
     |> CodeCorps.Analytics.Segment.track(:created, conn)
   end
-
-  defp reload_task({:ok, new_task}), do: {:ok, Repo.get(Task, new_task.id)}
-  defp reload_task({:error, changeset}), do: {:error, changeset}
 
   def handle_update(conn, task, attributes) do
     task

--- a/web/models/task.ex
+++ b/web/models/task.ex
@@ -5,7 +5,7 @@ defmodule CodeCorps.Task do
   schema "tasks" do
     field :body, :string
     field :markdown, :string
-    field :number, :integer
+    field :number, :integer, read_after_writes: true
     field :task_type, :string
     field :state, :string
     field :status, :string, default: "open"


### PR DESCRIPTION
Was working on stripe and found this option in the Ecto docs. Cleans up the code a bit.
