### PR TITLE
Write Policy for Stripe Account

### DIFF
--- a/lib/code_corps/helpers/policy.ex
+++ b/lib/code_corps/helpers/policy.ex
@@ -6,7 +6,7 @@ defmodule CodeCorps.Helpers.Policy do
 
   import Ecto.Query
 
-  alias CodeCorps.{Organization, OrganizationMembership, Project, Repo, User}
+  alias CodeCorps.{Organization, OrganizationMembership, Project, Repo, StripeAccount, User}
   alias Ecto.Changeset
 
   @doc """
@@ -24,6 +24,7 @@ defmodule CodeCorps.Helpers.Policy do
     |> where([m], m.member_id == ^user_id and m.organization_id == ^organization_id)
     |> Repo.one
   end
+  def get_membership(%StripeAccount{organization_id: organization_id}, %User{id: user_id}), do: do_get_membership(organization_id, user_id)
 
   @doc """
   Retrieves a project record, from a model struct, or an `Ecto.Changeset` containing a `project_id` field

--- a/test/policies/stripe_account_policy_test.exs
+++ b/test/policies/stripe_account_policy_test.exs
@@ -1,0 +1,64 @@
+defmodule CodeCorps.StripeAccountPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.StripeAccount
+  import CodeCorps.StripeAccountPolicy, only: [show?: 2]
+
+  alias CodeCorps.StripeAccount
+
+  describe "show?" do
+    test "returns true when user is an admin" do
+      user = build(:user, admin: true)
+      stripe_account = insert(:stripe_account)
+
+      assert show?(user, stripe_account)
+    end
+
+    test "returns true when user is owner of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "owner", member: user, organization: organization)
+
+      stripe_account = insert(:stripe_account, organization: organization)
+
+      assert show?(user, stripe_account)
+    end
+
+    test "returns false when user is admin of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "admin", member: user)
+
+      stripe_account = insert(:stripe_account, organization: organization)
+
+      refute show?(user, stripe_account)
+    end
+
+    test "returns false when user is not member of organization" do
+      user = insert(:user)
+      stripe_account = insert(:stripe_account)
+
+      refute show?(user, stripe_account)
+    end
+
+    test "returns false when user is pending member of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "pending", member: user)
+
+      stripe_account = insert(:stripe_account, organization: organization)
+
+      refute show?(user, stripe_account)
+    end
+
+    test "returns false when user is contributor of organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_membership, role: "contributor", member: user)
+
+      stripe_account = insert(:stripe_account, organization: organization)
+
+      refute show?(user, stripe_account)
+    end
+  end
+end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -105,6 +105,13 @@ defmodule CodeCorps.Factories do
     }
   end
 
+  def stripe_account_factory do
+    %CodeCorps.StripeAccount{
+      id_from_stripe: sequence(:id_from_stripe, &"stripe_id_#{&1}"),
+      organization: build(:organization),
+    }
+  end
+
   def stripe_customer_factory do
     %CodeCorps.StripeCustomer{
       created: Timex.now,

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -12,6 +12,7 @@ defmodule Canary.Abilities do
   alias CodeCorps.Role
   alias CodeCorps.RoleSkill
   alias CodeCorps.Skill
+  alias CodeCorps.StripeAccount
   alias CodeCorps.StripeCustomer
   alias CodeCorps.User
   alias CodeCorps.UserCategory
@@ -91,6 +92,8 @@ defmodule Canary.Abilities do
     def can?(%User{} = user, :delete, %RoleSkill{}), do: RoleSkillPolicy.delete?(user)
 
     def can?(%User{} = user, :create, Skill), do: SkillPolicy.create?(user)
+
+    def can?(%User{} = user, :show, %StripeAccount{}=stripe_account), do: StripeAccountPolicy.show?(user, stripe_account)
 
     def can?(%User{} = user, :create, %Changeset{data: %StripeCustomer{}} = changeset), do: StripeCustomerPolicy.create?(user, changeset)
     def can?(%User{} = user, :show, %StripeCustomer{} = stripe_customer), do: StripeCustomerPolicy.show?(user, stripe_customer)

--- a/web/policies/stripe_account_policy.ex
+++ b/web/policies/stripe_account_policy.ex
@@ -1,0 +1,13 @@
+defmodule CodeCorps.StripeAccountPolicy do
+  import CodeCorps.Helpers.Policy,
+    only: [get_membership: 2, get_role: 1, owner?: 1]
+
+  alias CodeCorps.StripeAccount
+  alias CodeCorps.User
+  alias CodeCorps.OrganizationMembership
+  alias Ecto.Changeset
+
+  def show?(%User{admin: true}, %StripeAccount{}), do: true
+  def show?(%User{} = user, %StripeAccount{} = stripe_account), do: stripe_account |> get_membership(user) |> get_role |> owner?
+  def show?(%User{}, %StripeAccount{}), do: false
+end


### PR DESCRIPTION
# What's in this PR?

Added Stripe Account policy to ability.ex, stripe_account_policy.ex, factory, and tests to stripe_account_policy_test.

Currently on hold until the index: filter question has been resolved. See comments for more information.

## References
Fixes #450 

Progress on: #447 
