### PR TITLE
Enable creation and showing of plans

### DIFF
--- a/lib/code_corps/stripe/adapters/stripe_connect_plan.ex
+++ b/lib/code_corps/stripe/adapters/stripe_connect_plan.ex
@@ -4,14 +4,37 @@ defmodule CodeCorps.Stripe.Adapters.StripeConnectPlan do
   usable for creation of `StripeConnectPlan` records locally
   """
 
-  import CodeCorps.MapUtils, only: [rename: 3]
+  import CodeCorps.MapUtils, only: [rename: 3, keys_to_string: 1]
 
   @doc """
   Converts a map received from the Stripe API into a map that can be used
   to create a `CodeCorps.StripeConnectPlan` record
   """
-  def params_from_stripe(%{} = stripe_map) do
-    stripe_map
-    |> rename("id", "id_from_stripe")
+  @stripe_attributes [:amount, :created, :id, :name]
+
+  def to_params(%Stripe.Plan{} = stripe_plan) do
+    stripe_plan
+    |> Map.from_struct
+    |> Map.take(@stripe_attributes)
+    |> rename(:id, :id_from_stripe)
+    |> keys_to_string
+  end
+
+  @non_stripe_attributes ["project_id"]
+
+  def add_non_stripe_attributes(%{} = params, %{} = attributes) do
+    attributes
+    |> get_non_stripe_attributes
+    |> add_to(params)
+  end
+
+  defp get_non_stripe_attributes(%{} = attributes) do
+    attributes
+    |> Map.take(@non_stripe_attributes)
+  end
+
+  defp add_to(%{} = attributes, %{} = params) do
+    params
+    |> Map.merge(attributes)
   end
 end

--- a/lib/code_corps/stripe/stripe_connect_plan.ex
+++ b/lib/code_corps/stripe/stripe_connect_plan.ex
@@ -1,0 +1,65 @@
+defmodule CodeCorps.Stripe.StripeConnectPlan do
+  alias CodeCorps.Project
+  alias CodeCorps.Repo
+  alias CodeCorps.Stripe.Adapters
+
+  @api Application.get_env(:code_corps, :stripe)
+
+  def create(%{"project_id" => project_id} = attributes) do
+    project_id
+    |> get_project
+    |> get_stripe_parameters
+    |> create_plan_on_stripe
+    |> handle_response(attributes)
+  end
+
+  defp get_project(project_id), do: Project |> Repo.get(project_id)
+
+  defp get_stripe_parameters(%Project{} = project) do
+    attributes = get_stripe_attributes(project)
+    options = get_stripe_options(project)
+
+    {attributes, options}
+  end
+
+  defp get_stripe_attributes(%Project{id: id, slug: slug, title: title}) do
+    %{
+      amount: 1,
+      currency: "usd",
+      id: "plan_#{slug}_#{id}",
+      interval: "month",
+      name: "Monthly donation plan to #{title} on CodeCorps"
+    }
+  end
+
+  def get_stripe_options(%Project{organization_id: organization_id}) do
+    organization =
+      CodeCorps.Organization
+      |> Repo.get(organization_id)
+      |> Repo.preload([:stripe_connect_account])
+
+    [connect_account: organization.stripe_connect_account.id_from_stripe]
+  end
+
+  @spec create_plan_on_stripe({map, Keyword.t}) :: {:ok, map} | {:error, struct}
+  defp create_plan_on_stripe({attrs, opts}), do: @api.Plan.create(attrs, opts)
+
+  defp handle_response({:ok, %Stripe.Plan{} = plan}, attributes) do
+    plan
+    |> get_attributes(attributes)
+    |> insert
+  end
+  defp handle_response({:error, error}, _attributes), do: {:error, error}
+
+  defp get_attributes(%Stripe.Plan{} = stripe_plan, %{} = attributes) do
+    stripe_plan
+    |> Adapters.StripeConnectPlan.to_params
+    |> Adapters.StripeConnectPlan.add_non_stripe_attributes(attributes)
+  end
+
+  defp insert(%{} = attributes) do
+    %CodeCorps.StripeConnectPlan{}
+    |> CodeCorps.StripeConnectPlan.create_changeset(attributes)
+    |> CodeCorps.Repo.insert
+  end
+end

--- a/lib/code_corps/stripity_stripe_testing/plan.ex
+++ b/lib/code_corps/stripity_stripe_testing/plan.ex
@@ -1,0 +1,23 @@
+defmodule CodeCorps.StripityStripeTesting.Plan do
+  def create(map, _opts) do
+    {:ok, do_create(map)}
+  end
+
+  defp do_create(_) do
+    {:ok, created} = DateTime.from_unix(1479472835)
+
+    %Stripe.Plan{
+      id: "plan_9aMOFmqy1esIRE",
+      amount: 5000,
+      created: created,
+      currency: "usd",
+      interval: "month",
+      interval_count: 1,
+      livemode: false,
+      metadata: %{},
+      name: "Monthly subscription for Code Corps",
+      statement_descriptor: nil,
+      trial_period_days: nil
+    }
+  end
+end

--- a/test/controllers/stripe_connect_plan_controller_test.exs
+++ b/test/controllers/stripe_connect_plan_controller_test.exs
@@ -1,0 +1,63 @@
+defmodule CodeCorps.StripeConnectPlanControllerTest do
+  use CodeCorps.ApiCase, resource_name: :stripe_connect_plan
+
+
+
+  describe "show" do
+    @tag :authenticated
+    test "shows resource when authenticated and authorized", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      insert(:organization_membership, role: "owner", member: current_user, organization: organization)
+      project = insert(:project, organization: organization)
+
+      stripe_connect_plan = insert(:stripe_connect_plan, project: project)
+      conn
+      |> request_show(stripe_connect_plan)
+      |> json_response(200)
+      |> Map.get("data")
+      |> assert_result_id(stripe_connect_plan.id)
+    end
+
+    test "renders 401 when unauthenticated", %{conn: conn} do
+      stripe_connect_plan = insert(:stripe_connect_plan)
+
+      assert conn |> request_show(stripe_connect_plan) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders 403 when not authorized", %{conn: conn} do
+      stripe_connect_plan = insert(:stripe_connect_plan)
+      assert conn |> request_show(stripe_connect_plan) |> json_response(403)
+    end
+
+    @tag :authenticated
+    test "renders 404 when record not found", %{conn: conn} do
+      assert conn |> request_show(:not_found) |> json_response(404)
+    end
+  end
+
+  describe "create" do
+    @tag :authenticated
+    test "creates and renders resource user is authenticated and authorized", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      insert(:organization_membership, role: "owner", member: current_user, organization: organization)
+      insert(:stripe_connect_account, organization: organization)
+      project = insert(:project, organization: organization)
+
+      assert conn |> request_create(%{project: project}) |> json_response(201)
+    end
+
+    test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
+      assert conn |> request_create |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 403 when not authorized", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      insert(:organization_membership, role: "admin", member: current_user, organization: organization)
+      project = insert(:project, organization: organization)
+
+      assert conn |> request_create(%{project: project}) |> json_response(403)
+    end
+  end
+end

--- a/test/lib/code_corps/stripe/adapters/stripe_connect_plan_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_connect_plan_test.exs
@@ -1,14 +1,46 @@
 defmodule CodeCorps.Stripe.Adapters.StripeConnectPlanTest do
   use ExUnit.Case, async: true
 
-  import CodeCorps.Stripe.Adapters.StripeConnectPlan, only: [params_from_stripe: 1]
+  import CodeCorps.Stripe.Adapters.StripeConnectPlan, only: [to_params: 1, add_non_stripe_attributes: 2]
 
-  @stripe_map %{"id" => "str_123", "foo" => "bar"}
-  @local_map %{"id_from_stripe" => "str_123", "foo" => "bar"}
+  {:ok, timestamp} = DateTime.from_unix(1479472835)
 
-  describe "params_from_stripe/1" do
+  @stripe_connect_plan %Stripe.Plan{
+    id: "plan_9aMOFmqy1esIRE",
+    amount: 5000,
+    created: timestamp,
+    currency: "usd",
+    interval: "month",
+    interval_count: 1,
+    livemode: false,
+    metadata: %{},
+    name: "Monthly subscription for Code Corps",
+    statement_descriptor: nil,
+    trial_period_days: nil
+  }
+
+  @local_map %{
+    "amount" => 5000,
+    "created" => timestamp,
+    "id_from_stripe" => "plan_9aMOFmqy1esIRE",
+    "name" => "Monthly subscription for Code Corps"
+  }
+
+  describe "to_params/1" do
     test "converts from stripe map to local properly" do
-      assert @stripe_map |> params_from_stripe == @local_map
+      assert @stripe_connect_plan |> to_params == @local_map
+    end
+  end
+
+  describe "add_non_stripe_attributes/2" do
+    test "adds 'project_id' from second hash into first hash" do
+      params = %{"id_from_stripe" => "plan_123"}
+      attributes = %{"project_id" =>123, "foo" => "bar"}
+
+      actual_output = params |> add_non_stripe_attributes(attributes)
+      expected_output = %{"id_from_stripe" => "plan_123", "project_id" => 123}
+
+      assert actual_output == expected_output
     end
   end
 end

--- a/test/support/stripe_connect_plan_policy_test.exs
+++ b/test/support/stripe_connect_plan_policy_test.exs
@@ -1,0 +1,101 @@
+defmodule CodeCorps.StripeConnectPlanPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.StripeConnectPlanPolicy, only: [show?: 2, create?: 2]
+  import CodeCorps.StripeConnectPlan, only: [create_changeset: 2]
+
+  defp setup_related_records do
+    user = insert(:user)
+    organization = insert(:organization)
+    project = insert(:project, organization: organization)
+
+    {user, organization, project}
+  end
+
+  defp setup_plan(project) do
+    insert(:stripe_connect_plan, project: project)
+  end
+
+  defp setup_membership(_, _, nil), do: nil
+  defp setup_membership(user, organization, role) do
+    insert(:organization_membership, role: role, member: user, organization: organization)
+  end
+
+  defp setup_data_for_role(role) do
+    {user, organization, project} = setup_related_records
+    setup_membership(user, organization, role)
+    plan = setup_plan(project)
+
+    {user, plan}
+  end
+
+  describe "show?" do
+    test "returns true when user is owner of organization" do
+      {user, plan} = setup_data_for_role("owner")
+      assert show?(user, plan)
+    end
+
+    test "returns false when user is admin of organization" do
+      {user, plan} = setup_data_for_role("admin")
+      refute show?(user, plan)
+    end
+
+    test "returns false when user is pending member of organization" do
+      {user, plan} = setup_data_for_role("pending")
+
+      refute show?(user, plan)
+    end
+
+    test "returns false when user is contributor of organization" do
+      {user, plan} = setup_data_for_role("contributor")
+
+      refute show?(user, plan)
+    end
+
+    test "returns false when user is not member of organization" do
+      {user, plan} = setup_data_for_role(nil)
+
+      refute show?(user, plan)
+    end
+  end
+
+  defp setup_changeset_for_role(role) do
+    {user, organization, project} = setup_related_records
+    setup_membership(user, organization, role)
+    changeset = setup_changeset(project)
+
+    {user, changeset}
+  end
+
+  defp setup_changeset(project), do: %CodeCorps.StripeConnectPlan{} |> create_changeset(%{project_id: project.id})
+
+  describe "create?" do
+    test "returns true when user is owner of organization" do
+      {user, changeset} = setup_changeset_for_role("owner")
+      assert create?(user, changeset)
+    end
+
+    test "returns false when user is admin of organization" do
+      {user, changeset} = setup_changeset_for_role("admin")
+      refute create?(user, changeset)
+    end
+
+    test "returns false when user is pending member of organization" do
+      {user, changeset} = setup_changeset_for_role("pending")
+
+      refute create?(user, changeset)
+    end
+
+    test "returns false when user is contributor of organization" do
+      {user, changeset} = setup_changeset_for_role("contributor")
+
+      refute create?(user, changeset)
+    end
+
+    test "returns false when user is not member of organization" do
+      {user, changeset} = setup_changeset_for_role(nil)
+
+      refute create?(user, changeset)
+    end
+  end
+end

--- a/test/views/project_view_test.exs
+++ b/test/views/project_view_test.exs
@@ -6,10 +6,12 @@ defmodule CodeCorps.ProjectViewTest do
   test "renders all attributes and relationships properly" do
     organization = insert(:organization)
     project = insert(:project, organization: organization)
-    task = insert(:task, project: project)
+
+    donation_goal = insert(:donation_goal, project: project)
     project_category = insert(:project_category, project: project)
     project_skill = insert(:project_skill, project: project)
-    donation_goal = insert(:donation_goal, project: project)
+    stripe_connect_plan = insert(:stripe_connect_plan, project: project)
+    task = insert(:task, project: project)
 
     rendered_json = render(CodeCorps.ProjectView, "show.json-api", data: project)
 
@@ -55,6 +57,12 @@ defmodule CodeCorps.ProjectViewTest do
                 "type" => "project-skill"
               }
             ]
+          },
+          "stripe-connect-plan" => %{
+            "data" => %{
+              "id" => stripe_connect_plan.id |> Integer.to_string,
+              "type" => "stripe-connect-plan"
+            }
           },
           "tasks" => %{
             "data" => [

--- a/test/views/stripe_connect_plan_view_test.exs
+++ b/test/views/stripe_connect_plan_view_test.exs
@@ -1,0 +1,37 @@
+defmodule CodeCorps.StripeConnectPlanViewTest do
+  use CodeCorps.ConnCase, async: true
+
+  import Phoenix.View, only: [render: 3]
+
+  test "renders all attributes and relationships properly" do
+    project = insert(:project)
+    plan = insert(:stripe_connect_plan, project: project)
+
+    rendered_json =  render(CodeCorps.StripeConnectPlanView, "show.json-api", data: plan)
+
+    expected_json = %{
+      "data" => %{
+        "attributes" => %{
+          "amount" => plan.amount,
+          "created" => plan.created,
+          "id-from-stripe" => plan.id_from_stripe,
+          "inserted-at" => plan.inserted_at,
+          "name" => plan.name,
+          "updated-at" => plan.updated_at
+        },
+        "id" => plan.id |> Integer.to_string,
+        "relationships" => %{
+          "project" => %{
+            "data" => %{"id" => project.id |> Integer.to_string, "type" => "project"}
+          }
+        },
+        "type" => "stripe-connect-plan",
+      },
+      "jsonapi" => %{
+        "version" => "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+end

--- a/web/controllers/stripe_connect_plan_controller.ex
+++ b/web/controllers/stripe_connect_plan_controller.ex
@@ -1,0 +1,32 @@
+defmodule CodeCorps.StripeConnectPlanController do
+  use CodeCorps.Web, :controller
+  use JaResource
+
+  alias CodeCorps.StripeConnectPlan
+
+  plug :load_and_authorize_changeset, model: StripeConnectPlan, only: [:create]
+  plug :load_and_authorize_resource, model: StripeConnectPlan, only: [:show]
+  plug JaResource
+
+  def handle_create(conn, attributes) do
+    attributes
+    |> CodeCorps.Stripe.StripeConnectPlan.create
+    |> handle_create_result(conn)
+  end
+
+  defp handle_create_result({:ok, %StripeConnectPlan{}} = result, conn) do
+    result |> CodeCorps.Analytics.Segment.track(:created, conn)
+  end
+  defp handle_create_result({:error, %Stripe.APIErrorResponse{}} = error, conn) do
+    error |> IO.inspect
+    conn
+    |> put_status(500)
+    |> render(CodeCorps.ErrorView, "500.json-api")
+  end
+  defp handle_create_result({:error, %Stripe.OAuthAPIErrorResponse{}}, conn) do
+    conn
+    |> put_status(400)
+    |> render(CodeCorps.ErrorView, "stripe-400.json-api")
+  end
+  defp handle_create_result({:error, %Ecto.Changeset{} = changeset}, _conn), do: changeset
+end

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -13,6 +13,7 @@ defmodule Canary.Abilities do
   alias CodeCorps.RoleSkill
   alias CodeCorps.Skill
   alias CodeCorps.StripeConnectAccount
+  alias CodeCorps.StripeConnectPlan
   alias CodeCorps.StripePlatformCard
   alias CodeCorps.StripePlatformCustomer
   alias CodeCorps.User
@@ -34,6 +35,7 @@ defmodule Canary.Abilities do
   alias CodeCorps.RoleSkillPolicy
   alias CodeCorps.SkillPolicy
   alias CodeCorps.StripeConnectAccountPolicy
+  alias CodeCorps.StripeConnectPlanPolicy
   alias CodeCorps.StripePlatformCardPolicy
   alias CodeCorps.StripePlatformCustomerPolicy
   alias CodeCorps.UserPolicy
@@ -98,6 +100,9 @@ defmodule Canary.Abilities do
 
     def can?(%User{} = user, :show, %StripeConnectAccount{} = stripe_connect_account), do: StripeConnectAccountPolicy.show?(user, stripe_connect_account)
     def can?(%User{} = user, :create, %Changeset{ data: %StripeConnectAccount{}} = changeset), do: StripeConnectAccountPolicy.create?(user, changeset)
+
+    def can?(%User{} = user, :show, %StripeConnectPlan{} = stripe_connect_plan), do: StripeConnectPlanPolicy.show?(user, stripe_connect_plan)
+    def can?(%User{} = user, :create, %Changeset{ data: %StripeConnectPlan{}} = changeset), do: StripeConnectPlanPolicy.create?(user, changeset)
 
     def can?(%User{} = user, :show, %StripePlatformCard{} = stripe_platform_card), do: StripePlatformCardPolicy.show?(user, stripe_platform_card)
     def can?(%User{} = user, :create, %Changeset{ data: %StripePlatformCard{}} = changeset), do: StripePlatformCardPolicy.create?(user, changeset)

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -20,6 +20,7 @@ defmodule CodeCorps.Project do
     field :title, :string
 
     belongs_to :organization, CodeCorps.Organization
+    has_one :stripe_connect_plan, CodeCorps.StripeConnectPlan
 
     has_many :donation_goals, CodeCorps.DonationGoal
     has_many :project_categories, CodeCorps.ProjectCategory

--- a/web/models/stripe_connect_plan.ex
+++ b/web/models/stripe_connect_plan.ex
@@ -24,7 +24,7 @@ defmodule CodeCorps.StripeConnectPlan do
 
   def create_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:id_from_stripe, :project_id])
+    |> cast(params, [:amount, :created, :id_from_stripe, :name, :project_id])
     |> validate_required([:id_from_stripe, :project_id])
     |> unique_constraint(:id_from_stripe)
     |> assoc_constraint(:project)

--- a/web/policies/stripe_connect_account_policy.ex
+++ b/web/policies/stripe_connect_account_policy.ex
@@ -9,8 +9,5 @@ defmodule CodeCorps.StripeConnectAccountPolicy do
   def show?(%User{} = user, %StripeConnectAccount{} = stripe_connect_account), do: stripe_connect_account |> get_membership(user) |> get_role |> owner?
 
   def create?(%User{} = user, %Ecto.Changeset{} = changeset), do: changeset |> get_membership(user) |> get_role |> owner?
-  def create?(user, changeset) do
-    IO.inspect user
-    IO.inspect changeset
-  end
+  def create?(user, changeset), do: false
 end

--- a/web/policies/stripe_connect_plan_policy.ex
+++ b/web/policies/stripe_connect_plan_policy.ex
@@ -1,0 +1,10 @@
+defmodule CodeCorps.StripeConnectPlanPolicy do
+  import CodeCorps.Helpers.Policy,
+    only: [get_membership: 2, get_project: 1, get_role: 1, owner?: 1]
+
+  alias CodeCorps.StripeConnectPlan
+  alias CodeCorps.User
+
+  def show?(%User{} = user, %StripeConnectPlan{} = plan), do: plan |> get_project |> get_membership(user) |> get_role |> owner?
+  def create?(%User{} = user, %Ecto.Changeset{} = changeset), do: changeset |> get_project |> get_membership(user) |> get_role |> owner?
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -54,6 +54,7 @@ defmodule CodeCorps.Router do
     resources "/role-skills", RoleSkillController, only: [:create, :delete]
     resources "/skills", SkillController, only: [:create]
     resources "/stripe-connect-accounts", StripeConnectAccountController, only: [:show, :create]
+    resources "/stripe-connect-plans", StripeConnectPlanController, only: [:show, :create]
     resources "/stripe-platform-cards", StripePlatformCardController, only: [:show, :create]
     resources "/stripe-platform-customers", StripePlatformCustomerController, only: [:show, :create]
     resources "/tasks", TaskController, only: [:create, :update]

--- a/web/views/project_view.ex
+++ b/web/views/project_view.ex
@@ -1,6 +1,9 @@
 defmodule CodeCorps.ProjectView do
   use CodeCorps.PreloadHelpers,
-    default_preloads: [:donation_goals, :organization, :project_categories, :project_skills, :tasks]
+    default_preloads: [
+      :donation_goals, :organization, :project_categories,
+      :stripe_connect_plan, :project_skills, :tasks
+    ]
   use CodeCorps.Web, :view
   use JaSerializer.PhoenixView
 
@@ -10,6 +13,7 @@ defmodule CodeCorps.ProjectView do
   	:inserted_at, :updated_at]
 
   has_one :organization, serializer: CodeCorps.OrganizationView
+  has_one :stripe_connect_plan, serializer: CodeCorps.StripeConnectPlanView
 
   has_many :donation_goals, serializer: CodeCorps.DonationGoalView, identifiers: :always
   has_many :project_categories, serializer: CodeCorps.ProjectCategoryView, identifiers: :always

--- a/web/views/stripe_connect_plan_view.ex
+++ b/web/views/stripe_connect_plan_view.ex
@@ -1,0 +1,9 @@
+defmodule CodeCorps.StripeConnectPlanView do
+  use CodeCorps.PreloadHelpers, default_preloads: [:project]
+  use CodeCorps.Web, :view
+  use JaSerializer.PhoenixView
+
+  attributes [:amount, :created, :id_from_stripe, :inserted_at, :name, :updated_at]
+
+  has_one :project, serializer: CodeCorps.ProjectView
+end


### PR DESCRIPTION
# What's in this PR?

* We have `show` and `create` actions with respective policies.
* The stripe plan is created using the `connect_account` option. Is this the right approach, or are we creating the plan on our on account?

* [x] Needs tests

## References

Fixes #477, #478
