### PR TITLE
Add StripeAccount model

### DIFF
--- a/lib/code_corps/map_utils.ex
+++ b/lib/code_corps/map_utils.ex
@@ -1,0 +1,7 @@
+defmodule CodeCorps.MapUtils do
+  def rename(map, old_key, new_key) do
+    map
+    |> Map.put(new_key, map |> Map.get(old_key))
+    |> Map.delete(old_key)
+  end
+end

--- a/lib/code_corps/stripe/adapters/stripe_account.ex
+++ b/lib/code_corps/stripe/adapters/stripe_account.ex
@@ -1,0 +1,7 @@
+defmodule CodeCorps.Stripe.Adapters.StripeAccount do
+  import CodeCorps.MapUtils, only: [rename: 3]
+
+  def params_from_stripe(%{} = stripe_map) do
+    stripe_map |> rename("id", "id_from_stripe")
+  end
+end

--- a/priv/repo/migrations/20161020144622_create_stripe_account.exs
+++ b/priv/repo/migrations/20161020144622_create_stripe_account.exs
@@ -1,0 +1,29 @@
+defmodule CodeCorps.Repo.Migrations.CreateStripeAccount do
+  use Ecto.Migration
+
+  def change do
+    create table(:stripe_accounts) do
+      add :business_name, :string
+      add :business_url, :string
+      add :charges_enabled, :boolean
+      add :country, :string
+      add :default_currency, :string
+      add :details_submitted, :boolean
+      add :display_name, :string
+      add :email, :string
+      add :id_from_stripe, :string, null: false
+      add :managed, :boolean
+      add :support_email, :string
+      add :support_phone, :string
+      add :support_url, :string
+      add :transfers_enabled, :boolean
+
+      add :organization_id, references(:organizations), null: false
+
+      timestamps()
+    end
+
+    create unique_index(:stripe_accounts, [:id_from_stripe])
+    create unique_index(:stripe_accounts, [:organization_id])
+  end
+end

--- a/test/lib/code_corps/stripe/adapters/stripe_account_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_account_test.exs
@@ -1,0 +1,14 @@
+defmodule CodeCorps.Stripe.Adapters.StripeAccountTest do
+  use ExUnit.Case, async: true
+
+  import CodeCorps.Stripe.Adapters.StripeAccount, only: [params_from_stripe: 1]
+
+  @stripe_map %{"id" => "str_123", "foo" => "bar"}
+  @local_map %{"id_from_stripe" => "str_123", "foo" => "bar"}
+
+  describe "params_from_stripe/1" do
+    test "converts from stripe map to local properly" do
+      assert @stripe_map |> params_from_stripe == @local_map
+    end
+  end
+end

--- a/test/models/stripe_account_test.exs
+++ b/test/models/stripe_account_test.exs
@@ -1,0 +1,41 @@
+defmodule CodeCorps.StripeAccountTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.StripeAccount
+
+  @valid_attrs %{
+    id_from_stripe: "abc123"
+  }
+
+  @invalid_attrs %{}
+
+  describe "create_changeset/2" do
+    test "reports as valid when attributes are valid" do
+      organization_id = insert(:organization).id
+
+      changes = Map.merge(@valid_attrs, %{organization_id: organization_id})
+      changeset = StripeAccount.create_changeset(%StripeAccount{}, changes)
+      assert changeset.valid?
+    end
+
+    test "reports as invalid when attributes are invalid" do
+      changeset = StripeAccount.create_changeset(%StripeAccount{}, @invalid_attrs)
+      refute changeset.valid?
+
+      assert changeset.errors[:id_from_stripe] == {"can't be blank", []}
+      assert changeset.errors[:organization_id] == {"can't be blank", []}
+    end
+
+    test "ensures associations link to records that exist" do
+      attrs =  @valid_attrs |> Map.merge(%{organization_id: -1})
+
+      { result, changeset } =
+        StripeAccount.create_changeset(%StripeAccount{}, attrs)
+        |> Repo.insert
+
+      assert result == :error
+      refute changeset.valid?
+      assert changeset.errors[:organization] == {"does not exist", []}
+    end
+  end
+end

--- a/web/models/stripe_account.ex
+++ b/web/models/stripe_account.ex
@@ -1,0 +1,35 @@
+defmodule CodeCorps.StripeAccount do
+  @moduledoc """
+  Represents a StripeAccount stored on Code Corps.
+  """
+
+  use CodeCorps.Web, :model
+
+  schema "stripe_accounts" do
+    field :business_name, :string
+    field :business_url, :string
+    field :charges_enabled, :boolean
+    field :country, :string
+    field :default_currency, :string
+    field :details_submitted, :boolean
+    field :display_name, :string
+    field :email, :string
+    field :id_from_stripe, :string, null: false
+    field :managed, :boolean
+    field :support_email, :string
+    field :support_phone, :string
+    field :support_url, :string
+    field :transfers_enabled, :boolean
+
+    belongs_to :organization, CodeCorps.Organization
+
+    timestamps()
+  end
+
+  def create_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:id_from_stripe, :organization_id])
+    |> validate_required([:id_from_stripe, :organization_id])
+    |> assoc_constraint(:organization)
+  end
+end


### PR DESCRIPTION
Closes #362 

I'm not really sure if anything else should be done here for now. The changeset is pretty much a `no_op`, as is the one test that tests it.

Really, it was just a matter of adding the migration and the model.

We have a `belongs_to :organization`, but I did not add a `has_one :stripe_account` to the other side.
