### PR TITLE
Set Statement Descriptor on all Stripe Plans we create

### DIFF
--- a/lib/code_corps/stripe_service/stripe_connect_plan.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_plan.ex
@@ -34,7 +34,8 @@ defmodule CodeCorps.StripeService.StripeConnectPlanService do
       currency: "usd",
       id: "month",
       interval: "month",
-      name: "Monthly donation"
+      name: "Monthly donation",
+      statement_descriptor: "CODECORPS.ORG Monthly Donation"
     }
   end
 


### PR DESCRIPTION
# What's in this PR?

Very straightforward change. All the other plan data is already hardcoded.

## References
Fixes #499

