### PR TITLE
Refactoring request_update test helper to include default attrs

### DIFF
--- a/test/support/api_case.ex
+++ b/test/support/api_case.ex
@@ -111,7 +111,7 @@ defmodule CodeCorps.ApiCase do
       end
 
       def request_update(conn, :not_found), do: conn |> request_update(-1, %{})
-      def request_update(conn, attrs), do: conn |> request_update(default_record, attrs)
+      def request_update(conn, attrs \\ %{}), do: conn |> request_update(default_record, attrs)
       def request_update(conn, resource_or_id, attrs) do
         payload = json_payload(factory_name, attrs)
         path = conn |> path_for(:update, resource_or_id)


### PR DESCRIPTION
# What's in this PR?

Added default attributes to the request_update function in api_case.ex in order to assist with controller test refactoring.

## References

Progress on: #413

