### PR TITLE
Add StripeCard and StripeCustomer models

### DIFF
--- a/lib/code_corps/stripe/adapters/stripe_card.ex
+++ b/lib/code_corps/stripe/adapters/stripe_card.ex
@@ -1,0 +1,9 @@
+defmodule CodeCorps.Stripe.Adapters.StripeCard do
+  import CodeCorps.MapUtils, only: [rename: 3]
+
+  def params_from_stripe(%{} = stripe_map) do
+    stripe_map
+    |> rename("id", "id_from_stripe")
+    |> rename("customer", "customer_id_from_stripe")
+  end
+end

--- a/lib/code_corps/stripe/adapters/stripe_customer.ex
+++ b/lib/code_corps/stripe/adapters/stripe_customer.ex
@@ -1,0 +1,7 @@
+defmodule CodeCorps.Stripe.Adapters.StripeCustomer do
+  import CodeCorps.MapUtils, only: [rename: 3]
+
+  def params_from_stripe(%{} = stripe_map) do
+    stripe_map |> rename("id", "id_from_stripe")
+  end
+end

--- a/priv/repo/migrations/20161019090945_add_stripe_customers_cards_tables.exs
+++ b/priv/repo/migrations/20161019090945_add_stripe_customers_cards_tables.exs
@@ -1,0 +1,38 @@
+defmodule CodeCorps.Repo.Migrations.AddStripeCustomersCardsTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:stripe_customers) do
+      add :created, :datetime
+      add :currency, :string
+      add :delinquent, :boolean
+      add :email, :string
+      add :id_from_stripe, :string, null: false
+
+      add :user_id, references(:users, on_delete: :nothing), null: false
+
+      timestamps()
+    end
+
+    create unique_index(:stripe_customers, [:id_from_stripe])
+    create unique_index(:stripe_customers, [:user_id])
+
+    create table(:stripe_cards) do
+      add :brand, :string
+      add :customer_id_from_stripe, :string
+      add :cvc_check, :string
+      add :exp_month, :integer
+      add :exp_year, :integer
+      add :id_from_stripe, :string, null: false
+      add :last4, :string
+      add :name, :string
+
+      add :user_id, references(:users, on_delete: :nothing), null: false
+
+      timestamps()
+    end
+
+    create index(:stripe_cards, [:user_id])
+    create unique_index(:stripe_cards, [:id_from_stripe])
+  end
+end

--- a/test/controllers/project_skill_controller_test.exs
+++ b/test/controllers/project_skill_controller_test.exs
@@ -47,14 +47,13 @@ defmodule CodeCorps.ProjectSkillControllerTest do
       project_skill = insert(:project_skill, project: project, skill: skill)
       conn = get conn, project_skill_path(conn, :show, project_skill)
 
-      data =
-        conn
-        |> json_response(200)
-        |> Map.get("data")
-        |> assert_result_id(project_skill.id)
-        |> assert_jsonapi_relationship("project", project.id)
-        |> assert_jsonapi_relationship("skill", skill.id)
-        |> assert_attributes(%{})
+      conn
+      |> json_response(200)
+      |> Map.get("data")
+      |> assert_result_id(project_skill.id)
+      |> assert_jsonapi_relationship("project", project.id)
+      |> assert_jsonapi_relationship("skill", skill.id)
+      |> assert_attributes(%{})
     end
 
     test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do

--- a/test/lib/code_corps/map_utils_test.exs
+++ b/test/lib/code_corps/map_utils_test.exs
@@ -1,0 +1,9 @@
+defmodule CodeCorps.MapUtilsTest do
+  use ExUnit.Case, async: true
+
+  import CodeCorps.MapUtils, only: [rename: 3]
+
+  test "&rename/3 renames old key in map to new key" do
+    assert %{"foo" => 2} |> rename("foo", "bar") == %{"bar" => 2}
+  end
+end

--- a/test/lib/code_corps/stripe/adapters/stripe_card_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_card_test.exs
@@ -1,0 +1,18 @@
+defmodule CodeCorps.Stripe.Adapters.StripeCardTest do
+  use ExUnit.Case, async: true
+
+  import CodeCorps.Stripe.Adapters.StripeCard, only: [params_from_stripe: 1]
+
+  @stripe_map %{"id" => "str_123", "customer" => "cust_123", "foo" => "bar"}
+  @local_map %{
+    "id_from_stripe" => "str_123",
+    "customer_id_from_stripe" => "cust_123",
+    "foo" => "bar"
+  }
+
+  describe "params_from_stripe/1" do
+    test "converts from stripe map to local properly" do
+      assert @stripe_map |> params_from_stripe == @local_map
+    end
+  end
+end

--- a/test/lib/code_corps/stripe/adapters/stripe_customer_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_customer_test.exs
@@ -1,0 +1,14 @@
+defmodule CodeCorps.Stripe.Adapters.StripeCustomerTest do
+  use ExUnit.Case, async: true
+
+  import CodeCorps.Stripe.Adapters.StripeCustomer, only: [params_from_stripe: 1]
+
+  @stripe_map %{"id" => "str_123", "foo" => "bar"}
+  @local_map %{"id_from_stripe" => "str_123", "foo" => "bar"}
+
+  describe "params_from_stripe/1" do
+    test "converts from stripe map to local properly" do
+      assert @stripe_map |> params_from_stripe == @local_map
+    end
+  end
+end

