### PR TITLE
Move user and customer updates into a transaction, managed by a module

### DIFF
--- a/lib/code_corps/services/user_service.ex
+++ b/lib/code_corps/services/user_service.ex
@@ -1,0 +1,100 @@
+defmodule CodeCorps.Services.UserService do
+  @moduledoc """
+  Handles CRUD operations for users.
+
+  When operations happen on `CodeCorps.User`, we need to make sure changes
+  are propagated to related records, ex., `CodeCorps.StripePlatformCustomer` and
+  `CodeCorps.StripeConnectCustomer`
+
+  """
+
+  alias CodeCorps.{Repo, StripeConnectCustomer, StripePlatformCustomer, User}
+  alias CodeCorps.StripeService.{StripeConnectCustomerService, StripePlatformCustomerService}
+  alias Ecto.Changeset
+  alias Ecto.Multi
+
+  @doc """
+  Updates a `CodeCorps.User` record and, if necessary, associated
+  `CodeCorps.StripePlatformCustomer` and `CodeCorps.StripeConnectCustomer` records.
+
+  These related records inherit the email field from the user,
+  so they need to be kept in sync, both locally, and on the Stripe platform.
+
+  Returns one of
+  * `{:ok, %CodeCorps.User{}, nil, nil}`
+  * `{:ok, %CodeCorps.User{}, %CodeCorps.StripePlatformCustomer{}, nil}`
+  * `{:ok, %CodeCorps.User{}, %CodeCorps.StripePlatformCustomer{}, %CodeCorps.StripeConnectCustomer{}}`
+  * `{:error, %Ecto.Changeset{}}`
+  * `{:error, :unhandled}`
+
+  """
+  def update(%User{} = user, attributes) do
+    changeset = user |> User.update_changeset(attributes)
+    do_update(changeset)
+  end
+
+  defp do_update(%Changeset{changes: %{email: _email}} = changeset) do
+    multi =
+      Multi.new
+      |> Multi.update(:update_user, changeset)
+      |> Multi.run(:update_platform_customer, &update_platform_customer/1)
+      |> Multi.run(:update_connect_customers, &update_connect_customers/1)
+
+    case Repo.transaction(multi) do
+      {:ok, %{
+        update_user: user,
+        update_platform_customer: update_platform_customer_result,
+        update_connect_customers: update_connect_customers_results
+      }} ->
+        {:ok, user, update_platform_customer_result, update_connect_customers_results}
+      {:error, :update_user, %Ecto.Changeset{} = changeset, %{}} ->
+        {:error, changeset}
+      {:error, _failed_operation, _failed_value, _changes_so_far} ->
+        {:error, :unhandled}
+    end
+  end
+
+  defp do_update(%Changeset{} = changeset) do
+    with {:ok, user} <- Repo.update(changeset) do
+      {:ok, user, nil, nil}
+    else
+      {:error, changeset} -> {:error, changeset}
+      _ -> {:error, :unhandled}
+    end
+  end
+
+  defp update_platform_customer(%{update_user: %User{id: user_id, email: email}}) do
+    StripePlatformCustomer
+    |> Repo.get_by(user_id: user_id)
+    |> do_update_platform_customer(%{email: email})
+  end
+
+  defp do_update_platform_customer(nil, _), do: {:ok, nil}
+  defp do_update_platform_customer(%StripePlatformCustomer{} = stripe_platform_customer, attributes) do
+    {:ok, %StripePlatformCustomer{} = platform_customer, _} =
+      StripePlatformCustomerService.update(stripe_platform_customer, attributes)
+
+    {:ok, platform_customer}
+  end
+
+  defp update_connect_customers(%{update_platform_customer: nil}), do: {:ok, nil}
+
+  defp update_connect_customers(%{update_platform_customer: %StripePlatformCustomer{email: email} = stripe_platform_customer }) do
+    case do_update_connect_customers(stripe_platform_customer, %{email: email}) do
+      [_h | _t] = results -> {:ok, results}
+      [] -> {:ok, nil}
+    end
+  end
+
+  defp do_update_connect_customers(stripe_platform_customer, attributes) do
+    stripe_platform_customer
+    |> Repo.preload([stripe_connect_customers: :stripe_connect_account])
+    |> Map.get(:stripe_connect_customers)
+    |> Enum.map(&do_update_connect_customer(&1, attributes))
+  end
+
+  defp do_update_connect_customer(%StripeConnectCustomer{} = stripe_connect_customer, attributes) do
+    stripe_connect_customer
+    |> StripeConnectCustomerService.update(attributes)
+  end
+end

--- a/lib/code_corps/stripe_service/stripe_platform_customer.ex
+++ b/lib/code_corps/stripe_service/stripe_platform_customer.ex
@@ -2,16 +2,39 @@ defmodule CodeCorps.StripeService.StripePlatformCustomerService do
   alias CodeCorps.Repo
   alias CodeCorps.StripeService.Adapters.StripePlatformCustomerAdapter
   alias CodeCorps.StripePlatformCustomer
+  alias CodeCorps.User
 
   @api Application.get_env(:code_corps, :stripe)
 
   def create(attributes) do
