### PR TITLE
Refactor Preview Controller Test with Helpers

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -169,6 +169,14 @@ You can list all comments or retrieve individual comments, as well as create and
 
     + Attributes (Comment Response)
 
++ Response 401 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (JSON Web Token Invalid Response)
+
++ Response 403 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Forbidden Response)
+
 + Response 422 (application/vnd.api+json; charset=utf-8)
 
     + Attributes (Unprocessable Entity Response)
@@ -622,6 +630,10 @@ Preview resources allow a user to create a temporary HTML preview for any kind o
 + Response 401 (application/vnd.api+json; charset=utf-8)
 
     + Attributes (JSON Web Token Invalid Response)
+
++ Response 403 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Forbidden Response)
 
 + Response 422 (application/vnd.api+json; charset=utf-8)
 

--- a/test/controllers/preview_controller_test.exs
+++ b/test/controllers/preview_controller_test.exs
@@ -1,53 +1,24 @@
 defmodule CodeCorps.PreviewControllerTest do
-  use CodeCorps.ApiCase
+  use CodeCorps.ApiCase, resource_name: :preview
 
   alias CodeCorps.Preview
 
-  defp build_payload do
-    %{"data" => %{"type" => "preview", "attributes" => %{markdown: "A **strong** element"}}}
-  end
+  @valid_attrs %{markdown: "A **strong** element"}
 
   describe "create" do
     @tag :authenticated
-    test "creates and renders resource, with body containing markdown rendered to html", %{conn: conn, current_user: current_user} do
-      payload = build_payload |> put_relationships(current_user)
-      path = conn |> preview_path(:create)
-      json = conn |> post(path, payload) |> json_response(201)
-
-      id = json["data"]["id"] |> String.to_integer
-
-      assert id
-
-      attributes = json["data"]["attributes"]
-
-      assert attributes["body"] == "<p>A <strong>strong</strong> element</p>\n"
-      assert attributes["markdown"] == "A **strong** element"
-
-      preview = Preview |> Repo.get(id)
-
-      assert preview.body == "<p>A <strong>strong</strong> element</p>\n"
-      assert preview.markdown == "A **strong** element"
-    end
-
-    @tag :authenticated
-    test "it assigns current user as owner of preview, if available", %{conn: conn, current_user: current_user} do
-      payload = build_payload |> put_relationships(current_user)
-      path = conn |> preview_path(:create)
-      json = conn |> post(path, payload) |> json_response(201)
-
-
-      id = json["data"]["id"] |> String.to_integer
-
-      preview = Preview |> Repo.get(id)
-
-      assert preview.user_id == current_user.id
+    test "creates and renders resource when data is valid", %{conn: conn, current_user: current_user} do
+      attrs = @valid_attrs |> Map.merge(%{user: current_user})
+      assert conn |> request_create(attrs) |> json_response(201)
     end
 
     test "does not create resource, and responds with 401 when unauthenticated", %{conn: conn} do
-      payload = build_payload
-      path = conn |> preview_path(:create)
-      assert conn |> post(path, payload) |> json_response(401)
+      assert conn |> request_create(@valid_attrs) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not update resource and renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_create(@valid_attrs) |> json_response(403)
     end
   end
-
 end


### PR DESCRIPTION
# What's in this PR?

Refactored the preview controller test to use CodeCorps.ApiCase request helper functions.

Added 401/403 Response to comment endpoint for create. 

## References
Fixes: #406