--- a/test/models/stripe_card_test.exs
+++ b/test/models/stripe_card_test.exs
@@ -1,0 +1,41 @@
+defmodule CodeCorps.StripeCardTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.StripeCard
+
+  @valid_attrs %{
+    id_from_stripe: "abc123"
+  }
+
+  @invalid_attrs %{}
+
+  describe "create_changeset/2" do
+    test "reports as valid when attributes are valid" do
+      user_id = insert(:user).id
+
+      changes = Map.merge(@valid_attrs, %{user_id: user_id})
+      changeset = StripeCard.create_changeset(%StripeCard{}, changes)
+      assert changeset.valid?
+    end
+
+    test "reports as invalid when attributes are invalid" do
+      changeset = StripeCard.create_changeset(%StripeCard{}, @invalid_attrs)
+      refute changeset.valid?
+
+      assert changeset.errors[:id_from_stripe] == {"can't be blank", []}
+      assert changeset.errors[:user_id] == {"can't be blank", []}
+    end
+
+    test "ensures associations link to records that exist" do
+      attrs =  @valid_attrs |> Map.merge(%{user_id: -1})
+
+      { result, changeset } =
+        StripeCard.create_changeset(%StripeCard{}, attrs)
+        |> Repo.insert
+
+      assert result == :error
+      refute changeset.valid?
+      assert changeset.errors[:user] == {"does not exist", []}
+    end
+  end
+end

--- a/test/models/stripe_customer_test.exs
+++ b/test/models/stripe_customer_test.exs
@@ -1,0 +1,41 @@
+defmodule CodeCorps.StripeCustomerTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.StripeCustomer
+
+  @valid_attrs %{
+    id_from_stripe: "abc123"
+  }
+
+  @invalid_attrs %{}
+
+  describe "create_changeset/2" do
+    test "reports as valid when attributes are valid" do
+      user_id = insert(:user).id
+
+      changes = Map.merge(@valid_attrs, %{user_id: user_id})
+      changeset = StripeCustomer.create_changeset(%StripeCustomer{}, changes)
+      assert changeset.valid?
+    end
+
+    test "reports as invalid when attributes are invalid" do
+      changeset = StripeCustomer.create_changeset(%StripeCustomer{}, @invalid_attrs)
+      refute changeset.valid?
+
+      assert changeset.errors[:id_from_stripe] == {"can't be blank", []}
+      assert changeset.errors[:user_id] == {"can't be blank", []}
+    end
+
+    test "ensures associations link to records that exist" do
+      attrs =  @valid_attrs |> Map.merge(%{user_id: -1})
+
+      { result, changeset } =
+        StripeCustomer.create_changeset(%StripeCustomer{}, attrs)
+        |> Repo.insert
+
+      assert result == :error
+      refute changeset.valid?
+      assert changeset.errors[:user] == {"does not exist", []}
+    end
+  end
+end

--- a/test/views/project_view_test.exs
+++ b/test/views/project_view_test.exs
@@ -11,7 +11,7 @@ defmodule CodeCorps.ProjectViewTest do
     project_skill = insert(:project_skill, project: project)
     donation_goal = insert(:donation_goal, project: project)
 
-    rendered_json =  render(CodeCorps.ProjectView, "show.json-api", data: project)
+    rendered_json = render(CodeCorps.ProjectView, "show.json-api", data: project)
 
     expected_json = %{
       "data" => %{

--- a/web/models/stripe_card.ex
+++ b/web/models/stripe_card.ex
@@ -1,0 +1,25 @@
+defmodule CodeCorps.StripeCard do
+  use CodeCorps.Web, :model
+
+  schema "stripe_cards" do
+    field :brand, :string
+    field :customer_id_from_stripe, :string
+    field :cvc_check, :string
+    field :exp_month, :integer
+    field :exp_year, :integer
+    field :id_from_stripe, :string, null: false
+    field :last4, :string
+    field :name, :string
+
+    belongs_to :user, CodeCorps.User
+
+    timestamps()
+  end
+
+  def create_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:id_from_stripe, :user_id])
+    |> validate_required([:id_from_stripe, :user_id])
+    |> assoc_constraint(:user)
+  end
+end

--- a/web/models/stripe_customer.ex
+++ b/web/models/stripe_customer.ex
@@ -1,0 +1,24 @@
+defmodule CodeCorps.StripeCustomer do
+  use CodeCorps.Web, :model
+
+  schema "stripe_customers" do
+    field :created, Ecto.DateTime
+    field :currency, :string
+    field :delinquent, :boolean
+    field :email, :string
+    field :id_from_stripe, :string, null: false
+
+    belongs_to :user, CodeCorps.User
+
+    has_many :stripe_cards, CodeCorps.StripeCard, foreign_key: :stripe_customer_id
+
+    timestamps()
+  end
+
+  def create_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:id_from_stripe, :user_id])
+    |> validate_required([:id_from_stripe, :user_id])
+    |> assoc_constraint(:user)
+  end
+end


### PR DESCRIPTION
Will close #363 and #368 

Since `StripeCard#customer` and `StripeCustomer#default_source` in the original stripe payloads are clearly actually relationships between the two models (meaning a stripe customer has one default source/card and many individual cards, while a stripe card belongs to a stripe customer), I decided to create models with those relationships. 

While having string ids was relatively simple, I didn't want to complicate things too much with the foreign ids, so I just kept things explicit by defining adapters that convert between a stripe payload and a param map to be used in a changeset.

I'm not sure how the two models should relate to existing models. Should a project belong to / have one stripe customer. Should it be a user or an organization instead? I'm guessing organization, but I'm not sure how multiple projects per organization will be handled in that case.