-    with {:ok, customer} <- @api.Customer.create(attributes),
+    with stripe_attributes <- build_stripe_attributes(attributes),
+         {:ok, customer} <- @api.Customer.create(stripe_attributes),
          {:ok, params} <- StripePlatformCustomerAdapter.to_params(customer, attributes)
     do
       %StripePlatformCustomer{}
       |> StripePlatformCustomer.create_changeset(params)
       |> Repo.insert
     end
+  end
+
+  @doc """
+
+  """
+  def update(%StripePlatformCustomer{id_from_stripe: id_from_stripe} = customer, attributes) do
+    with {:ok, %Stripe.Customer{} = stripe_customer} <- @api.Customer.update(id_from_stripe, attributes),
+         {:ok, params} <- StripePlatformCustomerAdapter.to_params(stripe_customer, attributes),
+         {:ok, %StripePlatformCustomer{} = updated_customer} <- customer |> StripePlatformCustomer.update_changeset(params) |> Repo.update
+    do
+      {:ok, updated_customer, stripe_customer}
+    else
+      {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
+      {:error, %Stripe.APIErrorResponse{} = error} -> {:error, error}
+      _ -> {:error, :unhandled}
+    end
+  end
+
+  defp build_stripe_attributes(%{"user_id" => user_id}) do
+    %User{email: email} = Repo.get(User, user_id)
+    %{email: email}
   end
 end

--- a/lib/code_corps/stripe_testing/customer.ex
+++ b/lib/code_corps/stripe_testing/customer.ex
@@ -3,6 +3,10 @@ defmodule CodeCorps.StripeTesting.Customer do
     {:ok, do_create(map)}
   end
 
+  def update(id, map, _opts \\ []) do
+    {:ok, do_update(id, map)}
+  end
+
   defp do_create(_) do
     {:ok, created} = DateTime.from_unix(1479472835)
 
@@ -15,6 +19,23 @@ defmodule CodeCorps.StripeTesting.Customer do
       delinquent: false,
       description: nil,
       email: "mail@test.com",
+      livemode: false,
+      metadata: %{}
+    }
+  end
+
+  defp do_update(id, map) do
+    {:ok, created} = DateTime.from_unix(1479472835)
+
+    %Stripe.Customer{
+      id: id,
+      account_balance: 0,
+      created: created,
+      currency: "usd",
+      default_source: nil,
+      delinquent: false,
+      description: nil,
+      email: map.email,
       livemode: false,
       metadata: %{}
     }

--- a/test/lib/code_corps/services/user_service_test.exs
+++ b/test/lib/code_corps/services/user_service_test.exs
@@ -1,0 +1,83 @@
+defmodule CodeCorps.Services.UserServiceTest do
+  use ExUnit.Case, async: true
+
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.StripePlatformCustomer
+  alias CodeCorps.Services.UserService
+
+  describe "update/1" do
+    test "it just updates the user if there is nothing associated to update" do
+      user = insert(:user, email: "mail@mail.com", first_name: "Joe")
+
+      {:ok, user, nil, nil}
+        = UserService.update(user, %{email: "changed@mail.com"})
+
+      assert user.email == "changed@mail.com"
+      assert user.first_name == "Joe"
+    end
+
+    test "it returns an {:error, changeset} if there are validation errors with the user" do
+      user = insert(:user, email: "mail@mail.com")
+      {:error, changeset} = UserService.update(user, %{email: ""})
+
+      refute changeset.valid?
+    end
+
+    test "it just updates the user if the changeset does not contain an email" do
+      user = insert(:user, email: "mail@mail.com")
+      stripe_platform_customer = insert(:stripe_platform_customer, email: "mail@mail.com", user: user)
+
+      {:ok, user, nil, nil}
+        = UserService.update(user, %{first_name: "Mark"})
+
+      assert user.first_name == "Mark"
+      assert user.email == "mail@mail.com"
+
+      stripe_platform_customer = Repo.get(StripePlatformCustomer, stripe_platform_customer.id)
+
+      assert stripe_platform_customer.email == "mail@mail.com"
+    end
+
+    test "it also updates the associated platform customer if there is one" do
+      user = insert(:user, email: "mail@mail.com")
+      platform_customer = insert(:stripe_platform_customer, user: user)
+
+      {:ok, user, %StripePlatformCustomer{}, nil}
+        = UserService.update(user, %{email: "changed@mail.com"})
+
+      assert user.email == "changed@mail.com"
+
+      platform_customer = Repo.get(StripePlatformCustomer, platform_customer.id)
+
+      assert platform_customer.email == "changed@mail.com"
+    end
+
+    test "it also updates the associated connect customers if there are any" do
+      user = insert(:user, email: "mail@mail.com")
+
+      platform_customer = %{id_from_stripe: platform_customer_id}
+        = insert(:stripe_platform_customer, user: user)
+
+      [connect_customer_1, connect_customer_2] =
+        insert_pair(:stripe_connect_customer, stripe_platform_customer: platform_customer)
+
+      {:ok, user, %StripePlatformCustomer{}, connect_updates} = UserService.update(user, %{email: "changed@mail.com"})
+
+      assert user.email == "changed@mail.com"
+
+      platform_customer = Repo.get_by(StripePlatformCustomer, id_from_stripe: platform_customer_id)
+      assert platform_customer.email == "changed@mail.com"
+
+      [
+        {:ok, %Stripe.Customer{} = stripe_record_1},
+        {:ok, %Stripe.Customer{} = stripe_record_2}
+      ] = connect_updates
+
+      assert stripe_record_1.id == connect_customer_1.id_from_stripe
+      assert stripe_record_1.email == "changed@mail.com"
+      assert stripe_record_2.id == connect_customer_2.id_from_stripe
+      assert stripe_record_2.email == "changed@mail.com"
+    end
+  end
+end

