### PR TITLE
Add StripePlan and StripeSubscription models

### DIFF
--- a/lib/code_corps/stripe/adapters/stripe_plan.ex
+++ b/lib/code_corps/stripe/adapters/stripe_plan.ex
@@ -1,0 +1,17 @@
+defmodule CodeCorps.Stripe.Adapters.StripePlan do
+  @moduledoc """
+  Used for conversion between stripe api payload maps and maps
+  usable for creation of `StripePlan` records locally
+  """
+
+  import CodeCorps.MapUtils, only: [rename: 3]
+
+  @doc """
+  Converts a map received from the Stripe API into a map that can be used
+  to create a `CodeCorps.StripePlan` record
+  """
+  def params_from_stripe(%{} = stripe_map) do
+    stripe_map
+    |> rename("id", "id_from_stripe")
+  end
+end

--- a/lib/code_corps/stripe/adapters/stripe_subscription.ex
+++ b/lib/code_corps/stripe/adapters/stripe_subscription.ex
@@ -1,0 +1,19 @@
+defmodule CodeCorps.Stripe.Adapters.StripeSubscription do
+  @moduledoc """
+  Used for conversion between stripe api payload maps and maps
+  usable for creation of StripeSubscription records locally
+  """
+
+  import CodeCorps.MapUtils, only: [rename: 3]
+
+  @doc """
+  Converts a map received from the Stripe API into a map that can be used
+  to create a `CodeCorps.StripeSubscription` record
+  """
+  def params_from_stripe(%{} = stripe_map) do
+    stripe_map
+    |> rename("id", "id_from_stripe")
+    |> rename("stripe_plan", "plan_id_from_stripe")
+    |> rename("customer", "customer_id_from_stripe")
+  end
+end

--- a/priv/repo/migrations/20161021131026_create_stripe_plans_stripe_subscriptions.exs
+++ b/priv/repo/migrations/20161021131026_create_stripe_plans_stripe_subscriptions.exs
@@ -1,0 +1,44 @@
+defmodule CodeCorps.Repo.Migrations.CreateStripePlansStripeSubscriptions do
+  use Ecto.Migration
+
+  def change do
+    create table(:stripe_plans) do
+      add :amount, :integer
+      add :created, :datetime
+      add :id_from_stripe, :string, null: false
+      add :name, :string
+
+      add :project_id, references(:projects), null: false
+
+      timestamps()
+    end
+
+    create unique_index(:stripe_plans, [:id_from_stripe])
+
+    create table(:stripe_subscriptions) do
+      add :application_fee_percent, :decimal
+      add :cancelled_at, :datetime
+      add :customer_id_from_stripe, :string
+      add :created, :datetime
+      add :current_period_end, :datetime
+      add :current_period_start, :datetime
+      add :ended_at, :datetime
+      add :id_from_stripe, :string, null: false
+      add :plan_id_from_stripe, :string, null: false
+      add :quantity, :integer
+      add :start, :datetime
+      add :status, :string
+
+      add :stripe_plan_id, references(:stripe_plans), null: false
+      add :user_id, references(:users)
+
+      timestamps()
+    end
+
+    create index(:stripe_subscriptions, [:plan_id_from_stripe])
+    create index(:stripe_subscriptions, [:stripe_plan_id])
+    create index(:stripe_subscriptions, [:user_id])
+
+    create unique_index(:stripe_subscriptions, [:id_from_stripe])
+  end
+end

--- a/test/lib/code_corps/stripe/adapters/stripe_plan_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_plan_test.exs
@@ -1,0 +1,14 @@
+defmodule CodeCorps.Stripe.Adapters.StripePlanTest do
+  use ExUnit.Case, async: true
+
+  import CodeCorps.Stripe.Adapters.StripePlan, only: [params_from_stripe: 1]
+
+  @stripe_map %{"id" => "str_123", "foo" => "bar"}
+  @local_map %{"id_from_stripe" => "str_123", "foo" => "bar"}
+
+  describe "params_from_stripe/1" do
+    test "converts from stripe map to local properly" do
+      assert @stripe_map |> params_from_stripe == @local_map
+    end
+  end
+end

