### PR TITLE
Add policy, adapters, etc for StripeConnectSubscription

### DIFF
--- a/lib/code_corps/stripe/adapters/stripe_connect_subscription.ex
+++ b/lib/code_corps/stripe/adapters/stripe_connect_subscription.ex
@@ -4,16 +4,53 @@ defmodule CodeCorps.Stripe.Adapters.StripeConnectSubscription do
   usable for creation of StripeConnectSubscription records locally
   """
 
-  import CodeCorps.MapUtils, only: [rename: 3]
+  alias CodeCorps.Stripe.Adapters
+
+  import CodeCorps.MapUtils, only: [rename: 3, keys_to_string: 1]
+
+  @stripe_attributes [
+    :application_fee_percent, :canceled_at, :created, :current_period_end, :current_period_start, :customer, :ended_at, :id, :plan_id_from_stripe,
+    :quantity, :start, :status
+  ]
 
   @doc """
   Converts a map received from the Stripe API into a map that can be used
   to create a `CodeCorps.StripeConnectSubscription` record
   """
-  def params_from_stripe(%{} = stripe_map) do
-    stripe_map
-    |> rename("id", "id_from_stripe")
-    |> rename("stripe_connect_plan", "plan_id_from_stripe")
-    |> rename("customer", "customer_id_from_stripe")
+  def to_params(%Stripe.Subscription{plan: stripe_plan} = stripe_subscription, %{} = attributes) do
+    result =
+      stripe_subscription
+      |> Map.from_struct
+      |> Map.take(@stripe_attributes)
+      |> rename(:id, :id_from_stripe)
+      |> rename(:canceled_at, :cancelled_at)
+      |> rename(:customer, :customer_id_from_stripe)
+      |> add_plan(stripe_plan)
+      |> keys_to_string
+      |> add_non_stripe_attributes(attributes)
+
+    {:ok, result}
+  end
+
+  @non_stripe_attributes ["stripe_connect_plan_id", "user_id"]
+
+  defp add_non_stripe_attributes(%{} = params, %{} = attributes) do
+    attributes
+    |> get_non_stripe_attributes
+    |> add_to(params)
+  end
+
+  defp get_non_stripe_attributes(%{} = attributes) do
+    attributes
+    |> Map.take(@non_stripe_attributes)
+  end
+
+  defp add_to(%{} = attributes, %{} = params) do
+    params
+    |> Map.merge(attributes)
+  end
+
+  defp add_plan(subscription, %Stripe.Plan{id: id} = plan) do
+    subscription |> Map.put("plan_id_from_stripe", id)
   end
 end

--- a/lib/code_corps/stripe/stripe_connect_plan.ex
+++ b/lib/code_corps/stripe/stripe_connect_plan.ex
@@ -23,13 +23,13 @@ defmodule CodeCorps.Stripe.StripeConnectPlan do
     end
   end
 
-  defp to_create_attributes(%Project{id: id, slug: slug, title: title}) do
+  defp to_create_attributes(%Project{title: title}) do
     %{
       amount: 1,
       currency: "usd",
-      id: "plan_#{slug}_#{id}",
+      id: "month",
       interval: "month",
-      name: "Monthly donation plan to #{title} on CodeCorps"
+      name: "Monthly donation to #{title}."
     }
   end
 

--- a/lib/code_corps/stripity_stripe_testing/subscription.ex
+++ b/lib/code_corps/stripity_stripe_testing/subscription.ex
@@ -1,0 +1,31 @@
+defmodule CodeCorps.StripityStripeTesting.Subscription do
+  def create(map, _opts) do
+    {:ok, do_create(map)}
+  end
+
+  defp do_create(_) do
+    {:ok, date} = DateTime.from_unix(1479472835)
+
+    %Stripe.Subscription{
+      application_fee_percent: 5.0,
+      cancel_at_period_end: false,
+      canceled_at: nil,
+      created: date,
+      current_period_end: date,
+      current_period_start: date,
+      customer: "cus_123",
+      ended_at: nil,
+      id: "sub_123",
+      livemode: false,
+      metadata: %{},
+      plan: CodeCorps.StripityStripeTesting.Plan.create(%{}, []),
+      quantity: 1000,
+      source: nil,
+      start: date,
+      status: "active",
+      tax_percent: nil,
+      trial_end: nil,
+      trial_start: nil
+    }
+  end
+end

--- a/test/lib/code_corps/stripe/adapters/stripe_connect_plan_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_connect_plan_test.exs
@@ -6,7 +6,7 @@ defmodule CodeCorps.Stripe.Adapters.StripeConnectPlanTest do
   {:ok, timestamp} = DateTime.from_unix(1479472835)
 
   @stripe_connect_plan %Stripe.Plan{
-    id: "plan_9aMOFmqy1esIRE",
+    id: "month",
     amount: 5000,
     created: timestamp,
     currency: "usd",
@@ -22,7 +22,7 @@ defmodule CodeCorps.Stripe.Adapters.StripeConnectPlanTest do
   @local_map %{
     "amount" => 5000,
     "created" => timestamp,
-    "id_from_stripe" => "plan_9aMOFmqy1esIRE",
+    "id_from_stripe" => "month",
     "name" => "Monthly subscription for Code Corps"
   }
 

--- a/test/lib/code_corps/stripe/adapters/stripe_connect_subscription_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_connect_subscription_test.exs
@@ -1,14 +1,75 @@
 defmodule CodeCorps.Stripe.Adapters.StripeConnectSubscriptionTest do
   use ExUnit.Case, async: true
 
-  import CodeCorps.Stripe.Adapters.StripeConnectSubscription, only: [params_from_stripe: 1]
+  import CodeCorps.Stripe.Adapters.StripeConnectSubscription, only: [to_params: 2]
 
-  @stripe_map %{"id" => "str_123", "stripe_connect_plan" => "pln_123", "foo" => "bar", "customer" => "cus_123"}
-  @local_map %{"id_from_stripe" => "str_123", "plan_id_from_stripe" => "pln_123", "foo" => "bar", "customer_id_from_stripe" => "cus_123"}
+  {:ok, date} = DateTime.from_unix(1479472835)
 
-  describe "params_from_stripe/1" do
+  @stripe_connect_subscription %Stripe.Subscription{
+    application_fee_percent: 5.0,
+    cancel_at_period_end: false,
+    canceled_at: nil,
+    created: date,
+    current_period_end: date,
+    current_period_start: date,
+    customer: "cus_123",
+    ended_at: nil,
+    id: "sub_123",
+    livemode: false,
+    metadata: %{},
+    plan: %Stripe.Plan{
+      id: "month",
+      amount: 5000,
+      created: date,
+      currency: "usd",
+      interval: "month",
+      interval_count: 1,
+      livemode: false,
+      metadata: %{},
+      name: "Monthly subscription for Code Corps",
+      statement_descriptor: nil,
+      trial_period_days: nil
+    },
+    quantity: 1000,
+    source: nil,
+    start: date,
+    status: "active",
+    tax_percent: nil,
+    trial_end: nil,
+    trial_start: nil
+  }
+
+  @local_map %{
+    "application_fee_percent" => 5.0,
+    "cancelled_at" => nil,
+    "created" => date,
+    "current_period_end" => date,
+    "current_period_start" => date,
+    "customer_id_from_stripe" => "cus_123",
+    "ended_at" => nil,
+    "id_from_stripe" => "sub_123",
+    "plan_id_from_stripe" => "month",
+    "quantity" => 1000,
+    "start" => date,
+    "status" => "active"
+  }
+
+  describe "to_params/2" do
     test "converts from stripe map to local properly" do
-      assert @stripe_map |> params_from_stripe == @local_map
+      test_attributes = %{
+        "stripe_connect_plan_id" => 123,
+        "user_id" =>123,
+        "foo" => "bar"
+      }
+      expected_attributes = %{
+        "stripe_connect_plan_id" => 123,
+        "user_id" =>123
+      }
+
+      {:ok, result} = to_params(@stripe_connect_subscription, test_attributes)
+      expected_map = Map.merge(@local_map, expected_attributes)
+
+      assert result == expected_map
     end
   end
 end

--- a/test/lib/code_corps/stripe/adapters/stripe_platform_card_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_platform_card_test.exs
@@ -4,7 +4,7 @@ defmodule CodeCorps.Stripe.Adapters.StripePlatformCardTest do
   import CodeCorps.Stripe.Adapters.StripePlatformCard, only: [to_params: 2]
 
   @stripe_platform_card %Stripe.Card{
-    id: "card_19IHPnBKl1F6IRFf8w7gpdOe",
+    id: "card_123",
     metadata: %{},
     address_city: nil,
     address_country: nil,
@@ -16,7 +16,7 @@ defmodule CodeCorps.Stripe.Adapters.StripePlatformCardTest do
     address_zip_check: nil,
     brand: "Visa",
     country: "US",
-    customer: "cus_123456",
+    customer: "cus_123",
     cvc_check: "unchecked",
     dynamic_last4: nil,
     exp_month: 11,
@@ -29,12 +29,12 @@ defmodule CodeCorps.Stripe.Adapters.StripePlatformCardTest do
   }
 
   @local_map %{
-    "id_from_stripe" => "card_19IHPnBKl1F6IRFf8w7gpdOe",
+    "id_from_stripe" => "card_123",
     "brand" => "Visa",
     "exp_month" => 11,
     "exp_year" => 2016,
     "last4" => "4242",
-    "customer_id_from_stripe" => "cus_123456",
+    "customer_id_from_stripe" => "cus_123",
     "cvc_check" => "unchecked",
     "name" => nil
   }

--- a/test/lib/code_corps/stripe/adapters/stripe_platform_customer_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_platform_customer_test.exs
@@ -6,7 +6,7 @@ defmodule CodeCorps.Stripe.Adapters.StripePlatformCustomerTest do
   {:ok, timestamp} = DateTime.from_unix(1479472835)
 
   @stripe_platform_customer %Stripe.Customer{
-    id: "cus_9aMOFmqy1esIRE",
+    id: "cus_123",
     account_balance: 0,
     created: timestamp,
     currency: "usd",
@@ -19,7 +19,7 @@ defmodule CodeCorps.Stripe.Adapters.StripePlatformCustomerTest do
   }
 
   @local_map %{
-    "id_from_stripe" => "cus_9aMOFmqy1esIRE",
+    "id_from_stripe" => "cus_123",
     "created" => timestamp,
     "currency" => "usd",
     "delinquent" => false,

--- a/test/policies/stripe_connect_subscription_policy_test.exs
+++ b/test/policies/stripe_connect_subscription_policy_test.exs
@@ -1,0 +1,40 @@
+defmodule CodeCorps.StripeConnectSubscriptionPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.StripeConnectSubscriptionPolicy, only: [create?: 2, show?: 2]
+  import CodeCorps.StripeConnectSubscription, only: [create_changeset: 2]
+
+  alias CodeCorps.StripeConnectSubscription
+
+  describe "create?" do
+    test "returns true if user is creating their own record" do
+      user = insert(:user)
+      changeset = %StripeConnectSubscription{} |> create_changeset(%{user_id: user.id})
+
+      assert create?(user, changeset)
+    end
+
+    test "returns false if user is creating someone else's record" do
+      user = build(:user)
+      changeset = %StripeConnectSubscription{} |> create_changeset(%{user_id: -1})
+
+      refute create?(user, changeset)
+    end
+  end
+
+  describe "show?" do
+    test "returns true if user is viewing their own record" do
+      user = insert(:user)
+      stripe_connect_subscription = insert(:stripe_connect_subscription, user: user)
+
+      assert show?(user, stripe_connect_subscription)
+    end
+
+    test "returns false if user is viewing someone else's record" do
+      user = insert(:user)
+      stripe_connect_subscription = insert(:stripe_connect_subscription)
+
+      refute show?(user, stripe_connect_subscription)
+    end
+  end
+end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -119,6 +119,16 @@ defmodule CodeCorps.Factories do
     }
   end
 
+  def stripe_connect_subscription_factory do
+    stripe_connect_plan = build(:stripe_connect_plan)
+    %CodeCorps.StripeConnectSubscription{
+      id_from_stripe: sequence(:id_from_stripe, &"stripe_id_#{&1}"),
+      plan_id_from_stripe: stripe_connect_plan.id_from_stripe,
+      stripe_connect_plan: stripe_connect_plan,
+      user: build(:user)
+    }
+  end
+
   def stripe_platform_customer_factory do
     %CodeCorps.StripePlatformCustomer{
       created: Timex.now,

--- a/web/controllers/stripe_connect_plan_controller.ex
+++ b/web/controllers/stripe_connect_plan_controller.ex
@@ -17,7 +17,7 @@ defmodule CodeCorps.StripeConnectPlanController do
   defp handle_create_result({:ok, %StripeConnectPlan{}} = result, conn) do
     result |> CodeCorps.Analytics.Segment.track(:created, conn)
   end
-  defp handle_create_result({:error, %Stripe.APIErrorResponse{}} = error, conn) do
+  defp handle_create_result({:error, %Stripe.APIErrorResponse{}}, conn) do
     conn
     |> put_status(500)
     |> render(CodeCorps.ErrorView, "500.json-api")

--- a/web/policies/stripe_connect_subscription_policy.ex
+++ b/web/policies/stripe_connect_subscription_policy.ex
@@ -1,0 +1,16 @@
+defmodule CodeCorps.StripeConnectSubscriptionPolicy do
+  alias CodeCorps.StripeConnectSubscription
+  alias CodeCorps.User
+  alias Ecto.Changeset
+
+  def create?(user, subscription), do: user |> owns?(subscription)
+  def show?(user, subscription), do: user |> owns?(subscription)
+
+  defp owns?(%User{id: current_user_id}, %Changeset{changes: %{user_id: user_id}}) do
+    current_user_id == user_id
+  end
+  defp owns?(%User{id: current_user_id}, %StripeConnectSubscription{user_id: user_id}) do
+    current_user_id == user_id
+  end
+  defp owns?(_, _), do: false
+end


### PR DESCRIPTION
# What's in this PR?

Adds policy, adapters, etc for `StripeConnectSubscription`.

## References
Fixes #457 