--- a/test/lib/code_corps/stripe_service/stripe_platform_customer_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_platform_customer_service_test.exs
@@ -1,0 +1,27 @@
+defmodule CodeCorps.StripeService.StripePlatformCustomerServiceTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.StripePlatformCustomer
+  alias CodeCorps.StripeService.StripePlatformCustomerService
+
+  describe "update/2" do
+    test "performs update" do
+      customer = insert(:stripe_platform_customer)
+      {
+        :ok,
+        %StripePlatformCustomer{} = customer,
+        %Stripe.Customer{} = stripe_customer
+      } = StripePlatformCustomerService.update(customer, %{email: "mail@mail.com"})
+
+      assert customer.email == "mail@mail.com"
+      assert stripe_customer.email == "mail@mail.com"
+      assert stripe_customer.id == customer.id_from_stripe
+    end
+
+    test "returns changeset with validation errors if there is an issue" do
+      customer = insert(:stripe_platform_customer)
+      {:error, changeset} = StripePlatformCustomerService.update(customer, %{email: nil})
+      refute changeset.valid?
+    end
+  end
+end

--- a/test/models/stripe_platform_customer_test.exs
+++ b/test/models/stripe_platform_customer_test.exs
@@ -39,4 +39,22 @@ defmodule CodeCorps.StripePlatformCustomerTest do
       assert changeset.errors[:user] == {"does not exist", []}
     end
   end
+
+  describe "update_changeset/2" do
+    test "reports as valid when attributes are valid" do
+      platform_customer = insert(:stripe_platform_customer)
+
+      changeset = StripePlatformCustomer.update_changeset(platform_customer, %{email: "changed@mail.com"})
+      assert changeset.valid?
+    end
+
+    test "requires email" do
+      platform_customer = insert(:stripe_platform_customer)
+
+      changeset = StripePlatformCustomer.update_changeset(platform_customer, %{email: nil})
+      refute changeset.valid?
+
+      assert changeset.errors[:email] == {"can't be blank", []}
+    end
+  end
 end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -113,7 +113,8 @@ defmodule CodeCorps.Factories do
 
   def stripe_connect_customer_factory do
     %CodeCorps.StripeConnectCustomer{
-      id_from_stripe: sequence(:id_from_stripe, &"stripe_id_#{&1}")
+      id_from_stripe: sequence(:id_from_stripe, &"stripe_id_#{&1}"),
+      stripe_connect_account: build(:stripe_connect_account)
     }
   end
 

--- a/web/models/stripe_platform_customer.ex
+++ b/web/models/stripe_platform_customer.ex
@@ -10,6 +10,8 @@ defmodule CodeCorps.StripePlatformCustomer do
 
     belongs_to :user, CodeCorps.User
 
+    has_many :stripe_connect_customers, CodeCorps.StripeConnectCustomer
+
     timestamps()
   end
 
@@ -18,5 +20,11 @@ defmodule CodeCorps.StripePlatformCustomer do
     |> cast(params, [:created, :currency, :delinquent, :id_from_stripe, :user_id])
     |> validate_required([:id_from_stripe, :user_id])
     |> assoc_constraint(:user)
+  end
+
+  def update_changeset(struct, params) do
+    struct
+    |> cast(params, [:email])
+    |> validate_required([:email])
   end
 end


### PR DESCRIPTION
# What's in this PR?

Adds a `UserManager` module, which, for now, is placed under lib/code_corps/user_manager.ex, but ought to probably moved into a new namespace, together with `DonationGoals` manager.

This module, for now, exposes an `update` function, which receives a user and a set of attributes.

The `update` function behaves in the following way:

* If the update does not change the user's email, then it only updates the user
* If the update does change the user email, and there is a platform customer associated with the user, it updates the platform customer as well, both on stripe and locally.

To update the platform customer, I've also implemented `StripeService.StripePlatformCustomer.update/2`, which handles updating of both the local and the API record.

The scope of the PR was unclear to me, so I implemented the whole process. Based on the issue title alone, the assumption would be we just need to pass in the parameters during customer creation. However, the issue description also mentions keeping it up to date so "we can search by user email".

## Questions:

* Right now, it seems like the email is the only field that makes sense to update. A platform customer also has a description field, so I guess we could be setting something there as well.
* Initially, I was going to perform connect customer updates as well, but we aren't storing anything locally that could conceivably be updated. The email might need to be kept up to date on stripe, but we are not storing it locally.


## References
Fixes #489

