### PR TITLE
Update Stripe webhooks

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -46,7 +46,10 @@ config :guardian, Guardian,
   secret_key: "e62fb6e2746f6b1bf8b5b735ba816c2eae1d5d76e64f18f3fc647e308b0c159e"
 
 config :code_corps, :analytics, CodeCorps.Analytics.InMemoryAPI
+
+# Configures stripe for dev mode
 config :code_corps, :stripe, Stripe
+config :code_corps, :stripe_env, :dev
 
 config :sentry,
   environment_name: Mix.env || :dev

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -41,6 +41,10 @@ config :logger, level: :info
 # Configures Segment for analytics
 config :code_corps, :analytics, CodeCorps.Analytics.SegmentAPI
 
+# Configures stripe for production
+config :code_corps, :stripe, Stripe
+config :code_corps, :stripe_env, :prod
+
 config :sentry,
   environment_name: Mix.env || :prod
 

--- a/config/remote-development.exs
+++ b/config/remote-development.exs
@@ -32,6 +32,11 @@ config :guardian, Guardian,
 # Do not print debug messages in production
 config :logger, level: :info
 
+
+# Configures stripe for remote dev
+config :code_corps, :stripe, Stripe
+config :code_corps, :stripe_env, :remote_dev
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -43,6 +43,10 @@ config :code_corps, :analytics, CodeCorps.Analytics.SegmentAPI
 config :sentry,
   environment_name: Mix.env || :staging
 
+# Configures stripe for staging
+config :code_corps, :stripe, Stripe
+config :code_corps, :stripe_env, :staging
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,7 +30,9 @@ config :guardian, Guardian,
 
 config :code_corps, :analytics, CodeCorps.Analytics.TestAPI
 
+# Configures stripe for test mode
 config :code_corps, :stripe, CodeCorps.StripeTesting
+config :code_corps, :stripe_env, :test
 
 config :code_corps, :icon_color_generator, CodeCorps.RandomIconColor.TestGenerator
 

--- a/lib/code_corps/services/base64_image.ex
+++ b/lib/code_corps/services/base64_image.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.Base64Image do
+defmodule CodeCorps.Services.Base64ImageService do
   def save_to_file("data:" <> data_string) do
     [content_type, content_string] =
       data_string

--- a/lib/code_corps/services/base64_image_uploader.ex
+++ b/lib/code_corps/services/base64_image_uploader.ex
@@ -1,6 +1,8 @@
-defmodule CodeCorps.Base64ImageUploader do
+defmodule CodeCorps.Services.Base64ImageUploaderService do
   use Arc.Ecto.Schema
   import Ecto.Changeset, only: [cast: 3, validate_required: 2]
+
+  alias CodeCorps.Services.Base64ImageService
 
   @doc """
   Takes a changeset, a virtual origin field containing base64 image
@@ -18,7 +20,7 @@ defmodule CodeCorps.Base64ImageUploader do
   defp do_upload_image(changeset, image_content, destination_field) do
     plug_upload =
       image_content
-      |> CodeCorps.Base64Image.save_to_file()
+      |> Base64ImageService.save_to_file()
       |> build_plug_upload
 
     changeset

--- a/lib/code_corps/services/markdown_renderer.ex
+++ b/lib/code_corps/services/markdown_renderer.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.MarkdownRenderer do
+defmodule CodeCorps.Services.MarkdownRendererService do
   def render_markdown_to_html(changeset, source_field, destination_field) do
     case changeset do
       %Ecto.Changeset{valid?: false} ->

--- a/lib/code_corps/services/project.ex
+++ b/lib/code_corps/services/project.ex
@@ -1,0 +1,25 @@
+defmodule CodeCorps.Services.ProjectService do
+  @moduledoc """
+  Handles special CRUD operations for `CodeCorps.Project`.
+  """
+
+  import Ecto.Query
+
+  alias CodeCorps.{Project, Repo, StripeConnectPlan, StripeConnectSubscription}
+
+  def update_project_totals(%Project{stripe_connect_plan: %StripeConnectPlan{id: plan_id}} = project) do
+    total_monthly_donated =
+      StripeConnectSubscription
+      |> where([s], s.status == "active" and s.stripe_connect_plan_id == ^plan_id)
+      |> Repo.aggregate(:sum, :quantity)
+
+    total_monthly_donated = default_to_zero(total_monthly_donated)
+
+    project
+    |> Project.update_total_changeset(%{total_monthly_donated: total_monthly_donated})
+    |> Repo.update
+  end
+
+  defp default_to_zero(nil), do: 0
+  defp default_to_zero(value), do: value
+end

--- a/lib/code_corps/stripe_service/adapters/stripe_connect_account.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_connect_account.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.StripeService.Adapters.StripeConnectAccount do
+defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter do
   import CodeCorps.MapUtils, only: [rename: 3, keys_to_string: 1]
 
   @stripe_attributes [

--- a/lib/code_corps/stripe_service/adapters/stripe_connect_card.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_connect_card.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.StripeService.Adapters.StripeConnectCard do
+defmodule CodeCorps.StripeService.Adapters.StripeConnectCardAdapter do
   import CodeCorps.MapUtils, only: [rename: 3, keys_to_string: 1]
 
   @stripe_attributes [:id]

--- a/lib/code_corps/stripe_service/adapters/stripe_connect_customer.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_connect_customer.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.StripeService.Adapters.StripeConnectCustomer do
+defmodule CodeCorps.StripeService.Adapters.StripeConnectCustomerAdapter do
   import CodeCorps.MapUtils, only: [rename: 3, keys_to_string: 1]
 
   def to_params(%Stripe.Customer{} = customer, %{} = attributes) do

--- a/lib/code_corps/stripe_service/adapters/stripe_connect_plan.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_connect_plan.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.StripeService.Adapters.StripeConnectPlan do
+defmodule CodeCorps.StripeService.Adapters.StripeConnectPlanAdapter do
   @moduledoc """
   Used for conversion between stripe api payload maps and maps
   usable for creation of `StripeConnectPlan` records locally

