### PR TITLE
Refactor comments controller to use new helpers

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -2259,10 +2259,10 @@ This endpoint allows you to check whether a username is valid (by running a vali
 
 ## Forbidden Response (object)
 + errors
+    + detail: `You are not authorized to perform this action.` (string)
     + id: `FORBIDDEN` (string)
-    + title: `Forbidden` (string)
-    + detail: `You are not authorized to perform this action on {subject_name}` (string) - Details of what record was not found.
     + status: 403 (number) - HTTP status code
+    + title: `403 Forbidden` (string)
 
 ## No Content Response (object)
 

--- a/test/controllers/category_controller_test.exs
+++ b/test/controllers/category_controller_test.exs
@@ -68,8 +68,8 @@ defmodule CodeCorps.CategoryControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
-      assert conn |> request_create(@valid_attrs) |> json_response(401)
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_create(@valid_attrs) |> json_response(403)
     end
   end
 
@@ -95,8 +95,8 @@ defmodule CodeCorps.CategoryControllerTest do
     end
 
     @tag :authenticated
-    test "does not update resource and renders 401 when not authorized", %{conn: conn} do
-      assert conn |> request_update(@valid_attrs) |> json_response(401)
+    test "does not update resource and renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_update(@valid_attrs) |> json_response(403)
     end
   end
 end

--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -1,13 +1,11 @@
 defmodule CodeCorps.CommentControllerTest do
-  use CodeCorps.ApiCase
+  use CodeCorps.ApiCase, resource_name: :comment
 
   alias CodeCorps.Comment
   alias CodeCorps.Repo
 
   @valid_attrs %{markdown: "I love elixir!"}
   @invalid_attrs %{markdown: ""}
-
-  defp build_payload, do: %{ "data" => %{"type" => "comment"}}
 
   describe "index" do
     test "lists all entries on index", %{conn: conn} do
@@ -34,23 +32,15 @@ defmodule CodeCorps.CommentControllerTest do
   describe "show" do
     test "shows chosen resource", %{conn: conn} do
       comment = insert(:comment)
-
-      path = conn |> comment_path(:show, comment)
-      conn = conn |> get(path)
-
-      data = json_response(conn, 200)["data"]
-
-      assert data["id"] == "#{comment.id}"
-      assert data["type"] == "comment"
-      assert data["attributes"]["body"] == comment.body
-      assert data["attributes"]["markdown"] == comment.markdown
-      assert data["relationships"]["user"]["data"]["id"] == "#{comment.user_id}"
-      assert data["relationships"]["task"]["data"]["id"] == "#{comment.task_id}"
+      conn
+      |> request_show(comment)
+      |> json_response(200)
+      |> Map.get("data")
+      |> assert_result_id(comment.id)
     end
 
     test "renders 404 when id is nonexistent", %{conn: conn} do
-      path = conn |> comment_path(:show, -1)
-      assert conn |> get(path) |> json_response(404)
+      assert conn |> request_show(:not_found) |> json_response(404)
     end
   end
 
@@ -58,63 +48,26 @@ defmodule CodeCorps.CommentControllerTest do
     @tag :authenticated
     test "creates and renders resource when data is valid", %{conn: conn, current_user: current_user} do
       task = insert(:task)
-
-      payload =
-        build_payload
-        |> put_attributes(@valid_attrs)
-        |> put_relationships(current_user, task)
-
-      path = conn |> comment_path(:create)
-      conn = conn |> post(path, payload)
-
-      assert json_response(conn, 201)["data"]["id"]
+      attrs = @valid_attrs |> Map.merge(%{task: task, user: current_user})
+      json = conn |> request_create(attrs) |> json_response(201)
+      assert json["data"]["id"]
       assert Repo.get_by(Comment, @valid_attrs)
     end
 
     @tag :authenticated
     test "does not create resource and renders errors when data is invalid", %{conn: conn, current_user: current_user} do
-      task = insert(:task)
-
-      payload =
-        build_payload
-        |> put_attributes(@invalid_attrs)
-        |> put_relationships(current_user, task)
-
-      path = conn |> comment_path(:create)
-      conn = conn |> post(path, payload)
-
-      assert json_response(conn, 422)["errors"] != %{}
+      attrs = @invalid_attrs |> Map.merge(%{user: current_user})
+      json = conn |> request_create(attrs) |> json_response(422)
+      assert json["errors"] != %{}
     end
 
     test "does not create resource and renders 401 when not authenticated", %{conn: conn} do
-      user = insert(:user)
-      task = insert(:task)
-
-      payload =
-        build_payload
-        |> put_attributes(@valid_attrs)
-        |> put_relationships(user, task)
-
-      path = conn |> comment_path(:create)
-      conn = conn |> post(path, payload)
-
-      assert json_response(conn, 401)
+      assert conn |> request_create(@valid_attrs) |> json_response(401)
     end
 
     @tag :authenticated
     test "does not create resource and renders 401 when not authorized", %{conn: conn} do
-      comment_user = insert(:user)
-      task = insert(:task)
-
-      payload =
-        build_payload
-        |> put_attributes(@valid_attrs)
-        |> put_relationships(comment_user, task)
-
-      path = conn |> comment_path(:create)
-      conn = conn |> post(path, payload)
-
-      assert json_response(conn, 401)
+      assert conn |> request_create(@valid_attrs) |> json_response(401)
     end
   end
 
@@ -122,61 +75,27 @@ defmodule CodeCorps.CommentControllerTest do
     @tag :authenticated
     test "updates and renders chosen resource when data is valid", %{conn: conn, current_user: current_user} do
       comment = insert(:comment, user: current_user)
-
-      payload =
-        build_payload
-        |> put_id(comment.id)
-        |> put_attributes(@valid_attrs)
-
-      path = conn |> comment_path(:update, comment)
-      conn = conn |> put(path, payload)
-
-      assert json_response(conn, 200)["data"]["id"]
+      attrs = @valid_attrs |> Map.merge(%{user: current_user})
+      json = conn |> request_update(comment, attrs) |> json_response(200)
+      assert json["data"]["id"]
       assert Repo.get_by(Comment, @valid_attrs)
     end
 
     @tag :authenticated
     test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, current_user: current_user} do
       comment = insert(:comment, user: current_user)
