### PR TITLE
Rename StripeSubscription to StripeConnectSubscription

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -1449,15 +1449,15 @@ The Stripe Connect plan resource allows users to select a monthly donation amoun
 
     + Attributes (Record Not Found Response)
 
-# Group Stripe Subscriptions
+# Group Stripe Connect Subscriptions
 
-This endpoint is for creating, editing and returning Stripe Subscriptions.
+This endpoint is for creating, editing and returning Stripe Connect Subscriptions.
 
-Stripe subscriptions allow us to charge a customer's card on a recurring basis. A subscription ties a customer to a particular plan. The default plans will be monthly $0.01 cent plans with an X multiplier to set the actual donation amount.
+Stripe Connect subscriptions allow us to charge a customer's card on a recurring basis. A subscription ties a customer to a particular plan. The default plans will be monthly $0.01 cent plans with an X multiplier to set the actual donation amount.
 
-## Stripe Subscriptions [/stripe-subscriptions]
+## Stripe Connect Subscriptions [/stripe-connect-subscriptions]
 
-### Create a Stripe subscription [POST]
+### Create a Stripe Connect subscription [POST]
 
 + Request
 
@@ -1468,7 +1468,7 @@ Stripe subscriptions allow us to charge a customer's card on a recurring basis. 
 
 + Response 201 (application/vnd.api+json; charset=utf-8)
 
-    + Attributes (Stripe Subscription Response)
+    + Attributes (Stripe Connect Subscription Response)
 
 + Response 401 (application/vnd.api+json; charset=utf-8)
 
@@ -1482,13 +1482,13 @@ Stripe subscriptions allow us to charge a customer's card on a recurring basis. 
 
     + Attributes (Unprocessable Entity Response)
 
-## Stripe Subscription [/stripe-subscriptions/{id}]
+## Stripe Connect Subscription [/stripe-connect-subscriptions/{id}]
 
 + Parameters
 
     + id (number, required)
 
-### Retrieve a Stripe subscription [GET]
+### Retrieve a Stripe Connect subscription [GET]
 
 + Request
 
@@ -1499,7 +1499,7 @@ Stripe subscriptions allow us to charge a customer's card on a recurring basis. 
 
 + Response 200 (application/vnd.api+json; charset=utf-8)
 
-    + Attributes (Stripe Subscription Response)
+    + Attributes (Stripe Connect Subscription Response)
 
 + Response 401 (application/vnd.api+json; charset=utf-8)
 
@@ -1513,7 +1513,7 @@ Stripe subscriptions allow us to charge a customer's card on a recurring basis. 
 
     + Attributes (Record Not Found Response)
 
-### Update a Stripe subscription [PATCH /subscriptions/{id}]
+### Update a Stripe Connect subscription [PATCH /subscriptions/{id}]
 
 + Request
 
@@ -1524,7 +1524,7 @@ Stripe subscriptions allow us to charge a customer's card on a recurring basis. 
 
 + Response 201 (application/vnd.api+json; charset=utf-8)
 
-    + Attributes (Stripe Subscription Response)
+    + Attributes (Stripe Connect Subscription Response)
 
 + Response 403 (application/vnd.api+json; charset=utf-8)
 