--- a/lib/code_corps/stripe_service/adapters/stripe_connect_subscription.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_connect_subscription.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.StripeService.Adapters.StripeConnectSubscription do
+defmodule CodeCorps.StripeService.Adapters.StripeConnectSubscriptionAdapter do
   @moduledoc """
   Used for conversion between stripe api payload maps and maps
   usable for creation of StripeConnectSubscription records locally

--- a/lib/code_corps/stripe_service/adapters/stripe_platform_card.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_platform_card.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.StripeService.Adapters.StripePlatformCard do
+defmodule CodeCorps.StripeService.Adapters.StripePlatformCardAdapter do
   import CodeCorps.MapUtils, only: [rename: 3, keys_to_string: 1]
 
   @stripe_attributes [:brand, :customer, :cvc_check, :exp_month, :exp_year, :id, :last4, :name, :user_id]

--- a/lib/code_corps/stripe_service/adapters/stripe_platform_customer.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_platform_customer.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.StripeService.Adapters.StripePlatformCustomer do
+defmodule CodeCorps.StripeService.Adapters.StripePlatformCustomerAdapter do
   import CodeCorps.MapUtils, only: [rename: 3, keys_to_string: 1]
 
   def to_params(%Stripe.Customer{} = customer, %{} = attributes) do

--- a/lib/code_corps/stripe_service/events/account_updated.ex
+++ b/lib/code_corps/stripe_service/events/account_updated.ex
@@ -1,148 +1,25 @@
 defmodule CodeCorps.StripeService.Events.AccountUpdated do
-  alias CodeCorps.StripeService.Adapters
+  alias CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter
   alias CodeCorps.StripeConnectAccount
   alias CodeCorps.Repo
 
   @api Application.get_env(:code_corps, :stripe)
 
-  # def handle(%{"data" => %{"object" => %{"livemode" => false}}}), do: {:ok, :ignored_not_live}
-  def handle(%{"data" => data}) do
-    stripe_account = data |> retrieve_account
-    local_account = data |> load_account
-
-    local_account |> update(stripe_account)
-  end
-
-  defp retrieve_account(%{"object" => %{"id" => id_from_stripe}}) do
-    # hardcoded for testing
-    id_from_stripe = "acct_19JlxsFTVVt7Lv80"
-
-    {:ok, stripe_account} = @api.Account.retrieve(id_from_stripe)
-    stripe_account
-  end
-
-  defp load_account(%{"object" => %{"id" => id_from_stripe}}) do
-     # hardcoded for testing
-    id_from_stripe = "acct_19JlxsFTVVt7Lv80"
-
-    StripeConnectAccount
-    |> Repo.get_by(id_from_stripe: id_from_stripe)
-  end
-
-  defp update(%StripeConnectAccount{} = record, %Stripe.Account{} = stripe_account) do
-    {:ok, params} =
-      stripe_account
-      |> Adapters.StripeConnectAccount.to_params(%{})
-
-    record
-    |> StripeConnectAccount.webhook_update_changeset(params)
-    |> Repo.update
+  def handle(%{"data" => %{"object" => %{"id" => id_from_stripe}}}) do
+    with {:ok, %Stripe.Account{} = stripe_account} <-
+           @api.Account.retrieve(id_from_stripe),
+         %StripeConnectAccount{} = local_account <-
+           Repo.get_by(StripeConnectAccount, id_from_stripe: id_from_stripe),
+         {:ok, params} <-
+           stripe_account |> StripeConnectAccountAdapter.to_params(%{})
+    do
+      local_account
+      |> StripeConnectAccount.webhook_update_changeset(params)
+      |> Repo.update
+    else
+      {:error, %Stripe.APIErrorResponse{}} -> {:error, :stripe_error}
+      nil -> {:error, :not_found}
+      _ -> {:error, :unexpected}
+    end
   end
 end
-
-account = %{
-  "business_logo" => nil,
-  "business_name" => nil,
-  "business_url" => nil,
-  "charges_enabled" => false,
-  "country" => "US",
-  "debit_negative_balances" => true,
-  "decline_charge_on" => %{
-    "avs_failure" => false, "cvc_failure" => true
-  },
-  "default_currency" => "usd",
-  "details_submitted" => true,
-  "display_name" => nil,
-  "email" => "test@stripe.com",
-  "external_accounts" => %{
-    "data" => [],
-    "has_more" => false,
-    "object" => "list",
-    "total_count" => 0,
-    "url" => "/v1/accounts/acct_17XohmBKl1F6IRFf/external_accounts"
-  },
-  "id" => "acct_00000000000000",
-  "legal_entity" => %{
-    "address" => %{
-      "city" => nil,
-      "country" => "US",
-      "line1" => nil,
-      "line2" => nil,
-      "postal_code" => nil,
-      "state" => nil
-    },
-    "business_name" => nil,
-    "business_tax_id_provided" => false,
-    "dob" => %{
-      "day" => nil,
-      "month" => nil,
-      "year" => nil
-    },
-    "first_name" => nil,
-    "last_name" => nil,
-    "personal_address" => %{
-      "city" => nil,
-      "country" => "US",
-      "line1" => nil,
-      "line2" => nil,
-      "postal_code" => nil,
-      "state" => nil
-    },
-    "personal_id_number_provided" => false,
-    "ssn_last_4_provided" => false,
-    "type" => nil,
-    "verification" => %{
-      "details" => nil,
-      "details_code" => nil,
-      "document" => nil,
-      "status" => "unverified"
-    }
-  },
-  "managed" => false,
-  "object" => "account",
-  "product_description" => nil,
-  "statement_descriptor" => "TEST",
-  "support_email" => nil,
-  "support_phone" => nil,
-  "timezone" => "Europe/Zagreb",
-  "tos_acceptance" => %{
-    "date" => nil,
-    "ip" => nil,
-    "user_agent" => nil
-  },
-  "transfer_schedule" => %{
-    "delay_days" => 2,
-    "interval" => "daily"
-  },
-  "transfer_statement_descriptor" => nil,
-  "transfers_enabled" => false,
-  "verification" => %{
-    "disabled_reason" => "fields_needed",
-    "due_by" => 1480345118,
-    "fields_needed" => [
-      "legal_entity.verification.document"
-    ]
-  }
-}
-
-previous_attributes = %{
-  "verification" => %{
-    "due_by" => nil,
-    "fields_needed" => []
-  }
-}
-
-event = %{
-  "api_version" => "2016-07-06",
-  "created" => 1326853478,
-  "data" => %{
-    "object" => account,
-    "previous_attributes" => previous_attributes
-  },
-  "id" => "evt_00000000000000",
-  "livemode" => false,
-  "object" => "event",
-  "pending_webhooks" => 1,
-  "request" => nil,
-  "type" => "account.updated"
-}

--- a/lib/code_corps/stripe_service/events/customer_subscription_updated.ex
+++ b/lib/code_corps/stripe_service/events/customer_subscription_updated.ex
@@ -3,42 +3,53 @@ defmodule CodeCorps.StripeService.Events.CustomerSubscriptionUpdated do
 
   alias CodeCorps.Project
   alias CodeCorps.Repo
+  alias CodeCorps.Services.DonationGoalsService
+  alias CodeCorps.Services.ProjectService
+  alias CodeCorps.StripeConnectAccount
+  alias CodeCorps.StripeConnectCustomer
   alias CodeCorps.StripeConnectPlan
   alias CodeCorps.StripeConnectSubscription
-  alias CodeCorps.StripeService.Adapters
+  alias CodeCorps.StripeService.Adapters.StripeConnectSubscriptionAdapter
 
   @api Application.get_env(:code_corps, :stripe)
 
-  # def handle(%{"data" => %{"object" => %{"livemode" => false}}}), do: {:ok, :ignored_not_live}
-  def handle(%{"data" => %{"object" => %{"id" => connect_subscription_id, "customer" => connect_customer_id}}}) do
-    {:ok, stripe_subscription} = retrieve_subscription(connect_subscription_id, connect_customer_id)
-    {:ok, params} = stripe_subscription |> Adapters.StripeConnectSubscription.to_params(%{})
+  def handle(%{"data" => %{"object" => %{"id" => stripe_sub_id, "customer" => connect_customer_id}}}) do
+    with %StripeConnectCustomer{stripe_connect_account: %StripeConnectAccount{id_from_stripe: connect_account_id}} <-
+           retrieve_connect_customer(connect_customer_id),
 
-    {:ok, subscription} = connect_customer_id |> load_subscription |> update_subscription(params)
-    {:ok, project} = subscription |> get_project |> update_project_totals
+         {:ok, %Stripe.Subscription{} = stripe_subscription} <-
+           @api.Subscription.retrieve(stripe_sub_id, connect_account: connect_account_id),
 
-    {:ok, subscription, project}
+         subscription <-
+           load_subscription(stripe_sub_id),
+
+         {:ok, params} <-
+           stripe_subscription |> StripeConnectSubscriptionAdapter.to_params(%{}),
+
+         _subscription <-
+           update_subscription(subscription, params),
+
+         project <-
+           get_project(subscription),
+
+         {:ok, project} <-
+           ProjectService.update_project_totals(project)
+    do
+      DonationGoalsService.update_project_goals(project)
+    else
+      {:error, %Stripe.APIErrorResponse{}} -> {:error, :stripe_error}
+      nil -> {:error, :not_found}
+      _ -> {:error, :unexpected}
+    end
   end
 
-  defp retrieve_subscription(connect_subscription_id,  connect_customer_id) do
-    # hardcoded for testing
-    connect_subscription_id = "sub_9d23Hm0TiyrMY4"
-    connect_customer_id = "cus_9d23RTnbRtp5mk"
-
-    connect_customer =
-      CodeCorps.StripeConnectCustomer
-      |> CodeCorps.Repo.get_by(id_from_stripe: connect_customer_id)
-      |> CodeCorps.Repo.preload(:stripe_connect_account)
-
-    connect_account_id = connect_customer.stripe_connect_account.id_from_stripe
-
-    @api.Subscription.retrieve(connect_subscription_id, connect_account: connect_account_id)
+  defp retrieve_connect_customer(connect_customer_id) do
+    StripeConnectCustomer
+    |> Repo.get_by(id_from_stripe: connect_customer_id)
+    |> Repo.preload(:stripe_connect_account)
   end
 
   defp load_subscription(id_from_stripe) do
-     # hardcoded for testing
-    id_from_stripe = "sub_9d23Hm0TiyrMY4"
-
     StripeConnectSubscription
     |> Repo.get_by(id_from_stripe: id_from_stripe)
   end
@@ -53,85 +64,7 @@ defmodule CodeCorps.StripeService.Events.CustomerSubscriptionUpdated do
     plan =
       StripeConnectPlan
       |> Repo.get(stripe_connect_plan_id)
-      |> Repo.preload(:project)
 
-    plan.project
-  end
-
-  defp update_project_totals(%Project{id: project_id} = project) do
-    total_monthly_donated =
-      StripeConnectSubscription
-      |> where([s], s.status=="active")
-      |> Repo.aggregate(:sum, :quantity)
-
-    project
-    |> Project.update_total_changeset(%{total_monthly_donated: total_monthly_donated})
-    |> Repo.update
+    Project |> Repo.get(plan.project_id) |> Repo.preload(:stripe_connect_plan)
   end
 end
-
-old_subscription_attributes = %{
-  "plan" => %{
-    "amount" => 1,
-    "created" => 1479981880,
-    "currency" => "usd",
-    "id" => "OLD_PLAN_ID",
-    "interval" => "month",
-    "interval_count" => 1,
-    "livemode" => false,
-    "metadata" => %{},
-    "name" => "Old plan",
-    "object" => "plan",
-    "statement_descriptor" => nil,
-    "trial_period_days" => nil
-  }
-}
-
-current_subscription_attributes = %{
-  "application_fee_percent" => nil,
-  "cancel_at_period_end" => false,
-  "canceled_at" => nil,
-  "created" => 1480085925,
-  "current_period_end" => 1482677925,
-  "current_period_start" => 1480085925,
-  "customer" => "cus_00000000000000",
-  "discount" => nil,
-  "ended_at" => nil,
-  "id" => "sub_00000000000000",
-  "livemode" => false,
-  "metadata" => %{},
-  "object" => "subscription",
-  "plan" => %{
-    "amount" => 1,
-    "created" => 1479981880,
-    "currency" => "usd",
-    "id" => "month_00000000000000",
-    "interval" => "month",
-    "interval_count" => 1,
-    "livemode" => false,
-    "metadata" => %{},
-    "name" => "Monthly donation to Code Corps.", "object" => "plan",
-    "statement_descriptor" => nil,
-    "trial_period_days" => nil
-  },
-  "quantity" => 1,
-  "start" => 1480085925,
-  "status" => "active",
-  "tax_percent" => nil,
-  "trial_end" => nil,
-  "trial_start" => nil
-}
-
-event = %{
-  "api_version" => "2016-07-06",
-  "created" => 1326853478,
-  "data" => %{
-    "object" => current_subscription_attributes,
-    "previous_attributes" => old_subscription_attributes
-  },
-  "id" => "evt_00000000000000",
-  "livemode" => false,
-  "object" => "event",
-  "pending_webhooks" => 1, "request" => nil,
-  "type" => "customer.subscription.updated"
-}

--- a/lib/code_corps/stripe_service/stripe_connect_account.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_account.ex
@@ -1,5 +1,5 @@
-defmodule CodeCorps.StripeService.StripeConnectAccount do
-  alias CodeCorps.StripeService.Adapters
+defmodule CodeCorps.StripeService.StripeConnectAccountService do
+  alias CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter
   alias Stripe.Connect.OAuth.TokenResponse
 
   @api Application.get_env(:code_corps, :stripe)
@@ -7,7 +7,7 @@ defmodule CodeCorps.StripeService.StripeConnectAccount do
   def create(%{"access_code" => code, "organization_id" => _organization_id} = attributes) do
     with {:ok, %TokenResponse{stripe_user_id: account_id}} <- @api.Connect.OAuth.token(code),
          {:ok, account} <- @api.Account.retrieve(account_id),
-         {:ok, params} <- Adapters.StripeConnectAccount.to_params(account, attributes)
+         {:ok, params} <- StripeConnectAccountAdapter.to_params(account, attributes)
     do
       %CodeCorps.StripeConnectAccount{}
       |> CodeCorps.StripeConnectAccount.create_changeset(params)

--- a/lib/code_corps/stripe_service/stripe_connect_card.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_card.ex
@@ -1,11 +1,7 @@
-defmodule CodeCorps.StripeService.StripeConnectCard do
-  alias CodeCorps.Repo
-  alias CodeCorps.StripeService.Adapters
-  alias CodeCorps.StripeConnectAccount
-  alias CodeCorps.StripeConnectCard
-  alias CodeCorps.StripeConnectCustomer
-  alias CodeCorps.StripePlatformCard
-  alias CodeCorps.StripePlatformCustomer
+defmodule CodeCorps.StripeService.StripeConnectCardService do
+  alias CodeCorps.{Repo, StripeConnectAccount, StripeConnectCard,
+  StripeConnectCustomer, StripePlatformCard, StripePlatformCustomer}
+  alias CodeCorps.StripeService.Adapters.StripeConnectCardAdapter
 
   import CodeCorps.MapUtils, only: [rename: 3, keys_to_string: 1]
   import Ecto.Query # needed for match
@@ -36,7 +32,7 @@ defmodule CodeCorps.StripeService.StripeConnectCard do
          {:ok, %Stripe.Card{} = connect_card} <-
            @api.Card.create(:customer, connect_customer_id, connect_token.id, connect_account: connect_account_id),
          {:ok, params} <-
-           Adapters.StripeConnectCard.to_params(connect_card, attributes)
+           StripeConnectCardAdapter.to_params(connect_card, attributes)
     do
       %StripeConnectCard{}
       |> StripeConnectCard.create_changeset(params)

--- a/lib/code_corps/stripe_service/stripe_connect_customer.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_customer.ex
@@ -1,6 +1,6 @@
-defmodule CodeCorps.StripeService.StripeConnectCustomer do
+defmodule CodeCorps.StripeService.StripeConnectCustomerService do
   alias CodeCorps.Repo
-  alias CodeCorps.StripeService.Adapters
+  alias CodeCorps.StripeService.Adapters.StripeConnectCustomerAdapter
   alias CodeCorps.StripeConnectAccount
   alias CodeCorps.StripeConnectCustomer
   alias CodeCorps.StripePlatformCustomer
@@ -25,7 +25,7 @@ defmodule CodeCorps.StripeService.StripeConnectCustomer do
     with {:ok, customer} <-
            @api.Customer.create(%{}, connect_account: connect_account.id_from_stripe),
          {:ok, params} <-
-           Adapters.StripeConnectCustomer.to_params(customer, attributes)
+           StripeConnectCustomerAdapter.to_params(customer, attributes)
     do
       %StripeConnectCustomer{}
       |> StripeConnectCustomer.create_changeset(params)

--- a/lib/code_corps/stripe_service/stripe_connect_plan.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_plan.ex
@@ -1,8 +1,8 @@
-defmodule CodeCorps.StripeService.StripeConnectPlan do
+defmodule CodeCorps.StripeService.StripeConnectPlanService do
   alias CodeCorps.Organization
   alias CodeCorps.Project
   alias CodeCorps.Repo
-  alias CodeCorps.StripeService.Adapters
+  alias CodeCorps.StripeService.Adapters.StripeConnectPlanAdapter
   alias CodeCorps.StripeConnectAccount
   alias CodeCorps.StripeConnectPlan
 
@@ -16,7 +16,7 @@ defmodule CodeCorps.StripeService.StripeConnectPlan do
          {:ok, plan} <-
            @api.Plan.create(create_attributes, connect_account: connect_account_id),
          {:ok, params} <-
-           Adapters.StripeConnectPlan.to_params(plan, attributes)
+           StripeConnectPlanAdapter.to_params(plan, attributes)
     do
       %StripeConnectPlan{}
       |> StripeConnectPlan.create_changeset(params)

--- a/lib/code_corps/stripe_service/stripe_platform_card.ex
+++ b/lib/code_corps/stripe_service/stripe_platform_card.ex
@@ -1,6 +1,6 @@
-defmodule CodeCorps.StripeService.StripePlatformCard do
+defmodule CodeCorps.StripeService.StripePlatformCardService do
   alias CodeCorps.Repo
-  alias CodeCorps.StripeService.Adapters
+  alias CodeCorps.StripeService.Adapters.StripePlatformCardAdapter
   alias CodeCorps.StripePlatformCard
   alias CodeCorps.StripePlatformCustomer
 
@@ -9,7 +9,7 @@ defmodule CodeCorps.StripeService.StripePlatformCard do
   def create(%{"stripe_token" => stripe_token, "user_id" => user_id} = attributes) do
     with %StripePlatformCustomer{} = customer <- get_customer(user_id),
          {:ok, card} <- @api.Card.create(:customer, customer.id_from_stripe, stripe_token),
-         {:ok, params} <- Adapters.StripePlatformCard.to_params(card, attributes)
+         {:ok, params} <- StripePlatformCardAdapter.to_params(card, attributes)
     do
       %StripePlatformCard{}
       |> StripePlatformCard.create_changeset(params)

--- a/lib/code_corps/stripe_service/stripe_platform_customer.ex
+++ b/lib/code_corps/stripe_service/stripe_platform_customer.ex
@@ -1,13 +1,13 @@
-defmodule CodeCorps.StripeService.StripePlatformCustomer do
+defmodule CodeCorps.StripeService.StripePlatformCustomerService do
   alias CodeCorps.Repo
-  alias CodeCorps.StripeService.Adapters
+  alias CodeCorps.StripeService.Adapters.StripePlatformCustomerAdapter
   alias CodeCorps.StripePlatformCustomer
 
   @api Application.get_env(:code_corps, :stripe)
 
   def create(attributes) do
     with {:ok, customer} <- @api.Customer.create(attributes),
-         {:ok, params} <- Adapters.StripePlatformCustomer.to_params(customer, attributes)
+         {:ok, params} <- StripePlatformCustomerAdapter.to_params(customer, attributes)
     do
       %StripePlatformCustomer{}
       |> StripePlatformCustomer.create_changeset(params)

--- a/lib/code_corps/stripe_testing/subscription.ex
+++ b/lib/code_corps/stripe_testing/subscription.ex
@@ -3,8 +3,14 @@ defmodule CodeCorps.StripeTesting.Subscription do
     {:ok, do_create(map)}
   end
 
+  def retrieve(map, _opts \\ []) do
+    {:ok, do_retrieve(map)}
+  end
+
   defp do_create(_) do
     {:ok, date} = DateTime.from_unix(1479472835)
+
+    {:ok, plan} = CodeCorps.StripeTesting.Plan.create(%{}, [])
 
     %Stripe.Subscription{
       application_fee_percent: 5.0,
@@ -18,11 +24,39 @@ defmodule CodeCorps.StripeTesting.Subscription do
       id: "sub_123",
       livemode: false,
       metadata: %{},
-      plan: CodeCorps.StripeTesting.Plan.create(%{}, []),
+      plan: plan,
       quantity: 1000,
       source: nil,
       start: date,
       status: "active",
+      tax_percent: nil,
+      trial_end: nil,
+      trial_start: nil
+    }
+  end
+
+  defp do_retrieve(_) do
+    {:ok, date} = DateTime.from_unix(1479472835)
+
+    {:ok, plan} = CodeCorps.StripeTesting.Plan.create(%{}, [])
+
+    %Stripe.Subscription{
+      application_fee_percent: 5.0,
+      cancel_at_period_end: false,
+      canceled_at: nil,
+      created: date,
+      current_period_end: date,
+      current_period_start: date,
+      customer: "cus_123",
+      ended_at: nil,
+      id: "sub_123",
+      livemode: false,
+      metadata: %{},
+      plan: plan,
+      quantity: 1000,
+      source: nil,
+      start: date,
+      status: "canceled",
       tax_percent: nil,
       trial_end: nil,
       trial_start: nil

--- a/test/controllers/stripe_connect_events_controller_test.exs
+++ b/test/controllers/stripe_connect_events_controller_test.exs
@@ -1,0 +1,112 @@
+defmodule CodeCorps.StripeConnectEventsControllerTest do
+  use CodeCorps.ConnCase
+
+  alias CodeCorps.Project
+  alias CodeCorps.StripeConnectAccount
+
+  setup do
+    conn =
+      %{build_conn | host: "api."}
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("content-type", "application/json")
+
+    {:ok, conn: conn}
+  end
+
+  @account %{
+    "id" => "acct_123",
+    "transfers_enabled" => true
+  }
+
+  @subscription %{
+    "customer" => "cus_123",
+    "id" => "acct_123",
+    "status" => "canceled"
+  }
+
+  defp event_for(object, type) do
+    %{
+      "api_version" => "2016-07-06",
+      "created" => 1326853478,
+      "data" => %{
+        "object" => object
+      },
+      "id" => "evt_123",
+      "livemode" => false,
+      "object" => "event",
+      "pending_webhooks" => 1,
+      "request" => nil,
+      "type" => type
+    }
+  end
+
+  describe "account.updated" do
+    test "returns 200 and updates account when one matches", %{conn: conn} do
+      event = event_for(@account, "account.updated")
+      stripe_id =  @account["id"]
+
+      insert(:stripe_connect_account,
+        id_from_stripe: stripe_id,
+        transfers_enabled: false
+      )
+
+      conn = post conn, stripe_connect_events_path(conn, :create), event
+
+      assert response(conn, 200)
+
+      updated_account =
+        StripeConnectAccount
+        |> Repo.get_by(id_from_stripe: stripe_id)
+
+      assert updated_account.transfers_enabled
+    end
+
+    test "returns 400 when doesn't match an existing account", %{conn: conn} do
+      event = event_for(@account, "account.updated")
+      conn = post conn, stripe_connect_events_path(conn, :create), event
+
+      assert response(conn, 400)
+    end
+  end
+
+  describe "customer.subscription.updated" do
+    test "returns 200 and updates account when one matches", %{conn: conn} do
+      event = event_for(@subscription, "customer.subscription.updated")
+      stripe_id =  @subscription["id"]
+      connect_customer_id = @subscription["customer"]
+
+      project = insert(:project, total_monthly_donated: 1000)
+      account = insert(:stripe_connect_account)
+      platform_customer = insert(:stripe_platform_customer)
+
+      insert(:stripe_connect_customer,
+        id_from_stripe: connect_customer_id,
+        stripe_connect_account: account,
+        stripe_platform_customer: platform_customer)
+
+      plan = insert(:stripe_connect_plan, project: project)
+
+      insert(:stripe_connect_subscription,
+        id_from_stripe: stripe_id,
+        stripe_connect_plan: plan)
+
+      conn = post conn, stripe_connect_events_path(conn, :create), event
+
+      assert response(conn, 200)
+
+      updated_project =
+        Project
+        |> Repo.get_by(id: project.id)
+
+      assert updated_project.total_monthly_donated == 0
+    end
+  end
+
+  describe "any other event" do
+    test "returns 200", %{conn: conn} do
+      event = event_for(%{}, "any.other")
+      path = conn |> stripe_connect_events_path(:create)
+      assert conn |> post(path, event) |> response(200)
+    end
+  end
+end

--- a/test/controllers/stripe_platform_events_controller_test.exs
+++ b/test/controllers/stripe_platform_events_controller_test.exs
@@ -1,0 +1,36 @@
+defmodule CodeCorps.StripePlatformEventsControllerTest do
+  use CodeCorps.ConnCase
+
+  setup do
+    conn =
+      %{build_conn | host: "api."}
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("content-type", "application/json")
+
+    {:ok, conn: conn}
+  end
+
+  defp event_for(object, type) do
+    %{
+      "api_version" => "2016-07-06",
+      "created" => 1326853478,
+      "data" => %{
+        "object" => object
+      },
+      "id" => "evt_00000000000000",
+      "livemode" => false,
+      "object" => "event",
+      "pending_webhooks" => 1,
+      "request" => nil,
+      "type" => type
+    }
+  end
+
+  describe "any event" do
+    test "returns 200", %{conn: conn} do
+      event = event_for(%{}, "any.event")
+      path = conn |> stripe_platform_events_path(:create)
+      assert conn |> post(path, event) |> response(200)
+    end
+  end
+end

--- a/test/lib/code_corps/services/donation_goals_test.exs
+++ b/test/lib/code_corps/services/donation_goals_test.exs
@@ -1,20 +1,23 @@
-defmodule CodeCorps.DonationGoalsManagerTest do
+defmodule CodeCorps.Services.DonationGoalsServiceTest do
   use ExUnit.Case, async: true
 
   use CodeCorps.ModelCase
 
+  import CodeCorps.Project, only: [update_total_changeset: 2]
+
   alias CodeCorps.DonationGoal
-  alias CodeCorps.DonationGoalsManager
+  alias CodeCorps.Services.DonationGoalsService
 
   defp assert_current_goal_id(goal_id) do
     current_goal =
       DonationGoal
       |> Repo.get_by(current: true)
+
     assert current_goal.id == goal_id
   end
 
-  defp donate(plan, amount) do
-    insert(:stripe_connect_subscription, quantity: amount, stripe_connect_plan: plan)
+  defp set_donated(project, amount) do
+    project |> update_total_changeset(%{total_monthly_donated: amount}) |> Repo.update
   end
 
   describe "create/1" do
@@ -22,62 +25,57 @@ defmodule CodeCorps.DonationGoalsManagerTest do
       project = insert(:project)
       insert(:stripe_connect_plan, project: project)
 
-      {:ok, %DonationGoal{} = donation_goal} = DonationGoalsManager.create(%{amount: 10, description: "Test", project_id: project.id})
+      {:ok, %DonationGoal{} = donation_goal} = DonationGoalsService.create(%{amount: 10, description: "Test", project_id: project.id})
       assert_current_goal_id(donation_goal.id)
     end
 
     test "returns {:error, changeset} if there are validation errors" do
-      {:error, %Ecto.Changeset{} = changeset} = DonationGoalsManager.create(%{amount: 10})
+      {:error, %Ecto.Changeset{} = changeset} = DonationGoalsService.create(%{amount: 10})
       refute changeset.valid?
     end
 
     test "sets current goal correctly when amount exists already" do
-      project = insert(:project)
-      plan = insert(:stripe_connect_plan, project: project)
-      insert(:stripe_connect_subscription, quantity: 10, stripe_connect_plan: plan)
+      project = insert(:project, total_monthly_donated: 10)
 
-      {:ok, first_goal} = DonationGoalsManager.create(%{amount: 20, description: "Test", project_id: project.id})
+      {:ok, first_goal} = DonationGoalsService.create(%{amount: 20, description: "Test", project_id: project.id})
 
       assert_current_goal_id(first_goal.id)
 
-      {:ok, second_goal} = DonationGoalsManager.create(%{amount: 15, description: "Test", project_id: project.id})
+      {:ok, second_goal} = DonationGoalsService.create(%{amount: 15, description: "Test", project_id: project.id})
 
       assert_current_goal_id(second_goal.id)
     end
 
     test "sets current goal correctly" do
-      project = insert(:project)
-      plan = insert(:stripe_connect_plan, project: project)
+      project = insert(:project, total_monthly_donated: 5)
 
-      insert(:stripe_connect_subscription, quantity: 5, stripe_connect_plan: plan)
-
-      {:ok, first_goal} = DonationGoalsManager.create(%{amount: 10, description: "Test", project_id: project.id})
+      {:ok, first_goal} = DonationGoalsService.create(%{amount: 10, description: "Test", project_id: project.id})
 
       # total donated is 5,
       # only goal inserted is the first goal
       assert_current_goal_id(first_goal.id)
 
-      {:ok, second_goal} = DonationGoalsManager.create(%{amount: 7, description: "Test", project_id: project.id})
+      {:ok, second_goal} = DonationGoalsService.create(%{amount: 7, description: "Test", project_id: project.id})
 
       assert_current_goal_id(second_goal.id)
 
-      {:ok, _} = DonationGoalsManager.create(%{amount: 20, description: "Test", project_id: project.id})
+      {:ok, _} = DonationGoalsService.create(%{amount: 20, description: "Test", project_id: project.id})
 
       # total donated is still 5
       # first goal larger than 5 is the second goal
       assert_current_goal_id(second_goal.id)
 
-      insert(:stripe_connect_subscription, quantity: 15, stripe_connect_plan: plan)
+      project |> set_donated(20)
 
-      {:ok, fourth_goal} = DonationGoalsManager.create(%{amount: 30, description: "Test", project_id: project.id})
+      {:ok, fourth_goal} = DonationGoalsService.create(%{amount: 30, description: "Test", project_id: project.id})
 
       # total donated is 20.
       # first applicable goal is fourth goal, with an amount of 30
       assert_current_goal_id(fourth_goal.id)
 
-      insert(:stripe_connect_subscription, quantity: 30, stripe_connect_plan: plan)
+      project |> set_donated(45)
 
-      {:ok, fourth_goal} = DonationGoalsManager.create(%{amount: 40, description: "Test", project_id: project.id})
+      {:ok, fourth_goal} = DonationGoalsService.create(%{amount: 40, description: "Test", project_id: project.id})
 
       # total donated is 45, which is more than any defined goal
       # largest goal inserted after change the fourth goal, with an amount of 40
@@ -88,56 +86,53 @@ defmodule CodeCorps.DonationGoalsManagerTest do
   describe "update/2" do
     test "updates existing goal, returns {:ok, record}" do
       project = insert(:project)
-      insert(:stripe_connect_plan, project: project)
       donation_goal = insert(:donation_goal, amount: 10, project: project)
 
-      {:ok, %DonationGoal{} = updated_goal} = DonationGoalsManager.update(donation_goal, %{amount: 15})
+      {:ok, %DonationGoal{} = updated_goal} = DonationGoalsService.update(donation_goal, %{amount: 15})
       assert_current_goal_id(updated_goal.id)
       assert updated_goal.id == donation_goal.id
     end
     test "returns {:error, changeset} if there are validation errors" do
       project = insert(:project)
-      insert(:stripe_connect_plan, project: project)
       donation_goal = insert(:donation_goal, amount: 10, project: project)
 
-      {:error, %Ecto.Changeset{} = changeset} = DonationGoalsManager.update(donation_goal, %{amount: nil})
+      {:error, %Ecto.Changeset{} = changeset} = DonationGoalsService.update(donation_goal, %{amount: nil})
       refute changeset.valid?
     end
 
     test "sets current goal correctly" do
       project = insert(:project)
-      plan = insert(:stripe_connect_plan, project: project)
       goal_1 = insert(:donation_goal, amount: 10, project: project)
       goal_2 = insert(:donation_goal, amount: 15, project: project)
       insert(:donation_goal, amount: 20, project: project)
 
-      DonationGoalsManager.update(goal_1, %{amount: 11})
+      DonationGoalsService.update(goal_1, %{amount: 11})
 
       # amount donated is 0, first goal above that is still goal 1
       assert_current_goal_id(goal_1.id)
 
-      DonationGoalsManager.update(goal_1, %{amount: 21})
+      DonationGoalsService.update(goal_1, %{amount: 21})
 
       # amount donated is still 0, first goal above that is now goal 2
       assert_current_goal_id(goal_2.id)
 
-      insert(:stripe_connect_subscription, quantity: 25, stripe_connect_plan: plan)
+      project |> set_donated(25)
 
-      DonationGoalsManager.update(goal_1, %{amount: 21})
+      DonationGoalsService.update(goal_1, %{amount: 21})
 
       # amount donated is now 25
       # this is more than any current goal
       # largest goal is goal 1, with 21
       assert_current_goal_id(goal_1.id)
 
-      DonationGoalsManager.update(goal_2, %{amount: 22})
+      DonationGoalsService.update(goal_2, %{amount: 22})
 
       # amount donated is now 25
       # this is more than any current goal
       # largest goal is goal 2, with 22
       assert_current_goal_id(goal_2.id)
 
-      DonationGoalsManager.update(goal_1, %{amount: 27})
+      DonationGoalsService.update(goal_1, %{amount: 27})
 
       # amount donated is still 25
       # first goal higher than that is goal 1, with 27
@@ -150,34 +145,33 @@ defmodule CodeCorps.DonationGoalsManagerTest do
   describe "set_current_goal_for_project/1" do
     test "sets current goal correctly" do
       project = insert(:project)
-      plan = insert(:stripe_connect_plan, project: project)
 
       goal_1 = insert(:donation_goal, amount: 10, project: project)
       goal_2 = insert(:donation_goal, amount: 15, project: project)
       goal_3 = insert(:donation_goal, amount: 20, project: project)
 
-      plan |> donate(5)
-      DonationGoalsManager.update_related_goals(goal_1)
+      project |> set_donated(5)
+      DonationGoalsService.update_related_goals(goal_1)
       assert_current_goal_id(goal_1.id)
 
-      plan |> donate(5) # total is now 10
-      DonationGoalsManager.update_related_goals(goal_2)
+      project |> set_donated(10) # total is now 10
+      DonationGoalsService.update_related_goals(goal_2)
       assert_current_goal_id(goal_2.id)
 
-      plan |> donate(5) # total is now 15
-      DonationGoalsManager.update_related_goals(goal_3)
+      project |> set_donated(15) # total is now 15
+      DonationGoalsService.update_related_goals(goal_3)
       assert_current_goal_id(goal_3.id)
 
-      plan |> donate(5) # total is now 20
-      DonationGoalsManager.update_related_goals(goal_3)
+      project |> set_donated(20) # total is now 20
+      DonationGoalsService.update_related_goals(goal_3)
       assert_current_goal_id(goal_3.id)
 
-      plan |> donate(5) # total is now 25
-      DonationGoalsManager.update_related_goals(goal_3)
+      project |> set_donated(25) # total is now 25
+      DonationGoalsService.update_related_goals(goal_3)
       assert_current_goal_id(goal_3.id)
 
       goal_4 = insert(:donation_goal, amount: 30, project: project) # 30 is more than the current 25 total
-      DonationGoalsManager.update_related_goals(goal_4)
+      DonationGoalsService.update_related_goals(goal_4)
       assert_current_goal_id(goal_4.id)
     end
   end

--- a/test/lib/code_corps/services/markdown_renderer_test.exs
+++ b/test/lib/code_corps/services/markdown_renderer_test.exs
@@ -1,9 +1,9 @@
-defmodule CodeCorps.MarkdownRendererTest do
+defmodule CodeCorps.Services.MarkdownRendererServiceTest do
   use ExUnit.Case, async: true
 
   alias CodeCorps.Task
 
-  import CodeCorps.MarkdownRenderer
+  import CodeCorps.Services.MarkdownRendererService
 
   @valid_attrs %{
     title: "Test task",

--- a/test/lib/code_corps/services/project_test.exs
+++ b/test/lib/code_corps/services/project_test.exs
@@ -1,0 +1,42 @@
+defmodule CodeCorps.Services.ProjectServiceTest do
+  use ExUnit.Case, async: true
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.Project
+  alias CodeCorps.Repo
+  alias CodeCorps.Services.ProjectService
+
+  describe "update_project_totals/1" do
+    test "updates the project totals when has active subscriptions" do
+      project = insert(:project)
+      plan = insert(:stripe_connect_plan, project: project)
+      insert(:stripe_connect_subscription, stripe_connect_plan: plan, quantity: 1000, status: "active")
+      insert(:stripe_connect_subscription, stripe_connect_plan: plan, quantity: 1000, status: "active")
+
+      repo_project =
+        Project
+        |> Repo.get(project.id)
+        |> Repo.preload([:stripe_connect_plan])
+
+      {:ok, result} = ProjectService.update_project_totals(repo_project)
+
+      assert result.id == project.id
+      assert result.total_monthly_donated == 2000
+    end
+
+    test "updates the project totals when has no active subscriptions" do
+      project = insert(:project)
+      insert(:stripe_connect_plan, project: project)
+
+      repo_project =
+        Project
+        |> Repo.get(project.id)
+        |> Repo.preload([:stripe_connect_plan])
+
+      {:ok, result} = ProjectService.update_project_totals(repo_project)
+
+      assert result.id == project.id
+      assert result.total_monthly_donated == 0
+    end
+  end
+end

--- a/test/lib/code_corps/stripe/adapters/stripe_connect_account_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_connect_account_test.exs
@@ -1,7 +1,7 @@
-defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountTest do
+defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountTestAdapter do
   use ExUnit.Case, async: true
 
-  import CodeCorps.StripeService.Adapters.StripeConnectAccount, only: [to_params: 2]
+  import CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter, only: [to_params: 2]
 
   @stripe_connect_account %Stripe.Account{
     business_name: "Code Corps PBC",

--- a/test/lib/code_corps/stripe/adapters/stripe_connect_plan_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_connect_plan_test.exs
@@ -1,7 +1,7 @@
-defmodule CodeCorps.StripeService.Adapters.StripeConnectPlanTest do
+defmodule CodeCorps.StripeService.Adapters.StripeConnectPlanTestAdapter do
   use ExUnit.Case, async: true
 
-  import CodeCorps.StripeService.Adapters.StripeConnectPlan, only: [to_params: 2]
+  import CodeCorps.StripeService.Adapters.StripeConnectPlanAdapter, only: [to_params: 2]
 
   {:ok, timestamp} = DateTime.from_unix(1479472835)
 

--- a/test/lib/code_corps/stripe/adapters/stripe_connect_subscription_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_connect_subscription_test.exs
@@ -1,7 +1,7 @@
-defmodule CodeCorps.StripeService.Adapters.StripeConnectSubscriptionTest do
+defmodule CodeCorps.StripeService.Adapters.StripeConnectSubscriptionTestAdapter do
   use ExUnit.Case, async: true
 
-  import CodeCorps.StripeService.Adapters.StripeConnectSubscription, only: [to_params: 2]
+  import CodeCorps.StripeService.Adapters.StripeConnectSubscriptionAdapter, only: [to_params: 2]
 
   {:ok, date} = DateTime.from_unix(1479472835)
 

--- a/test/lib/code_corps/stripe/adapters/stripe_platform_card_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_platform_card_test.exs
@@ -1,7 +1,7 @@
-defmodule CodeCorps.StripeService.Adapters.StripePlatformCardTest do
+defmodule CodeCorps.StripeService.Adapters.StripePlatformCardTestAdapter do
   use ExUnit.Case, async: true
 
-  import CodeCorps.StripeService.Adapters.StripePlatformCard, only: [to_params: 2]
+  import CodeCorps.StripeService.Adapters.StripePlatformCardAdapter, only: [to_params: 2]
 
   @stripe_platform_card %Stripe.Card{
     id: "card_123",

--- a/test/lib/code_corps/stripe/adapters/stripe_platform_customer_test.exs
+++ b/test/lib/code_corps/stripe/adapters/stripe_platform_customer_test.exs
@@ -1,7 +1,7 @@
-defmodule CodeCorps.StripeService.Adapters.StripePlatformCustomerTest do
+defmodule CodeCorps.StripeService.Adapters.StripePlatformCustomerTestAdapter do
   use ExUnit.Case, async: true
 
-  import CodeCorps.StripeService.Adapters.StripePlatformCustomer, only: [to_params: 2]
+  import CodeCorps.StripeService.Adapters.StripePlatformCustomerAdapter, only: [to_params: 2]
 
   {:ok, timestamp} = DateTime.from_unix(1479472835)
 

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -111,6 +111,12 @@ defmodule CodeCorps.Factories do
     }
   end
 
+  def stripe_connect_customer_factory do
+    %CodeCorps.StripeConnectCustomer{
+      id_from_stripe: sequence(:id_from_stripe, &"stripe_id_#{&1}")
+    }
+  end
+
   def stripe_connect_plan_factory do
     %CodeCorps.StripeConnectPlan{
       id_from_stripe: sequence(:id_from_stripe, &"stripe_id_#{&1}"),

--- a/test/views/donation_goal_view_test.exs
+++ b/test/views/donation_goal_view_test.exs
@@ -8,7 +8,7 @@ defmodule CodeCorps.DonationGoalViewTest do
     plan = insert(:stripe_connect_plan, project: project)
     insert(:stripe_connect_subscription, stripe_connect_plan: plan, quantity: 100)
     donation_goal = insert(:donation_goal, project: project, amount: 500)
-    CodeCorps.DonationGoalsManager.update_related_goals(donation_goal)
+    CodeCorps.Services.DonationGoalsService.update_related_goals(donation_goal)
 
     rendered_json = render(CodeCorps.DonationGoalView, "show.json-api", data: donation_goal)
 
@@ -17,7 +17,7 @@ defmodule CodeCorps.DonationGoalViewTest do
         "id" => donation_goal.id |> Integer.to_string,
         "type" => "donation-goal",
         "attributes" => %{
-          "achieved" => true,
+          "achieved" => false,
           "amount" => donation_goal.amount,
           "current" => donation_goal.current,
           "description" => donation_goal.description

--- a/web/controllers/donation_goal_controller.ex
+++ b/web/controllers/donation_goal_controller.ex
@@ -5,7 +5,7 @@ defmodule CodeCorps.DonationGoalController do
   import CodeCorps.Helpers.Query, only: [id_filter: 2]
 
   alias CodeCorps.DonationGoal
-  alias CodeCorps.DonationGoalsManager
+  alias CodeCorps.Services.DonationGoalsService
 
   plug :load_and_authorize_changeset, model: DonationGoal, only: [:create]
   plug :load_and_authorize_resource, model: DonationGoal, only: [:update, :delete]
@@ -15,11 +15,11 @@ defmodule CodeCorps.DonationGoalController do
 
   def handle_create(_conn, attributes) do
     attributes
-    |> DonationGoalsManager.create
+    |> DonationGoalsService.create
   end
 
   def handle_update(_conn, record, attributes) do
     record
-    |> DonationGoalsManager.update(attributes)
+    |> DonationGoalsService.update(attributes)
   end
 end

--- a/web/controllers/stripe_auth_controller.ex
+++ b/web/controllers/stripe_auth_controller.ex
@@ -8,11 +8,11 @@ defmodule CodeCorps.StripeAuthController do
 
   plug :load_and_authorize_resource, model: Project, only: [:stripe_auth]
 
-  # We're using `stripe_auth` instead of `show` to use the Organization
+  # We're using `stripe_auth` instead of `show` to use the Project
   # policy for authorization
   def stripe_auth(conn, %{"id" => project_id}) do
     user = conn.assigns[:current_user]
-    
+
     project =
       Project
       |> Repo.get(project_id)

--- a/web/controllers/stripe_connect_account_controller.ex
+++ b/web/controllers/stripe_connect_account_controller.ex
@@ -3,6 +3,7 @@ defmodule CodeCorps.StripeConnectAccountController do
   use JaResource
 
   alias CodeCorps.StripeConnectAccount
+  alias CodeCorps.StripeService.StripeConnectAccountService
 
   plug :load_and_authorize_changeset, model: StripeConnectAccount, only: [:create]
   plug :load_and_authorize_resource, model: StripeConnectAccount, only: [:show]
@@ -10,7 +11,7 @@ defmodule CodeCorps.StripeConnectAccountController do
 
   def handle_create(conn, attributes) do
     attributes
-    |> CodeCorps.StripeService.StripeConnectAccount.create
+    |> StripeConnectAccountService.create
     |> handle_create_result(conn)
   end
 

--- a/web/controllers/stripe_connect_events_controller.ex
+++ b/web/controllers/stripe_connect_events_controller.ex
@@ -3,20 +3,33 @@ defmodule CodeCorps.StripeConnectEventsController do
 
   alias CodeCorps.StripeService.Events
 
-  def webhook(conn, json) do
-    handle(json) |> IO.inspect
-    conn |> respond
+  def create(conn, json) do
+    result = handle(json)
+    respond(conn, result)
   end
 
-  def handle(%{"type" => "account.updated"} = attributes) do
-    Events.AccountUpdated.handle(attributes)
+  def handle(%{"livemode" => false} = attributes) do
+    case Application.get_env(:code_corps, :stripe_env) do
+      :prod -> {:ok, :ignored}
+      _ -> do_handle(attributes)
+    end
   end
 
-  def handle(%{"type" => "customer.subscription.updated"} = attributes) do
-    Events.CustomerSubscriptionUpdated.handle(attributes)
+  def handle(%{"livemode" => true} = attributes) do
+    case Application.get_env(:code_corps, :stripe_env) do
+      :prod -> do_handle(attributes)
+      _ -> {:ok, :ignored}
+    end
   end
 
-  def handle(_attributes), do: {:ok, :unhandled_event}
+  def do_handle(%{"type" => "account.updated"} = attributes), do: Events.AccountUpdated.handle(attributes)
+  def do_handle(%{"type" => "customer.subscription.updated"} = attributes), do: Events.CustomerSubscriptionUpdated.handle(attributes)
+  def do_handle(_attributes), do: {:ok, :unhandled_event}
 
-  def respond(conn), do: conn |> send_resp(200, "")
+  def respond(conn, {:error, _error}) do
+    conn |> send_resp(400, "")
+  end
+  def respond(conn, _) do
+    conn |> send_resp(200, "")
+  end
 end

--- a/web/controllers/stripe_connect_plan_controller.ex
+++ b/web/controllers/stripe_connect_plan_controller.ex
@@ -3,6 +3,7 @@ defmodule CodeCorps.StripeConnectPlanController do
   use JaResource
 
   alias CodeCorps.StripeConnectPlan
+  alias CodeCorps.StripeService.StripeConnectPlanService
 
   plug :load_and_authorize_changeset, model: StripeConnectPlan, only: [:create]
   plug :load_and_authorize_resource, model: StripeConnectPlan, only: [:show]
@@ -10,7 +11,7 @@ defmodule CodeCorps.StripeConnectPlanController do
 
   def handle_create(conn, attributes) do
     attributes
-    |> CodeCorps.StripeService.StripeConnectPlan.create
+    |> StripeConnectPlanService.create
     |> handle_create_result(conn)
   end
 

--- a/web/controllers/stripe_connect_subscription_controller.ex
+++ b/web/controllers/stripe_connect_subscription_controller.ex
@@ -3,6 +3,7 @@ defmodule CodeCorps.StripeConnectSubscriptionController do
   use JaResource
 
   alias CodeCorps.StripeConnectSubscription
+  alias CodeCorps.StripeService.StripeConnectSubscriptionService
 
   plug :load_and_authorize_resource, model: StripeConnectSubscription, only: [:show,], preload: [:user]
   plug :load_and_authorize_changeset, model: StripeConnectSubscription, only: [:create]
@@ -11,7 +12,7 @@ defmodule CodeCorps.StripeConnectSubscriptionController do
 
   def handle_create(conn, attributes) do
     attributes
-    |> CodeCorps.StripeService.StripeConnectSubscription.create
+    |> StripeConnectSubscriptionService.find_or_create
     |> handle_create_result(conn)
   end
 

--- a/web/controllers/stripe_platform_card_controller.ex
+++ b/web/controllers/stripe_platform_card_controller.ex
@@ -3,6 +3,7 @@ defmodule CodeCorps.StripePlatformCardController do
   use JaResource
 
   alias CodeCorps.StripePlatformCard
+  alias CodeCorps.StripeService.StripePlatformCardService
 
   plug :load_and_authorize_resource, model: StripePlatformCard, only: [:show,], preload: [:user]
   plug :load_and_authorize_changeset, model: StripePlatformCard, only: [:create]
@@ -11,7 +12,7 @@ defmodule CodeCorps.StripePlatformCardController do
 
   def handle_create(conn, attributes) do
     attributes
-    |> CodeCorps.StripeService.StripePlatformCard.create
+    |> StripePlatformCardService.create
     |> handle_create_result(conn)
   end
 

--- a/web/controllers/stripe_platform_customer_controller.ex
+++ b/web/controllers/stripe_platform_customer_controller.ex
@@ -3,6 +3,7 @@ defmodule CodeCorps.StripePlatformCustomerController do
   use JaResource
 
   alias CodeCorps.StripePlatformCustomer
+  alias CodeCorps.StripeService.StripePlatformCustomerService
 
   plug :load_and_authorize_resource, model: StripePlatformCustomer, only: [:show]
   plug :load_and_authorize_changeset, model: StripePlatformCustomer, only: [:create]
@@ -10,7 +11,7 @@ defmodule CodeCorps.StripePlatformCustomerController do
 
   def handle_create(conn, attributes) do
     attributes
-    |> CodeCorps.StripeService.StripePlatformCustomer.create
+    |> StripePlatformCustomerService.create
     |> handle_create_result(conn)
   end
 

--- a/web/controllers/stripe_platform_events_controller.ex
+++ b/web/controllers/stripe_platform_events_controller.ex
@@ -1,8 +1,8 @@
 defmodule CodeCorps.StripePlatformEventsController do
   use CodeCorps.Web, :controller
 
-  def webhook(conn, json) do
-    handle(json) |> IO.inspect
+  def create(conn, json) do
+    handle(json)
     conn |> respond
   end
 

--- a/web/models/comment.ex
+++ b/web/models/comment.ex
@@ -1,7 +1,7 @@
 defmodule CodeCorps.Comment do
   use CodeCorps.Web, :model
 
-  alias CodeCorps.MarkdownRenderer
+  alias CodeCorps.Services.MarkdownRendererService
 
   schema "comments" do
     field :body, :string
@@ -20,7 +20,7 @@ defmodule CodeCorps.Comment do
     struct
     |> cast(params, [:markdown])
     |> validate_required([:markdown])
-    |> MarkdownRenderer.render_markdown_to_html(:markdown, :body)
+    |> MarkdownRendererService.render_markdown_to_html(:markdown, :body)
   end
 
   def create_changeset(struct, params) do

--- a/web/models/organization.ex
+++ b/web/models/organization.ex
@@ -5,7 +5,7 @@ defmodule CodeCorps.Organization do
 
   use Arc.Ecto.Schema
   use CodeCorps.Web, :model
-  import CodeCorps.Base64ImageUploader
+  import CodeCorps.Services.Base64ImageUploaderService
   import CodeCorps.Helpers.Slug
   import CodeCorps.Validators.SlugValidator
   alias CodeCorps.SluggedRoute

--- a/web/models/preview.ex
+++ b/web/models/preview.ex
@@ -4,7 +4,7 @@ defmodule CodeCorps.Preview do
   """
 
   use CodeCorps.Web, :model