-
-      payload =
-        build_payload
-        |> put_id(comment.id)
-        |> put_attributes(@invalid_attrs)
-
-      path = conn |> comment_path(:update, comment)
-      conn = conn |> put(path, payload)
-
-      assert json_response(conn, 422)["errors"] != %{}
+      attrs = @invalid_attrs |> Map.merge(%{user: current_user})
+      json = conn |> request_update(comment, attrs) |> json_response(422)
+      assert json["errors"] != %{}
     end
 
     test "does not update resource and renders 401 when not authenticated", %{conn: conn} do
-      comment = insert(:comment)
-
-      payload =
-        build_payload
-        |> put_id(comment.id)
-        |> put_attributes(@valid_attrs)
-
-      path = conn |> comment_path(:update, comment)
-      conn = conn |> put(path, payload)
-
-      assert json_response(conn, 401)
+      assert conn |> request_update(@valid_attrs) |> json_response(401)
     end
 
     @tag :authenticated
     test "does not update resource and renders 401 when not authorized", %{conn: conn} do
-      comment = insert(:comment)
-
-      payload =
-        build_payload
-        |> put_id(comment.id)
-        |> put_attributes(@valid_attrs)
-
-      path = conn |> comment_path(:update, comment)
-      conn = conn |> put(path, payload)
-
-      assert json_response(conn, 401)
+      assert conn |> request_update(@valid_attrs) |> json_response(401)
     end
   end
 end

--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -49,9 +49,7 @@ defmodule CodeCorps.CommentControllerTest do
     test "creates and renders resource when data is valid", %{conn: conn, current_user: current_user} do
       task = insert(:task)
       attrs = @valid_attrs |> Map.merge(%{task: task, user: current_user})
-      json = conn |> request_create(attrs) |> json_response(201)
-      assert json["data"]["id"]
-      assert Repo.get_by(Comment, @valid_attrs)
+      assert conn |> request_create(attrs) |> json_response(201)
     end
 
     @tag :authenticated
@@ -66,8 +64,8 @@ defmodule CodeCorps.CommentControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
-      assert conn |> request_create(@valid_attrs) |> json_response(401)
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_create(@valid_attrs) |> json_response(403)
     end
   end
 
@@ -76,9 +74,7 @@ defmodule CodeCorps.CommentControllerTest do
     test "updates and renders chosen resource when data is valid", %{conn: conn, current_user: current_user} do
       comment = insert(:comment, user: current_user)
       attrs = @valid_attrs |> Map.merge(%{user: current_user})
-      json = conn |> request_update(comment, attrs) |> json_response(200)
-      assert json["data"]["id"]
-      assert Repo.get_by(Comment, @valid_attrs)
+      assert conn |> request_update(comment, attrs) |> json_response(200)
     end
 
     @tag :authenticated