@@ -2745,7 +2745,7 @@ This endpoint allows you to check whether a username is valid (by running a vali
 + data(array[Stripe Connect Plan Resource])
 + include JSON API Version
 
-## Stripe Subscription Attributes (object)
+## Stripe Connect Subscription Attributes (object)
 + `cancelled-at`: null (string) - If the subscription has been canceled, the date of that cancellation.
 + created: `2016-07-08T03:03:51.967Z` (string) - A timestamp, indicating when the plan was created by Stripe
 + `current-period-end`: `2016-08-08T03:03:51.967Z` (string) - End of the current period that the subscription has been invoiced for. At the end of this period, a new invoice will be created.
@@ -2765,25 +2765,25 @@ This endpoint allows you to check whether a username is valid (by running a vali
       + `unpaid`
 + `updated-at`: `2014-07-07T18:01:26.000Z` (string)
 
-## Stripe Subscription Resource (object)
-+ include Stripe Subscription Resource Identifier
-+ attributes(Stripe Subscription Attributes)
+## Stripe Connect Subscription Resource (object)
++ include Stripe Connect Subscription Resource Identifier
++ attributes(Stripe Connect Subscription Attributes)
 + relationships
     + `stripe-platform-customer`
         + data(Stripe Platform Customer Resource Identifier)
     + `stripe-connect-plan`
         + data(Stripe Connect Plan Resource Identifier)
 
-## Stripe Subscription Resource Identifier
+## Stripe Connect Subscription Resource Identifier
 + id: `1` (string, required)
-+ type: `stripe-subscription` (string, required)
++ type: `stripe-connect-subscription` (string, required)
 
-## Stripe Subscription Response
-+ data(Stripe Subscription Resource)
+## Stripe Connect Subscription Response
++ data(Stripe Connect Subscription Resource)
 + include JSON API Version
 
-## Stripe Subscriptions Response
-+ data(array[Stripe Subscription Resource])
+## Stripe Connect Subscriptions Response
++ data(array[Stripe Connect Subscription Resource])
 + include JSON API Version
 
 ## Task Attributes (object)

--- a/lib/code_corps/stripe/adapters/stripe_connect_subscription.ex
+++ b/lib/code_corps/stripe/adapters/stripe_connect_subscription.ex
@@ -1,14 +1,14 @@
-defmodule CodeCorps.Stripe.Adapters.StripeSubscription do
+defmodule CodeCorps.Stripe.Adapters.StripeConnectSubscription do
   @moduledoc """
   Used for conversion between stripe api payload maps and maps
-  usable for creation of StripeSubscription records locally
+  usable for creation of StripeConnectSubscription records locally
   """
 
   import CodeCorps.MapUtils, only: [rename: 3]
 
   @doc """
   Converts a map received from the Stripe API into a map that can be used
-  to create a `CodeCorps.StripeSubscription` record
+  to create a `CodeCorps.StripeConnectSubscription` record
   """
   def params_from_stripe(%{} = stripe_map) do
     stripe_map

--- a/priv/repo/migrations/20161123150943_rename_stripe_connect_subscriptions.exs
+++ b/priv/repo/migrations/20161123150943_rename_stripe_connect_subscriptions.exs
@@ -1,0 +1,65 @@
+defmodule CodeCorps.Repo.Migrations.RenameStripeConnectSubscriptions do
+  use Ecto.Migration
+
+  def up do
+    execute "ALTER TABLE stripe_subscriptions DROP CONSTRAINT stripe_subscriptions_stripe_connect_plan_id_fkey"
+    execute "ALTER TABLE stripe_subscriptions DROP CONSTRAINT IF EXISTS stripe_subscriptions_pkey"
+
+    execute "DROP INDEX IF EXISTS stripe_subscriptions_pkey"
+
+    drop unique_index(:stripe_subscriptions, [:id_from_stripe])
+
+    drop index(:stripe_subscriptions, [:user_id])
+    drop index(:stripe_subscriptions, [:plan_id_from_stripe])
+    drop index(:stripe_subscriptions, [:stripe_connect_plan_id])
+
+    rename table(:stripe_subscriptions), to: table(:stripe_connect_subscriptions)
+
+    execute "CREATE UNIQUE INDEX stripe_connect_subscriptions_pkey ON stripe_connect_subscriptions USING btree (id)"
+
+    execute "ALTER SEQUENCE stripe_subscriptions_id_seq RENAME TO stripe_connect_subscriptions_id_seq"
+
+    execute "ALTER TABLE stripe_connect_subscriptions RENAME CONSTRAINT stripe_subscriptions_user_id_fkey TO stripe_connect_subscriptions_user_id_fkey"
+
+    create index(:stripe_connect_subscriptions, [:user_id])
+    create index(:stripe_connect_subscriptions, [:plan_id_from_stripe])
+    create index(:stripe_connect_subscriptions, [:stripe_connect_plan_id])
+
+    create unique_index(:stripe_connect_subscriptions, [:id_from_stripe], unique: true)
+
+    alter table(:stripe_connect_subscriptions) do
+      modify :stripe_connect_plan_id, references(:stripe_connect_plans)
+    end
+  end
+
+  def down do
+    execute "ALTER TABLE stripe_connect_subscriptions DROP CONSTRAINT stripe_connect_subscriptions_stripe_connect_plan_id_fkey"
+    execute "ALTER TABLE stripe_connect_subscriptions DROP CONSTRAINT IF EXISTS stripe_connect_subscriptions_pkey"
+
+    execute "DROP INDEX stripe_connect_subscriptions_pkey"
+
+    drop_if_exists index(:stripe_connect_subscriptions, [:user_id])
+    drop_if_exists index(:stripe_connect_subscriptions, [:plan_id_from_stripe])
+    drop_if_exists index(:stripe_connect_subscriptions, [:stripe_connect_plan_id])
+
+    drop_if_exists unique_index(:stripe_connect_subscriptions, [:id_from_stripe])
+
+    rename table(:stripe_connect_subscriptions), to: table(:stripe_subscriptions)
+
+    execute "CREATE UNIQUE INDEX stripe_subscriptions_pkey ON stripe_subscriptions USING btree (id)"
+
+    execute "ALTER SEQUENCE stripe_connect_subscriptions_id_seq RENAME TO stripe_subscriptions_id_seq"
+
+    execute "ALTER TABLE stripe_subscriptions RENAME CONSTRAINT stripe_connect_subscriptions_user_id_fkey TO stripe_subscriptions_user_id_fkey"
+
+    create index(:stripe_subscriptions, [:user_id])
+    create index(:stripe_subscriptions, [:plan_id_from_stripe])
+    create index(:stripe_subscriptions, [:stripe_connect_plan_id])
+
+    create unique_index(:stripe_subscriptions, [:id_from_stripe])
+
+    alter table(:stripe_subscriptions) do
+      modify :stripe_connect_plan_id, references(:stripe_connect_plans)
+    end
+  end
+end

--- a/test/lib/code_corps/stripe/adapters/stripe_connect_subscription_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_connect_subscription_test.exs
@@ -1,7 +1,7 @@
-defmodule CodeCorps.Stripe.Adapters.StripeSubscriptionTest do
+defmodule CodeCorps.Stripe.Adapters.StripeConnectSubscriptionTest do
   use ExUnit.Case, async: true
 
-  import CodeCorps.Stripe.Adapters.StripeSubscription, only: [params_from_stripe: 1]
+  import CodeCorps.Stripe.Adapters.StripeConnectSubscription, only: [params_from_stripe: 1]
 
   @stripe_map %{"id" => "str_123", "stripe_connect_plan" => "pln_123", "foo" => "bar", "customer" => "cus_123"}
   @local_map %{"id_from_stripe" => "str_123", "plan_id_from_stripe" => "pln_123", "foo" => "bar", "customer_id_from_stripe" => "cus_123"}

--- a/test/models/stripe_connect_subscription_test.exs
+++ b/test/models/stripe_connect_subscription_test.exs
@@ -1,7 +1,7 @@
-defmodule CodeCorps.StripeSubscriptionTest do
+defmodule CodeCorps.StripeConnectSubscriptionTest do
   use CodeCorps.ModelCase
 
-  alias CodeCorps.StripeSubscription
+  alias CodeCorps.StripeConnectSubscription
 
   @valid_attrs %{
     id_from_stripe: "abc123",
@@ -16,12 +16,12 @@ defmodule CodeCorps.StripeSubscriptionTest do
       user_id = insert(:user).id
 
       changes = Map.merge(@valid_attrs, %{stripe_connect_plan_id: stripe_connect_plan_id, user_id: user_id})
-      changeset = StripeSubscription.create_changeset(%StripeSubscription{}, changes)
+      changeset = StripeConnectSubscription.create_changeset(%StripeConnectSubscription{}, changes)
       assert changeset.valid?
     end
 
     test "reports as invalid when attributes are invalid" do
-      changeset = StripeSubscription.create_changeset(%StripeSubscription{}, @invalid_attrs)
+      changeset = StripeConnectSubscription.create_changeset(%StripeConnectSubscription{}, @invalid_attrs)
       refute changeset.valid?
 
       assert changeset.errors[:id_from_stripe] == {"can't be blank", []}
@@ -34,7 +34,7 @@ defmodule CodeCorps.StripeSubscriptionTest do
       attrs =  @valid_attrs |> Map.merge(%{stripe_connect_plan_id: -1, user_id: user_id})
 
       { result, changeset } =
-        StripeSubscription.create_changeset(%StripeSubscription{}, attrs)
+        StripeConnectSubscription.create_changeset(%StripeConnectSubscription{}, attrs)
         |> Repo.insert
 
       assert result == :error
@@ -47,7 +47,7 @@ defmodule CodeCorps.StripeSubscriptionTest do
       attrs =  @valid_attrs |> Map.merge(%{stripe_connect_plan_id: stripe_connect_plan_id, user_id: -1})
 
       { result, changeset } =
-        StripeSubscription.create_changeset(%StripeSubscription{}, attrs)
+        StripeConnectSubscription.create_changeset(%StripeConnectSubscription{}, attrs)
         |> Repo.insert
 
       assert result == :error

--- a/web/models/stripe_connect_subscription.ex
+++ b/web/models/stripe_connect_subscription.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.StripeSubscription do
+defmodule CodeCorps.StripeConnectSubscription do
   @moduledoc """
   Represents a `Subscription` object created using the Stripe API
 
@@ -27,7 +27,7 @@ defmodule CodeCorps.StripeSubscription do
 
   use CodeCorps.Web, :model
 
-  schema "stripe_subscriptions" do
+  schema "stripe_connect_subscriptions" do
     field :application_fee_percent, :decimal
     field :cancelled_at, Ecto.DateTime
     field :created, Ecto.DateTime


### PR DESCRIPTION
# What's in this PR?

Just a rename of `StripeSubscription` to `StripeConnectSubscription`. Should be mergeable on it's own, before implementing endpoints and policies.

## References

Fixes #473