-  alias CodeCorps.MarkdownRenderer
+  alias CodeCorps.Services.MarkdownRendererService
 
   schema "previews" do
     field :body, :string
@@ -23,6 +23,6 @@ defmodule CodeCorps.Preview do
     |> cast(params, [:markdown, :user_id])
     |> validate_required([:markdown, :user_id])
     |> assoc_constraint(:user)
-    |> MarkdownRenderer.render_markdown_to_html(:markdown, :body)
+    |> MarkdownRendererService.render_markdown_to_html(:markdown, :body)
   end
 end

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -5,10 +5,10 @@ defmodule CodeCorps.Project do
 
   use Arc.Ecto.Schema
   use CodeCorps.Web, :model
-  import CodeCorps.Base64ImageUploader
+  import CodeCorps.Services.Base64ImageUploaderService
   import CodeCorps.Helpers.Slug
   import CodeCorps.Validators.SlugValidator
-  alias CodeCorps.MarkdownRenderer
+  alias CodeCorps.Services.MarkdownRendererService
 
   schema "projects" do
     field :base64_icon_data, :string, virtual: true
@@ -18,7 +18,7 @@ defmodule CodeCorps.Project do
     field :long_description_markdown, :string
     field :slug, :string
     field :title, :string
-    field :total_monthly_donated, :integer
+    field :total_monthly_donated, :integer, default: 0
 
     belongs_to :organization, CodeCorps.Organization
 