@@ -94,8 +90,8 @@ defmodule CodeCorps.CommentControllerTest do
     end
 
     @tag :authenticated
-    test "does not update resource and renders 401 when not authorized", %{conn: conn} do
-      assert conn |> request_update(@valid_attrs) |> json_response(401)
+    test "does not update resource and renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_update(@valid_attrs) |> json_response(403)
     end
   end
 end

--- a/test/controllers/donation_goal_controller_test.exs
+++ b/test/controllers/donation_goal_controller_test.exs
@@ -51,8 +51,8 @@ defmodule CodeCorps.DonationGoalControllerTest do
     end
 
     @tag :authenticated
-    test "renders 401 when not authorized", %{conn: conn} do
-      assert conn |> request_create(@valid_attrs) |> json_response(401)
+    test "renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_create(@valid_attrs) |> json_response(403)
     end
   end
 
@@ -80,8 +80,8 @@ defmodule CodeCorps.DonationGoalControllerTest do
     end
 
     @tag :authenticated
-    test "renders 401 when not authorized", %{conn: conn} do
-      assert conn |> request_update(@valid_attrs) |> json_response(401)
+    test "renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_update(@valid_attrs) |> json_response(403)
     end
   end
 
@@ -103,8 +103,8 @@ defmodule CodeCorps.DonationGoalControllerTest do
     end
 
     @tag :authenticated
-    test "renders 401 when not authorized", %{conn: conn} do
-      assert conn |> request_delete |> json_response(401)
+    test "renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_delete |> json_response(403)
     end
   end
 end

--- a/test/controllers/organization_controller_test.exs
+++ b/test/controllers/organization_controller_test.exs
@@ -97,7 +97,7 @@ defmodule CodeCorps.OrganizationControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       payload =
         build_payload
         |> put_attributes(@invalid_attrs)
@@ -105,7 +105,7 @@ defmodule CodeCorps.OrganizationControllerTest do
       path = conn |> organization_path(:create)
       conn = conn |> post(path, payload)
 
-      assert json_response(conn, 401)
+      assert json_response(conn, 403)
     end
   end
 
@@ -158,7 +158,7 @@ defmodule CodeCorps.OrganizationControllerTest do
     end
 
     @tag :authenticated
-    test "does not update resource and renders 401 when not authorized", %{conn: conn, current_user: current_user} do
+    test "does not update resource and renders 403 when not authorized", %{conn: conn, current_user: current_user} do
       organization = insert(:organization)
       insert(:organization_membership, organization: organization, member: current_user, role: "member")
 
@@ -170,7 +170,7 @@ defmodule CodeCorps.OrganizationControllerTest do
       path = conn |> organization_path(:update, organization)
       conn = conn |> put(path, payload)
 
-      assert json_response(conn, 401)
+      assert json_response(conn, 403)
     end
 
     @tag :requires_env

--- a/test/controllers/organization_membership_controller_test.exs
+++ b/test/controllers/organization_membership_controller_test.exs
@@ -145,7 +145,7 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
     end
 
     @tag :authenticated
-    test "doesn't update and renders 401 when not authorized", %{conn: conn} do
+    test "doesn't update and renders 403 when not authorized", %{conn: conn} do
       membership = insert(:organization_membership)
 
       payload =
@@ -156,7 +156,7 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
       path = conn |> organization_membership_path(:update, membership)
       conn = conn |> put(path, payload)
 
-      assert conn |> json_response(401)
+      assert conn |> json_response(403)
     end
 
     @tag :authenticated
@@ -192,7 +192,7 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
     end
 
     @tag :authenticated
-    test "doesn't delete and renders 401 when not authorized", %{conn: conn} do
+    test "doesn't delete and renders 403 when not authorized", %{conn: conn} do
       membership = insert(:organization_membership)
 
       payload =
@@ -203,7 +203,7 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
       path = conn |> organization_membership_path(:delete, membership)
       conn = conn |> delete(path, payload)
 
-      assert conn |> json_response(401)
+      assert conn |> json_response(403)
     end
 
     @tag :authenticated

--- a/test/controllers/project_category_controller_test.exs
+++ b/test/controllers/project_category_controller_test.exs
@@ -108,7 +108,7 @@ defmodule CodeCorps.ProjectCategoryControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn, current_user: current_user} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn, current_user: current_user} do
       organization = insert(:organization)
       project = insert(:project, organization: organization)
       category = insert(:category)
