### PR TITLE
Write policies and endpoints for StripeCustomer

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -12,7 +12,6 @@ config :code_corps, CodeCorps.Endpoint,
   code_reloader: true,
   check_origin: false
 
-
 # Watch static and templates for browser reloading.
 config :code_corps, CodeCorps.Endpoint,
   live_reload: [
@@ -47,6 +46,7 @@ config :guardian, Guardian,
   secret_key: "e62fb6e2746f6b1bf8b5b735ba816c2eae1d5d76e64f18f3fc647e308b0c159e"
 
 config :code_corps, :analytics, CodeCorps.Analytics.InMemoryAPI
+config :code_corps, :stripe, Stripe
 
 config :sentry,
   environment_name: Mix.env || :dev

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,6 +30,8 @@ config :guardian, Guardian,
 
 config :code_corps, :analytics, CodeCorps.Analytics.TestAPI
 
+config :code_corps, :stripe, CodeCorps.Stripe.InMemory
+
 config :code_corps, :icon_color_generator, CodeCorps.RandomIconColor.TestGenerator
 
 # Set Corsica logging to output no console warning when rejecting a request

--- a/lib/code_corps/map_utils.ex
+++ b/lib/code_corps/map_utils.ex
@@ -4,4 +4,13 @@ defmodule CodeCorps.MapUtils do
     |> Map.put(new_key, map |> Map.get(old_key))
     |> Map.delete(old_key)
   end
+
+  def keys_to_string(map) do
+    for {key, val} <- map, into: %{} do
+      cond do
+        is_atom(key) -> {Atom.to_string(key), val}
+        true -> {key, val}
+      end
+    end
+  end
 end

--- a/lib/code_corps/stripe/adapters/stripe_customer.ex
+++ b/lib/code_corps/stripe/adapters/stripe_customer.ex
@@ -1,7 +1,29 @@
 defmodule CodeCorps.Stripe.Adapters.StripeCustomer do
-  import CodeCorps.MapUtils, only: [rename: 3]
+  import CodeCorps.MapUtils, only: [rename: 3, keys_to_string: 1]
 
-  def params_from_stripe(%{} = stripe_map) do
-    stripe_map |> rename("id", "id_from_stripe")
+  def to_params(%Stripe.Customer{} = customer) do
+    customer
+    |> Map.from_struct
+    |> Map.take([:created, :currency, :delinquent, :id, :email])
+    |> rename(:id, :id_from_stripe)
+    |> keys_to_string
+  end
+
+  @non_stripe_attribute_keys ["user_id"]
+
+  def add_non_stripe_attributes(%{} = params, %{} = attributes) do
+    attributes
+    |> get_non_stripe_attributes
+    |> add_to(params)
+  end
+
+  defp get_non_stripe_attributes(%{} = attributes) do
+    attributes
+    |> Map.take(@non_stripe_attribute_keys)
+  end
+
+  defp add_to(%{} = attributes, %{} = params) do
+    params
+    |> Map.merge(attributes)
   end
 end

--- a/lib/code_corps/stripe/in_memory.ex
+++ b/lib/code_corps/stripe/in_memory.ex
@@ -1,0 +1,24 @@
+defmodule CodeCorps.Stripe.InMemory do
+  defmodule Customer do
+    def create(map) do
+      {:ok, do_create(map)}
+    end
+
+    defp do_create(_) do
+      {:ok, created} = DateTime.from_unix(1479472835)
+
+      %Stripe.Customer{
+        id: "cus_9aMOFmqy1esIRE",
+        account_balance: 0,
+        created: created,
+        currency: "usd",
+        default_source: nil,
+        delinquent: false,
+        description: nil,
+        email: "mail@test.com",
+        livemode: false,
+        metadata: %{}
+      }
+    end
+  end
+end

--- a/lib/code_corps/stripe/stripe_service.ex
+++ b/lib/code_corps/stripe/stripe_service.ex
@@ -1,0 +1,7 @@
+defmodule CodeCorps.StripeService do
+  @stripe Application.get_env(:code_corps, :stripe)
+
+  def create_customer(map) do
+    @stripe.Customer.create(map)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,8 @@ defmodule CodeCorps.Mixfile do
         :scrivener_ecto,
         :segment,
         :sentry,
-        :stripity_stripe
+        :stripity_stripe,
+        :timex_ecto
       ]
     ]
   end