@@ -43,7 +43,7 @@ defmodule CodeCorps.Project do
     |> generate_slug(:title, :slug)
     |> validate_slug(:slug)
     |> unique_constraint(:slug, name: :index_projects_on_slug)
-    |> MarkdownRenderer.render_markdown_to_html(:long_description_markdown, :long_description_body)
+    |> MarkdownRendererService.render_markdown_to_html(:long_description_markdown, :long_description_body)
     |> upload_image(:base64_icon_data, :icon)
   end
 

--- a/web/models/stripe_connect_account.ex
+++ b/web/models/stripe_connect_account.ex
@@ -42,9 +42,9 @@ defmodule CodeCorps.StripeConnectAccount do
   end
 
   @webhook_update_params [
-    :business_name, :business_url, :charges_enabled, :country, :default_currency,
-    :details_submitted, :email, :managed, :support_email, :support_phone,
-    :support_url, :transfers_enabled
+    :business_name, :business_url, :charges_enabled, :country,
+    :default_currency, :details_submitted, :email, :managed, :support_email,
+    :support_phone, :support_url, :transfers_enabled
   ]
 
   def webhook_update_changeset(struct, params \\ %{}) do

--- a/web/models/task.ex
+++ b/web/models/task.ex
@@ -1,6 +1,6 @@
 defmodule CodeCorps.Task do
   use CodeCorps.Web, :model