@@ -117,7 +117,7 @@ defmodule CodeCorps.ProjectCategoryControllerTest do
       payload = build_payload |> put_relationships(project, category)
 
       path = conn |> project_category_path(:create)
-      assert conn |> post(path, payload) |> json_response(401)
+      assert conn |> post(path, payload) |> json_response(403)
     end
   end
 
@@ -142,10 +142,10 @@ defmodule CodeCorps.ProjectCategoryControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       project_category = insert(:project_category)
       path = conn |> project_category_path(:delete, project_category)
-      assert conn |> delete(path) |> json_response(401)
+      assert conn |> delete(path) |> json_response(403)
     end
 
     @tag :authenticated

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -155,7 +155,7 @@ defmodule CodeCorps.ProjectControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn, current_user: current_user} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn, current_user: current_user} do
       organization = insert(:organization)
       insert(:organization_membership, role: "contributor", member: current_user, organization: organization)
 
@@ -165,7 +165,7 @@ defmodule CodeCorps.ProjectControllerTest do
         |> put_relationships(organization)
 
       path = conn |> project_path(:create)
-      assert conn |> post(path, payload) |> json_response(401)
+      assert conn |> post(path, payload) |> json_response(403)
     end
   end
 
@@ -232,10 +232,10 @@ defmodule CodeCorps.ProjectControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       project = insert(:project)
       path = conn |> project_path(:update, project)
-      assert conn |> put(path) |> json_response(401)
+      assert conn |> put(path) |> json_response(403)
     end
 
     @tag :authenticated

--- a/test/controllers/project_skill_controller_test.exs
+++ b/test/controllers/project_skill_controller_test.exs
@@ -101,7 +101,7 @@ defmodule CodeCorps.ProjectSkillControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn, current_user: current_user} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn, current_user: current_user} do
       organization = insert(:organization)
       project = insert(:project, organization: organization)
       skill = insert(:skill)
@@ -111,7 +111,7 @@ defmodule CodeCorps.ProjectSkillControllerTest do
       payload = build_payload |> put_relationships(project, skill)
 
       path = conn |> project_skill_path(:create)
-      assert conn |> post(path, payload) |> json_response(401)
+      assert conn |> post(path, payload) |> json_response(403)
     end
   end
 
@@ -130,10 +130,10 @@ defmodule CodeCorps.ProjectSkillControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       project_skill = insert(:project_skill)
       path = conn |> project_skill_path(:delete, project_skill)
-      assert conn |> delete(path) |> json_response(401)
+      assert conn |> delete(path) |> json_response(403)
     end
 
     @tag :authenticated

--- a/test/controllers/role_controller_test.exs
+++ b/test/controllers/role_controller_test.exs
@@ -45,10 +45,10 @@ defmodule CodeCorps.RoleControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       path = conn |> role_path(:create)
       payload = build_payload |> put_attributes(@valid_attrs)
-      assert conn |> post(path, payload) |> json_response(401)
+      assert conn |> post(path, payload) |> json_response(403)
     end
   end
 end

--- a/test/controllers/role_skill_controller_test.exs
+++ b/test/controllers/role_skill_controller_test.exs
@@ -75,9 +75,9 @@ defmodule CodeCorps.RoleSkillControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       path = conn |> role_skill_path(:create)
-      assert conn |> post(path) |> json_response(401)
+      assert conn |> post(path) |> json_response(403)
     end
   end
 
@@ -133,10 +133,10 @@ defmodule CodeCorps.RoleSkillControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       role_skill = insert(:role_skill)
       path = conn |> role_skill_path(:delete, role_skill)
-      assert conn |> delete(path) |> json_response(401)
+      assert conn |> delete(path) |> json_response(403)
     end
 
     @tag :authenticated

--- a/test/controllers/skill_controller_test.exs
+++ b/test/controllers/skill_controller_test.exs
@@ -115,10 +115,10 @@ defmodule CodeCorps.SkillControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       path = conn |> skill_path(:create)
       payload = build_payload |> put_attributes(@valid_attrs)
-      assert conn |> post(path, payload) |> json_response(401)
+      assert conn |> post(path, payload) |> json_response(403)
     end
   end
 end

--- a/test/controllers/stripe_auth_controller_test.exs
+++ b/test/controllers/stripe_auth_controller_test.exs
@@ -23,11 +23,11 @@ defmodule CodeCorps.StripeAuthControllerTest do
 
     @tag :requires_env
     @tag :authenticated