--- a/test/lib/code_corps/stripe/adapters/stripe_subscription_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_subscription_test.exs
@@ -1,0 +1,14 @@
+defmodule CodeCorps.Stripe.Adapters.StripeSubscriptionTest do
+  use ExUnit.Case, async: true
+
+  import CodeCorps.Stripe.Adapters.StripeSubscription, only: [params_from_stripe: 1]
+
+  @stripe_map %{"id" => "str_123", "stripe_plan" => "pln_123", "foo" => "bar", "customer" => "cus_123"}
+  @local_map %{"id_from_stripe" => "str_123", "plan_id_from_stripe" => "pln_123", "foo" => "bar", "customer_id_from_stripe" => "cus_123"}
+
+  describe "params_from_stripe/1" do
+    test "converts from stripe map to local properly" do
+      assert @stripe_map |> params_from_stripe == @local_map
+    end
+  end
+end

--- a/test/models/stripe_plan_test.exs
+++ b/test/models/stripe_plan_test.exs
@@ -1,0 +1,41 @@
+defmodule CodeCorps.StripePlanTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.StripePlan
+
+  @valid_attrs %{
+    id_from_stripe: "abc123"
+  }
+
+  @invalid_attrs %{}
+
+  describe "create_changeset/2" do
+    test "reports as valid when attributes are valid" do
+      project_id = insert(:project).id
+
+      changes = Map.merge(@valid_attrs, %{project_id: project_id})
+      changeset = StripePlan.create_changeset(%StripePlan{}, changes)
+      assert changeset.valid?
+    end
+
+    test "reports as invalid when attributes are invalid" do
+      changeset = StripePlan.create_changeset(%StripePlan{}, @invalid_attrs)
+      refute changeset.valid?
+
+      assert changeset.errors[:id_from_stripe] == {"can't be blank", []}
+      assert changeset.errors[:project_id] == {"can't be blank", []}
+    end
+
+    test "ensures associations link to records that exist" do
+      attrs =  @valid_attrs |> Map.merge(%{project_id: -1})
+
+      { result, changeset } =
+        StripePlan.create_changeset(%StripePlan{}, attrs)
+        |> Repo.insert
+
+      assert result == :error
+      refute changeset.valid?
+      assert changeset.errors[:project] == {"does not exist", []}
+    end
+  end
+end

--- a/test/models/stripe_subscription_test.exs
+++ b/test/models/stripe_subscription_test.exs
@@ -1,0 +1,58 @@
+defmodule CodeCorps.StripeSubscriptionTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.StripeSubscription
+
+  @valid_attrs %{
+    id_from_stripe: "abc123",
+    plan_id_from_stripe: "abc123"
+  }
+
+  @invalid_attrs %{}
+
+  describe "create_changeset/2" do
+    test "reports as valid when attributes are valid" do
+      stripe_plan_id = insert(:stripe_plan).id
+      user_id = insert(:user).id
+
+      changes = Map.merge(@valid_attrs, %{stripe_plan_id: stripe_plan_id, user_id: user_id})
+      changeset = StripeSubscription.create_changeset(%StripeSubscription{}, changes)
+      assert changeset.valid?
+    end
+
+    test "reports as invalid when attributes are invalid" do
+      changeset = StripeSubscription.create_changeset(%StripeSubscription{}, @invalid_attrs)
+      refute changeset.valid?
+
+      assert changeset.errors[:id_from_stripe] == {"can't be blank", []}
+      assert changeset.errors[:plan_id_from_stripe] == {"can't be blank", []}
+      assert changeset.errors[:stripe_plan_id] == {"can't be blank", []}
+    end
+
+    test "ensures stripe_plan_id links to existing_record" do
+      user_id = insert(:user).id
+      attrs =  @valid_attrs |> Map.merge(%{stripe_plan_id: -1, user_id: user_id})
+
+      { result, changeset } =
+        StripeSubscription.create_changeset(%StripeSubscription{}, attrs)
+        |> Repo.insert
+
+      assert result == :error
+      refute changeset.valid?
+      assert changeset.errors[:stripe_plan] == {"does not exist", []}
+    end
+
+    test "ensures user_id links to existing_record" do
+      stripe_plan_id = insert(:stripe_plan).id
+      attrs =  @valid_attrs |> Map.merge(%{stripe_plan_id: stripe_plan_id, user_id: -1})
+
+      { result, changeset } =
+        StripeSubscription.create_changeset(%StripeSubscription{}, attrs)
+        |> Repo.insert
+
+      assert result == :error
+      refute changeset.valid?
+      assert changeset.errors[:user] == {"does not exist", []}
+    end
+  end
+end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -107,6 +107,13 @@ defmodule CodeCorps.Factories do
     }
   end
 