-  alias CodeCorps.MarkdownRenderer
+  alias CodeCorps.Services.MarkdownRendererService
 
   schema "tasks" do
     field :body, :string
@@ -23,7 +23,7 @@ defmodule CodeCorps.Task do
     |> cast(params, [:title, :markdown, :task_type])
     |> validate_required([:title, :markdown, :task_type])
     |> validate_inclusion(:task_type, task_types)
-    |> MarkdownRenderer.render_markdown_to_html(:markdown, :body)
+    |> MarkdownRendererService.render_markdown_to_html(:markdown, :body)
   end
 
   def create_changeset(struct, params) do

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -6,7 +6,7 @@ defmodule CodeCorps.User do
   use Arc.Ecto.Schema
   use CodeCorps.Web, :model
 
-  import CodeCorps.Base64ImageUploader
+  import CodeCorps.Services.Base64ImageUploaderService
   import CodeCorps.Validators.SlugValidator
 
   alias CodeCorps.SluggedRoute

--- a/web/router.ex
+++ b/web/router.ex
@@ -44,8 +44,8 @@ defmodule CodeCorps.Router do
   scope "/", CodeCorps, host: "api." do
     pipe_through [:stripe_webhooks]
 
-    post "/webooks/stripe/connect", StripeConnectEventsController, :create
-    post "/webooks/stripe/platform", StripePlatformEventsController, :create
+    post "/webhooks/stripe/connect", StripeConnectEventsController, :create
+    post "/webhooks/stripe/platform", StripePlatformEventsController, :create
   end
 
   scope "/", CodeCorps, host: "api." do


### PR DESCRIPTION
# What's in this PR?

This implements most of what's left in the Stripe webhooks.

I could not get the failing test to work for the "customer.subscription.updated" event so I removed it. Apparently `nil` chaining is being added to `Repo.preload` that would fix this issue, so going to hold off.

## References
Fixes #370 when finished