-    test "renders a 401 when not authorized", %{conn: conn} do
+    test "renders a 403 when not authorized", %{conn: conn} do
       project = insert(:project)
 
       conn = get conn, stripe_auth_path(conn, :stripe_auth, project)
-      assert json_response(conn, 401)
+      assert json_response(conn, 403)
     end
   end
 end

--- a/test/controllers/task_controller_test.exs
+++ b/test/controllers/task_controller_test.exs
@@ -226,12 +226,12 @@ defmodule CodeCorps.TaskControllerTest do
     end
 
     @tag :authenticated
-    test "does not update resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not update resource and renders 403 when not authorized", %{conn: conn} do
       task = insert(:task)
       payload = build_payload |> put_id(task.id) |> put_attributes(@invalid_attrs)
 
       path = conn |> task_path(:update, task)
-      assert conn |> put(path, payload) |> json_response(401)
+      assert conn |> put(path, payload) |> json_response(403)
     end
   end
 

--- a/test/controllers/token_controller_test.exs
+++ b/test/controllers/token_controller_test.exs
@@ -34,7 +34,7 @@ defmodule CodeCorps.TokenControllerTest do
       response = json_response(conn, 401)
       [error | _] = response["errors"]
       assert error["detail"] == "Your password doesn't match the email #{user.email}."
-      assert is_unauthorized?(error)
+      assert renders_401_unauthorized?(error)
       refute response["token"]
       refute response["user_id"]
     end
@@ -45,7 +45,7 @@ defmodule CodeCorps.TokenControllerTest do
       response = json_response(conn, 401)
       [error | _] = response["errors"]
       assert error["detail"] == "We couldn't find a user with the email notauser@test.com."
-      assert is_unauthorized?(error)
+      assert renders_401_unauthorized?(error)
       refute response["token"]
       refute response["user_id"]
     end
@@ -73,11 +73,11 @@ defmodule CodeCorps.TokenControllerTest do
       refute response["token"]
       refute response["user_id"]
       [error | _] = response["errors"]
-      assert is_unauthorized?(error)
+      assert renders_401_unauthorized?(error)
       assert error["detail"] == "token_expired"
     end
   end
 
-  defp is_unauthorized?(%{"id" => "UNAUTHORIZED", "title" => "401 Unauthorized", "status" => 401}), do: true
-  defp is_unauthorized?(_), do: false
+  defp renders_401_unauthorized?(%{"id" => "UNAUTHORIZED", "title" => "401 Unauthorized", "status" => 401}), do: true
+  defp renders_401_unauthorized?(_), do: false
 end

--- a/test/controllers/user_category_controller_test.exs
+++ b/test/controllers/user_category_controller_test.exs
@@ -92,9 +92,9 @@ defmodule CodeCorps.UserCategoryControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       path = conn |> user_category_path(:create)
-      assert conn |> post(path, build_payload) |> json_response(401)
+      assert conn |> post(path, build_payload) |> json_response(403)
     end
   end
 
@@ -112,10 +112,10 @@ defmodule CodeCorps.UserCategoryControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       user_category = insert(:user_category)
       path = conn |> user_category_path(:delete, user_category)
-      assert conn |> delete(path) |> json_response(401)
+      assert conn |> delete(path) |> json_response(403)
     end
 
     @tag :authenticated

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -198,7 +198,7 @@ defmodule CodeCorps.UserControllerTest do
         |> authenticate(another_user)
         |> put(path, params)
 
-      assert json_response(conn, 401)
+      assert json_response(conn, 403)
     end
 
     @tag :requires_env

--- a/test/controllers/user_role_controller_test.exs
+++ b/test/controllers/user_role_controller_test.exs
@@ -89,9 +89,9 @@ defmodule CodeCorps.UserRoleControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       path = conn |> user_role_path(:create)
-      assert conn |> post(path, build_payload) |> json_response(401)
+      assert conn |> post(path, build_payload) |> json_response(403)
     end
   end
 
@@ -110,10 +110,10 @@ defmodule CodeCorps.UserRoleControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       user_role = insert(:user_role)
       path = conn |> user_role_path(:delete, user_role)
-      assert conn |> delete(path) |> json_response(401)
+      assert conn |> delete(path) |> json_response(403)
     end
 
     @tag :authenticated

--- a/test/controllers/user_skill_controller_test.exs
+++ b/test/controllers/user_skill_controller_test.exs
@@ -89,9 +89,9 @@ defmodule CodeCorps.UserSkillControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       path = conn |> user_skill_path(:create)
-      assert conn |> post(path, build_payload) |> json_response(401)
+      assert conn |> post(path, build_payload) |> json_response(403)
     end
   end
 