@@ -84,7 +85,9 @@ defmodule CodeCorps.Mixfile do
       {:scrivener_ecto, "~> 1.0"}, # DB query pagination
       {:segment, github: "stueccles/analytics-elixir"}, # Segment analytics
       {:sentry, "~> 1.0"}, # Sentry error tracking
-      {:stripity_stripe, "~> 2.0.0-alpha.1"} # Stripe
+      {:stripity_stripe, "~> 2.0.0-alpha.2"}, # Stripe
+      {:timex, "~> 3.0"},
+      {:timex_ecto, "~> 3.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,7 @@
   "canada": {:hex, :canada, "1.0.1", "da96d0ff101a0c2a6cc7b07d92b8884ff6508f058781d3679999416feacf41c5", [:mix], []},
   "canary": {:hex, :canary, "1.0.0", "55e130bd015001d2fcdc16be23994c6bb711205a625f340d7a74f1c29825d4ba", [:mix], [{:canada, "~> 1.0.0", [hex: :canada, optional: false]}, {:ecto, ">= 1.1.0", [hex: :ecto, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+  "combine": {:hex, :combine, "0.9.3", "192e609b48b3f2210494e26f85db1712657be1a8f15795656710317ea43fc449", [:mix], []},
   "comeonin": {:hex, :comeonin, "2.6.0", "74c288338b33205f9ce97e2117bb9a2aaab103a1811d243443d76fdb62f904ac", [:make, :make, :mix], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "corsica": {:hex, :corsica, "0.5.0", "eb5b2fccc5bc4f31b8e2b77dd15f5f302aca5d63286c953e8e916f806056d50c", [:mix], [{:cowboy, ">= 1.0.0", [hex: :cowboy, optional: false]}, {:plug, ">= 0.9.0", [hex: :plug, optional: false]}]},
@@ -52,5 +53,8 @@
   "segment": {:git, "https://github.com/stueccles/analytics-elixir.git", "8fe520c16a8a9290d55c849bf4d67420396e1cdd", []},
   "sentry": {:hex, :sentry, "1.1.0", "7a035a02d24578e26c55fbea36f52d8705925ee7d5ce0ca766245ca78c91226f", [:mix], [{:hackney, "~> 1.6.1", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}, {:uuid, "~> 1.0", [hex: :uuid, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "stripity_stripe": {:hex, :stripity_stripe, "2.0.0-alpha.1", "d86faf49639cf8963c06fb92ce3f010c52f3710ef902a986e6a9391ab48ec27e", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:poison, "~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
+  "stripity_stripe": {:hex, :stripity_stripe, "2.0.0-alpha.2", "dd40e85bc0ca375c442e71a875855d9106106bbbf1508604126d3c0aecce1305", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:poison, "~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
+  "timex": {:hex, :timex, "3.1.5", "413d6d8d6f0162a5d47080cb8ca520d790184ac43e097c95191c7563bf25b428", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
+  "timex_ecto": {:hex, :timex_ecto, "3.0.5", "3ec6c25e10d2c0020958e5df64d2b5e690e441faa2c2259da8bc6bd3d7f39256", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: false]}, {:timex, "~> 3.0", [hex: :timex, optional: false]}]},
+  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []}}

--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -1,9 +1,6 @@
 defmodule CodeCorps.CommentControllerTest do
   use CodeCorps.ApiCase, resource_name: :comment
 
-  alias CodeCorps.Comment
-  alias CodeCorps.Repo
-
   @valid_attrs %{markdown: "I love elixir!"}
   @invalid_attrs %{markdown: ""}
 

--- a/test/controllers/preview_controller_test.exs
+++ b/test/controllers/preview_controller_test.exs
@@ -1,8 +1,6 @@
 defmodule CodeCorps.PreviewControllerTest do
   use CodeCorps.ApiCase, resource_name: :preview
 
-  alias CodeCorps.Preview
-
   @valid_attrs %{markdown: "A **strong** element"}
 
   describe "create" do

--- a/test/controllers/stripe_customer_controller_test.exs
+++ b/test/controllers/stripe_customer_controller_test.exs
@@ -1,0 +1,48 @@
+defmodule CodeCorps.StripeCustomerControllerTest do
+  use CodeCorps.ApiCase, resource_name: :stripe_customer
+
+  describe "show" do
+    @tag :authenticated
+    test "shows chosen resource when user is authenticated and authorized", %{conn: conn, current_user: current_user} do
+      stripe_customer = insert(:stripe_customer, user: current_user)
+
+      conn
+      |> request_show(stripe_customer)
+      |> json_response(200)
+      |> Map.get("data")
+      |> assert_result_id(stripe_customer.id)
+    end
+
+    test "renders 401 when unauthenticated", %{conn: conn} do
+      stripe_customer = insert(:stripe_customer)
+      assert conn |> request_show(stripe_customer) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders 403 when not authorized", %{conn: conn} do
+      stripe_customer = insert(:stripe_customer)
+      assert conn |> request_show(stripe_customer) |> json_response(403)
+    end
+
+    @tag :authenticated
+    test "renders 404 when id is nonexistent", %{conn: conn} do
+      assert conn |> request_show(:not_found) |> json_response(404)
+    end
+  end
+
+  describe "create" do
+    @tag :authenticated
+    test "creates and renders resource user is authenticated and authorized", %{conn: conn, current_user: current_user} do
+      assert conn |> request_create(%{user: current_user}) |> json_response(201)
+    end
+
+    test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
+      assert conn |> request_create |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_create |> json_response(403)
+    end
+  end
+end

--- a/test/controllers/task_controller_test.exs
+++ b/test/controllers/task_controller_test.exs
@@ -27,9 +27,9 @@ defmodule CodeCorps.TaskControllerTest do
     test "lists all entries newest first", %{conn: conn} do
       # Has to be done manually. Inserting as a list is too quick.
       # Field lacks the resolution to differentiate.
-      task_1 = insert(:task, inserted_at: Ecto.DateTime.cast!("2000-01-15T00:00:10"))
-      task_2 = insert(:task, inserted_at: Ecto.DateTime.cast!("2000-01-15T00:00:20"))
-      task_3 = insert(:task, inserted_at: Ecto.DateTime.cast!("2000-01-15T00:00:30"))
+      task_1 = insert(:task, inserted_at: Timex.to_date({2000, 1, 1}))
+      task_2 = insert(:task, inserted_at: Timex.to_date({2000, 1, 2}))
+      task_3 = insert(:task, inserted_at: Timex.to_date({2000, 1, 3}))
 
       path = conn |> task_path(:index)
       json = conn |> get(path) |> json_response(200)

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -3,7 +3,6 @@ defmodule CodeCorps.UserControllerTest do
 
   alias CodeCorps.User
   alias CodeCorps.Repo
-  alias CodeCorps.SluggedRoute
 
   @valid_attrs %{
     email: "test@user.com",

--- a/test/lib/code_corps/stripe/adapters/stripe_customer_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_customer_test.exs
@@ -1,14 +1,46 @@
 defmodule CodeCorps.Stripe.Adapters.StripeCustomerTest do
   use ExUnit.Case, async: true
 
-  import CodeCorps.Stripe.Adapters.StripeCustomer, only: [params_from_stripe: 1]
+  import CodeCorps.Stripe.Adapters.StripeCustomer, only: [to_params: 1, add_non_stripe_attributes: 2]
 
-  @stripe_map %{"id" => "str_123", "foo" => "bar"}
-  @local_map %{"id_from_stripe" => "str_123", "foo" => "bar"}
+  {:ok, timestamp} = DateTime.from_unix(1479472835)
 
-  describe "params_from_stripe/1" do
+  @stripe_customer %Stripe.Customer{
+    id: "cus_9aMOFmqy1esIRE",
+    account_balance: 0,
+    created: timestamp,
+    currency: "usd",
+    default_source: nil,
+    delinquent: false,
+    description: nil,
+    email: "mail@stripe.com",
+    livemode: false,
+    metadata: %{}
+  }
+
+  @local_map %{
+    "id_from_stripe" => "cus_9aMOFmqy1esIRE",
+    "created" => timestamp,
+    "currency" => "usd",
+    "delinquent" => false,
+    "email" => "mail@stripe.com"
+  }
+
+  describe "to_params/1" do
     test "converts from stripe map to local properly" do
-      assert @stripe_map |> params_from_stripe == @local_map
+      assert @stripe_customer |> to_params == @local_map
+    end
+  end
+
+  describe "add_non_stripe_attributes/2" do
+    test "adds 'user_id' from second hash into first hash" do
+      params = %{"id_from_stripe" => "cus_123"}
+      attributes = %{"user_id" =>123, "foo" => "bar"}
+
+      actual_output = params |> add_non_stripe_attributes(attributes)
+      expected_output = %{"id_from_stripe" => "cus_123", "user_id" => 123}
+
+      assert actual_output == expected_output
     end
   end
 end

--- a/test/policies/stripe_customer_policy_test.exs
+++ b/test/policies/stripe_customer_policy_test.exs
@@ -1,0 +1,28 @@
+defmodule CodeCorps.StripeCustomerPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.StripeCustomerPolicy, only: [show?: 2]
+
+  describe "show?" do
+    test "returns true when user is an admin" do
+      user = build(:user, admin: true)
+      stripe_customer = build(:stripe_customer)
+
+      assert show?(user, stripe_customer)
+    end
+
+    test "returns true when user is viewing their own information" do
+      user = insert(:user)
+      stripe_customer = insert(:stripe_customer, user: user)
+
+      assert show?(user, stripe_customer)
+    end
+
+    test "returns false when user id is not the StripeCustomer's user_id" do
+      [user, another_user] = insert_pair(:user)
+      stripe_customer = insert(:stripe_customer, user: user)
+
+      refute show?(another_user, stripe_customer)
+    end
+  end
+end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -3,7 +3,6 @@ defmodule CodeCorps.Factories do
   # with Ecto
   use ExMachina.Ecto, repo: CodeCorps.Repo
 
-
   def category_factory do
     %CodeCorps.Category{
       name: sequence(:name, &"Category #{&1}"),
@@ -103,6 +102,15 @@ defmodule CodeCorps.Factories do
   def slugged_route_factory do
     %CodeCorps.SluggedRoute{
       slug: sequence(:slug, &"slug-#{&1}")
+    }
+  end
+
+  def stripe_customer_factory do
+    %CodeCorps.StripeCustomer{
+      created: Timex.now,
+      email: sequence(:email, &"email_#{&1}@mail.com"),
+      id_from_stripe: sequence(:id_from_stripe, &"stripe_id_#{&1}"),
+      user: build(:user)
     }
   end
 

--- a/test/views/stripe_customer_view_test.exs
+++ b/test/views/stripe_customer_view_test.exs
@@ -1,0 +1,72 @@
+defmodule CodeCorps.StripeCustomerViewTest do
+  use CodeCorps.ConnCase, async: true
+
+  import Phoenix.View, only: [render: 3]
+
+  test "renders all attributes and relationships properly" do
+    user = insert(:user)
+    stripe_customer = insert(:stripe_customer, id_from_stripe: "some_id", email: "email", user: user)
+
+    rendered_json =  render(CodeCorps.StripeCustomerView, "show.json-api", data: stripe_customer)
+
+    expected_json = %{
+      "data" => %{
+        "attributes" => %{
+          "email" => "",
+          "created" => stripe_customer.created,
+          "currency" => stripe_customer.currency,
+          "delinquent" => stripe_customer.delinquent,
+          "id-from-stripe" => "",
+          "inserted-at" => stripe_customer.inserted_at,
+          "updated-at" => stripe_customer.updated_at
+        },
+        "id" => stripe_customer.id |> Integer.to_string,
+        "relationships" => %{
+          "user" => %{
+            "data" => %{"id" => user.id |> Integer.to_string, "type" => "user"}
+          }
+        },
+        "type" => "stripe-customer",
+      },
+      "jsonapi" => %{
+        "version" => "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+
+  test "renders email and id_from_stripe when user is the authenticated user" do
+    user = insert(:user)
+    stripe_customer = insert(:stripe_customer, id_from_stripe: "some_id", email: "email", user: user)
+
+    conn = Phoenix.ConnTest.build_conn |> assign(:current_user, user)
+    rendered_json = render(CodeCorps.StripeCustomerView, "show.json-api", data: stripe_customer, conn: conn)
+    assert rendered_json["data"]["attributes"]["email"] == stripe_customer.email
+    assert rendered_json["data"]["attributes"]["id-from-stripe"] == stripe_customer.id_from_stripe
+  end
+
+  test "renders email and id_from_stripe for only the authenticated user when rendering list" do
+    stripe_customers = insert_list(4, :stripe_customer)
+    auth_customer = stripe_customers |> List.last
+
+    conn = Phoenix.ConnTest.build_conn |> assign(:current_user, auth_customer.user)
+    rendered_json = render(CodeCorps.StripeCustomerView, "show.json-api", data: stripe_customers, conn: conn)
+
+    emails =
+      rendered_json["data"]
+      |> Enum.map(&Map.get(&1, "attributes"))
+      |> Enum.map(&Map.get(&1, "email"))
+      |> Enum.filter(fn(email) -> email != "" end)
+
+    assert emails == [auth_customer.email]
+
+    stripe_ids =
+      rendered_json["data"]
+      |> Enum.map(&Map.get(&1, "attributes"))
+      |> Enum.map(&Map.get(&1, "id-from-stripe"))
+      |> Enum.filter(fn(id_from_stripe) -> id_from_stripe != "" end)
+
+    assert stripe_ids == [auth_customer.id_from_stripe]
+  end
+end

--- a/test/views/user_view_test.exs
+++ b/test/views/user_view_test.exs
@@ -6,6 +6,8 @@ defmodule CodeCorps.UserViewTest do
   test "renders all attributes and relationships properly" do
     user = insert(:user)
     organization_membership = insert(:organization_membership, member: user)
+    slugged_route = insert(:slugged_route, user: user)
+    stripe_customer = insert(:stripe_customer, user: user)
     user_category = insert(:user_category, user: user)
     user_role = insert(:user_role, user: user)
     user_skill = insert(:user_skill, user: user)
@@ -38,7 +40,10 @@ defmodule CodeCorps.UserViewTest do
             ]
           },
           "slugged-route" => %{
-            "data" => nil
+            "data" => %{"id" => slugged_route.id |> Integer.to_string, "type" => "slugged-route"}
+          },
+          "stripe-customer" => %{
+            "data" => %{"id" => stripe_customer.id |> Integer.to_string, "type" => "stripe-customer"}
           },
           "user-categories" => %{
             "data" => [

--- a/web/controllers/stripe_customer_controller.ex
+++ b/web/controllers/stripe_customer_controller.ex
@@ -1,0 +1,36 @@
+defmodule CodeCorps.StripeCustomerController do
+  use CodeCorps.Web, :controller
+  use JaResource
+
+  alias CodeCorps.StripeCustomer
+  alias CodeCorps.Stripe.Adapters
+
+  plug :load_and_authorize_resource, model: StripeCustomer, only: [:show]
+  plug :load_and_authorize_changeset, model: StripeCustomer, only: [:create]
+  plug JaResource
+
+  def handle_create(conn, attributes) do
+    attributes
+    |> CodeCorps.StripeService.create_customer
+    |> handle_stripe_response(attributes, conn)
+  end
+
+  defp handle_stripe_response({:ok, stripe_response}, attributes, _conn) do
+    stripe_response
+    |> Adapters.StripeCustomer.to_params
+    |> Adapters.StripeCustomer.add_non_stripe_attributes(attributes)
+    |> create_record
+  end
+
+  defp handle_stripe_response({:error, %Stripe.APIError{}}, _, conn) do
+    conn
+    |> put_status(500)
+    |> render(CodeCorps.ErrorView, "500.json-api")
+  end
+
+  defp create_record(attributes) do
+    %StripeCustomer{}
+    |> StripeCustomer.create_changeset(attributes)
+    |> Repo.insert
+  end
+end

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -12,6 +12,7 @@ defmodule Canary.Abilities do
   alias CodeCorps.Role
   alias CodeCorps.RoleSkill
   alias CodeCorps.Skill
+  alias CodeCorps.StripeCustomer
   alias CodeCorps.User
   alias CodeCorps.UserCategory
   alias CodeCorps.UserRole
@@ -30,6 +31,7 @@ defmodule Canary.Abilities do
   alias CodeCorps.RolePolicy
   alias CodeCorps.RoleSkillPolicy
   alias CodeCorps.SkillPolicy
+  alias CodeCorps.StripeCustomerPolicy
   alias CodeCorps.UserPolicy
   alias CodeCorps.UserCategoryPolicy
   alias CodeCorps.UserRolePolicy
@@ -89,6 +91,9 @@ defmodule Canary.Abilities do
     def can?(%User{} = user, :delete, %RoleSkill{}), do: RoleSkillPolicy.delete?(user)
 
     def can?(%User{} = user, :create, Skill), do: SkillPolicy.create?(user)
+
+    def can?(%User{} = user, :create, %Changeset{data: %StripeCustomer{}} = changeset), do: StripeCustomerPolicy.create?(user, changeset)
+    def can?(%User{} = user, :show, %StripeCustomer{} = stripe_customer), do: StripeCustomerPolicy.show?(user, stripe_customer)
 
     def can?(%User{} = user, :create, %Changeset{data: %UserCategory{}} = changeset), do: UserCategoryPolicy.create?(user, changeset)
     def can?(%User{} = user, :delete, %UserCategory{} = user_category), do: UserCategoryPolicy.delete?(user, user_category)

--- a/web/models/stripe_customer.ex
+++ b/web/models/stripe_customer.ex
@@ -2,7 +2,7 @@ defmodule CodeCorps.StripeCustomer do
   use CodeCorps.Web, :model
 
   schema "stripe_customers" do
-    field :created, Ecto.DateTime
+    field :created, Timex.Ecto.DateTime
     field :currency, :string
     field :delinquent, :boolean
     field :email, :string
@@ -17,7 +17,7 @@ defmodule CodeCorps.StripeCustomer do
 
   def create_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:id_from_stripe, :user_id])
+    |> cast(params, [:created, :currency, :delinquent, :id_from_stripe, :user_id])
     |> validate_required([:id_from_stripe, :user_id])
     |> assoc_constraint(:user)
   end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -31,10 +31,9 @@ defmodule CodeCorps.User do
     field :state_transition, :string, virtual: true
 
     has_one :slugged_route, SluggedRoute
+    has_one :stripe_customer, CodeCorps.StripeCustomer
 
-    has_many :organization_memberships,
-      CodeCorps.OrganizationMembership,
-      foreign_key: :member_id
+    has_many :organization_memberships, CodeCorps.OrganizationMembership, foreign_key: :member_id
     has_many :organizations, through: [:organization_memberships, :organization]
 
     has_many :user_categories, CodeCorps.UserCategory

--- a/web/policies/stripe_customer_policy.ex
+++ b/web/policies/stripe_customer_policy.ex
@@ -1,0 +1,12 @@
+defmodule CodeCorps.StripeCustomerPolicy do
+  alias CodeCorps.StripeCustomer
+  alias CodeCorps.User
+  alias Ecto.Changeset
+
+  def create?(%User{id: current_user_id}, %Changeset{changes: %{user_id: user_id}}), do: current_user_id == user_id
+  def create?(%User{}, %Changeset{}), do: false
+
+  def show?(%User{admin: true}, %StripeCustomer{}), do: true
+  def show?(%User{id: current_user_id}, %StripeCustomer{user_id: user_id}), do: current_user_id == user_id
+  def show?(%User{}, %StripeCustomer{}), do: false
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -38,6 +38,30 @@ defmodule CodeCorps.Router do
   end
 
   scope "/", CodeCorps, host: "api." do
+    pipe_through [:api, :bearer_auth, :ensure_auth, :current_user]
+
+    resources "/categories", CategoryController, only: [:create, :update]
+    resources "/comments", CommentController, only: [:create, :update]
+    resources "/donation-goals", DonationGoalController, only: [:create, :update, :delete]
+    resources "/organizations", OrganizationController, only: [:create, :update]
+    resources "/organization-memberships", OrganizationMembershipController, only: [:create, :update, :delete]
+    resources "/previews", PreviewController, only: [:create]
+    resources "/projects", ProjectController, only: [:create, :update]
+    get "/projects/:id/stripe-auth", StripeAuthController, :stripe_auth
+    resources "/project-categories", ProjectCategoryController, only: [:create, :delete]
+    resources "/project-skills", ProjectSkillController, only: [:create, :delete]
+    resources "/roles", RoleController, only: [:create]
+    resources "/role-skills", RoleSkillController, only: [:create, :delete]
+    resources "/skills", SkillController, only: [:create]
+    resources "/stripe-customers", StripeCustomerController, only: [:show, :create]
+    resources "/tasks", TaskController, only: [:create, :update]
+    resources "/users", UserController, only: [:update]
+    resources "/user-categories", UserCategoryController, only: [:create, :delete]
+    resources "/user-roles", UserRoleController, only: [:create, :delete]
+    resources "/user-skills", UserSkillController, only: [:create, :delete]
+  end
+
+  scope "/", CodeCorps, host: "api." do
     pipe_through [:api, :bearer_auth, :current_user]
 
     post "/token", TokenController, :create
@@ -68,26 +92,5 @@ defmodule CodeCorps.Router do
     get "/:slug/:project_slug", ProjectController, :show
   end
 
-  scope "/", CodeCorps, host: "api." do
-    pipe_through [:api, :bearer_auth, :ensure_auth, :current_user]
 
-    resources "/categories", CategoryController, only: [:create, :update]
-    resources "/comments", CommentController, only: [:create, :update]
-    resources "/donation-goals", DonationGoalController, only: [:create, :update, :delete]
-    resources "/organizations", OrganizationController, only: [:create, :update]
-    resources "/organization-memberships", OrganizationMembershipController, only: [:create, :update, :delete]
-    resources "/previews", PreviewController, only: [:create]
-    resources "/projects", ProjectController, only: [:create, :update]
-    get "/projects/:id/stripe-auth", StripeAuthController, :stripe_auth
-    resources "/project-categories", ProjectCategoryController, only: [:create, :delete]
-    resources "/project-skills", ProjectSkillController, only: [:create, :delete]
-    resources "/roles", RoleController, only: [:create]
-    resources "/role-skills", RoleSkillController, only: [:create, :delete]
-    resources "/skills", SkillController, only: [:create]
-    resources "/tasks", TaskController, only: [:create, :update]
-    resources "/users", UserController, only: [:update]
-    resources "/user-categories", UserCategoryController, only: [:create, :delete]
-    resources "/user-roles", UserRoleController, only: [:create, :delete]
-    resources "/user-skills", UserSkillController, only: [:create, :delete]
-  end
 end

--- a/web/views/stripe_customer_view.ex
+++ b/web/views/stripe_customer_view.ex
@@ -1,0 +1,31 @@
+defmodule CodeCorps.StripeCustomerView do
+  use CodeCorps.PreloadHelpers, default_preloads: [:user]
+  use CodeCorps.Web, :view
+  use JaSerializer.PhoenixView
+
+  attributes [:created, :currency, :delinquent, :email, :id_from_stripe, :inserted_at, :updated_at]
+
+  has_one :user, serializer: CodeCorps.UserView
+
+  @doc """
+  Returns the email or an empty string, depending on the stripe_customer record
+  being rendered is the authenticated user's record, or some other user's.
+
+  Users can only see their own emails. Everyone else's are private.
+  """
+  def email(stripe_customer, %Plug.Conn{assigns: %{current_user: current_user}}) do
+    if stripe_customer.user == current_user, do: stripe_customer.email, else: ""
+  end
+  def email(_stripe_customer, _conn), do: ""
+
+  @doc """
+  Returns the id_from_stripe or an empty string, depending on the stripe_customer record
+  being rendered is the authenticated user's record, or some other user's.
+
+  Users can only see their own stripe ids. Everyone else's are private.
+  """
+  def id_from_stripe(stripe_customer, %Plug.Conn{assigns: %{current_user: current_user}}) do
+    if stripe_customer.user_id == current_user.id, do: stripe_customer.id_from_stripe, else: ""
+  end
+  def id_from_stripe(_stripe_customer, _conn), do: ""
+end

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -1,5 +1,6 @@
 defmodule CodeCorps.UserView do
-  use CodeCorps.PreloadHelpers, default_preloads: [:slugged_route, :organization_memberships, :user_categories, :user_roles, :user_skills]
+  use CodeCorps.PreloadHelpers,
+      default_preloads: [:slugged_route, :stripe_customer, :organization_memberships, :user_categories, :user_roles, :user_skills]
   use CodeCorps.Web, :view
   use JaSerializer.PhoenixView
 
@@ -10,6 +11,7 @@ defmodule CodeCorps.UserView do
   ]
 
   has_one :slugged_route, serializer: CodeCorps.SluggedRouteView
+  has_one :stripe_customer, serializer: CodeCorps.StripeCustomerView
   has_many :organization_memberships, serializer: CodeCorps.OrganizationMembershipView, identifiers: :always
   has_many :user_categories, serializer: CodeCorps.UserCategoryView, identifiers: :always
   has_many :user_roles, serializer: CodeCorps.UserRoleView, identifiers: :always

--- a/web/web.ex
+++ b/web/web.ex
@@ -23,6 +23,8 @@ defmodule CodeCorps.Web do
       import Ecto
       import Ecto.Changeset
       import Ecto.Query
+
+      use Timex.Ecto.Timestamps
     end
   end
 


### PR DESCRIPTION
# What's in this PR?

Added Stripe Customer policy for `index(filter_by_id)` and `show` endpoints to ability.ex, stripe_customer_policy.ex, factory, and tests to stripe_customer_policy_test.

## References
Progress on: #453 
Progress on: #447 
