### PR TITLE
Refactoring request_create test helper to include default attrs

### DIFF
--- a/test/support/api_case.ex
+++ b/test/support/api_case.ex
@@ -104,7 +104,7 @@ defmodule CodeCorps.ApiCase do
         conn |> get(path)
       end
 
-      def request_create(conn, attrs) do
+      def request_create(conn, attrs \\ %{}) do
         path = conn |> path_for(:create)
         payload = json_payload(factory_name, attrs)
         conn |> post(path, payload)


### PR DESCRIPTION
# What's in this PR?

Added default attributes to the request_create function in api_case.ex in order to assist with controller test refactoring.

## References
Suggested by @sbatson5 in comments on PR #420 

Progress on: #413 