@@ -109,10 +109,10 @@ defmodule CodeCorps.UserSkillControllerTest do
     end
 
     @tag :authenticated
-    test "does not create resource and renders 401 when not authorized", %{conn: conn} do
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
       user_skill = insert(:user_skill)
       path = conn |> user_skill_path(:delete, user_skill)
-      assert conn |> delete(path) |> json_response(401)
+      assert conn |> delete(path) |> json_response(403)
     end
 
     @tag :authenticated

--- a/test/views/token_view_test.exs
+++ b/test/views/token_view_test.exs
@@ -17,10 +17,10 @@ defmodule CodeCorps.TokenViewTest do
     assert expected_json == rendered_json
   end
 
-  test "renders error" do
+  test "renders 401" do
     message = "Silly wabbit, Trix are for kids!"
 
-    rendered_json = render(CodeCorps.TokenView, "error.json", %{message: message})
+    rendered_json = render(CodeCorps.TokenView, "401.json", %{message: message})
 
     expected_json = %{
       errors: [
@@ -29,6 +29,25 @@ defmodule CodeCorps.TokenViewTest do
           title: "401 Unauthorized",
           detail: message,
           status: 401
+        }
+      ]
+    }
+
+    assert expected_json == rendered_json
+  end
+
+  test "renders 403" do
+    message = "Silly wabbit, Trix are for kids!"
+
+    rendered_json = render(CodeCorps.TokenView, "403.json", %{message: message})
+
+    expected_json = %{
+      errors: [
+        %{
+          id: "FORBIDDEN",
+          title: "403 Forbidden",
+          detail: message,
+          status: 403
         }
       ]
     }

--- a/web/controllers/token_controller.ex
+++ b/web/controllers/token_controller.ex
@@ -16,7 +16,7 @@ defmodule CodeCorps.TokenController do
         |> put_status(:created)
         |> render("show.json", token: token, user_id: user.id)
 
-      {:error, reason} -> handle_unauthorized(conn, reason)
+      {:error, reason} -> handle_unauthenticated(conn, reason)
     end
   end
 
@@ -29,14 +29,14 @@ defmodule CodeCorps.TokenController do
             |> put_status(:created)
             |> render("show.json", token: new_token, user_id: user.id)
     else
-      {:error, reason} -> handle_unauthorized(conn, reason)
+      {:error, reason} -> handle_unauthenticated(conn, reason)
     end
   end
 
-  defp handle_unauthorized(conn, reason) do
+  defp handle_unauthenticated(conn, reason) do
     conn
     |> put_status(:unauthorized)
-    |> render("error.json", message: reason)
+    |> render("401.json", message: reason)
   end
 
   defp login_by_email_and_pass(%{"username" => email, "password" => password}) do

--- a/web/helpers/authentication_helpers.ex
+++ b/web/helpers/authentication_helpers.ex
@@ -10,8 +10,8 @@ defmodule CodeCorps.AuthenticationHelpers do
   def handle_unauthorized(conn = %{assigns: %{authorized: true}}), do: conn
   def handle_unauthorized(conn = %{assigns: %{authorized: false}}) do
     conn
-    |> put_status(401)
-    |> render(CodeCorps.TokenView, "error.json", message: "Not authorized")
+    |> put_status(403)
+    |> render(CodeCorps.TokenView, "403.json", message: "You are not authorized to perform this action.")
     |> halt
   end
 

--- a/web/views/token_view.ex
+++ b/web/views/token_view.ex
@@ -8,7 +8,7 @@ defmodule CodeCorps.TokenView do
     }
   end
 
-  def render("error.json", %{message: message}) do
+  def render("401.json", %{message: message}) do
     %{
       errors: [
         %{
@@ -16,6 +16,19 @@ defmodule CodeCorps.TokenView do
           title: "401 Unauthorized",
           detail: message,
           status: 401,
+        }
+      ]
+    }
+  end
+
+  def render("403.json", %{message: message}) do
+    %{
+      errors: [
+        %{
+          id: "FORBIDDEN",
+          title: "403 Forbidden",
+          detail: message,
+          status: 403,
         }
       ]
     }


### PR DESCRIPTION
# What's in this PR?

Refactoring to use `CodeCorps.ApiCase` request helper functions.

Also _finally_ fixes 401 "unauthorized" to really render as 403 forbidden.