+  def stripe_plan_factory do
+    %CodeCorps.StripePlan{
+      id_from_stripe: sequence(:id_from_stripe, &"stripe_id_#{&1}"),
+      project: build(:project)
+    }
+  end
+
   def user_factory do
     %CodeCorps.User{
       username: sequence(:username, &"user#{&1}"),

--- a/web/models/stripe_plan.ex
+++ b/web/models/stripe_plan.ex
@@ -1,0 +1,32 @@
+defmodule CodeCorps.StripePlan do
+  @moduledoc """
+  Represents a `Plan` object created using the Stripe API
+
+  ## Fields
+  * `amount` - A positive integer, the amount in cents to be charged for this plan
+  * `created` - A timestamp, indicating when the plan was created by Stripe
+  * `id_from_stripe` - Stripe's `id`
+  * `name` - A friendly display name for the plan
+  """
+
+  use CodeCorps.Web, :model
+
+  schema "stripe_plans" do
+    field :amount, :integer
+    field :created, Ecto.DateTime
+    field :id_from_stripe, :string, null: false
+    field :name, :string
+
+    belongs_to :project, CodeCorps.Project
+
+    timestamps()
+  end
+
+  def create_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:id_from_stripe, :project_id])
+    |> validate_required([:id_from_stripe, :project_id])
+    |> unique_constraint(:id_from_stripe)
+    |> assoc_constraint(:project)
+  end
+end

--- a/web/models/stripe_subscription.ex
+++ b/web/models/stripe_subscription.ex
@@ -1,0 +1,61 @@
+defmodule CodeCorps.StripeSubscription do
+  @moduledoc """
+  Represents a `Subscription` object created using the Stripe API
+
+  ## Fields
+
+  * `application_fee_percent` - Percentage of fee taken by Code Corps
+  * `cancelled_at` - Timestamp of cancellation, provided the subscription has been cancelled
+  * `created` - A timestamp, indicating when the plan was created by Stripe
+  * `current_period_end` - End date of the period the subscription has been last invoiced for
+  * `current_period_start` - Start date of the period the subscription was last invoiced
+  * `customer_id_from_stripe` - Stripe's `customer_id`
+  * `ended_at` - End date, if the subscribtion has been ended (by cancelling or switching plans)
+  * `id_from_stripe` - Stripe's `id`
+  * `plan_id_from_stripe` - Stripe's plan `id`
+  * `quantity` - Quantity of the plan to subscribe to. For example, we have a $0.01 plan, which we subscribe in multiple quantities for.
+  * `start` - Date the most recent update to this subscription started
+  * `status` - trialing, active, past_due, canceled, or unpaid
+
+  ## Note on `status`
+
+  Subscriptioms start at `trialing` and then move on to active when trial period is over.
+  When `active`, if payment fails, it will go into `past_due`.
+  Once enough retry attempts failures occur,
+  it goes either to `cancelled` or `unpaid` depending on settings.
+  """
+
+  use CodeCorps.Web, :model
+
+  schema "stripe_subscriptions" do
+    field :application_fee_percent, :decimal
+    field :cancelled_at, Ecto.DateTime
+    field :created, Ecto.DateTime
+    field :current_period_end, Ecto.DateTime
+    field :current_period_start, Ecto.DateTime
+    field :customer_id_from_stripe, :string
+    field :ended_at, Ecto.DateTime
+    field :id_from_stripe, :string, null: false
+    field :plan_id_from_stripe, :string, null: false
+    field :quantity, :integer
+    field :start, Ecto.DateTime
+    field :status, :string
+
+    belongs_to :stripe_plan, CodeCorps.StripePlan
+    belongs_to :user, CodeCorps.User
+
+    timestamps()
+  end
+
+  @permitted_params [:customer_id_from_stripe, :id_from_stripe, :plan_id_from_stripe, :stripe_plan_id, :user_id]
+  @required_params [:id_from_stripe, :plan_id_from_stripe, :stripe_plan_id, :user_id]
+
+  def create_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @permitted_params)
+    |> validate_required(@required_params)
+    |> unique_constraint(:id_from_stripe)
+    |> assoc_constraint(:stripe_plan)
+    |> assoc_constraint(:user)
+  end
+end


### PR DESCRIPTION
Closes #361, #367 

Since a `StripeSubscription` is related to a `StripeCustomer`, we need to merge #377 before this can be merged. The lines of code that fail due to this have been commented out for now.

Instead of going with separate fields for stripe id and actual record id, I used the approach from #377 to make the id columns into strings.

Also similarly to #377, I created an adapter which does a minor conversion between a stripe payload for a Subscription into a locally compatible payload and back.
