### PR TITLE
Add redirect_uri to stripe_auth

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -50,6 +50,7 @@ config :code_corps, :analytics, CodeCorps.Analytics.InMemoryAPI
 # Configures stripe for dev mode
 config :code_corps, :stripe, Stripe
 config :code_corps, :stripe_env, :dev
+config :code_corps, :stripe_redirect_uri, "http://localhost:4200/oauth/stripe"
 
 config :sentry,
   environment_name: Mix.env || :dev

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -44,6 +44,7 @@ config :code_corps, :analytics, CodeCorps.Analytics.SegmentAPI
 # Configures stripe for production
 config :code_corps, :stripe, Stripe
 config :code_corps, :stripe_env, :prod
+config :code_corps, :stripe_redirect_uri, "http://www.codecorps.org/oauth/stripe"
 
 config :sentry,
   environment_name: Mix.env || :prod

--- a/config/remote-development.exs
+++ b/config/remote-development.exs
@@ -36,6 +36,7 @@ config :logger, level: :info
 # Configures stripe for remote dev
 config :code_corps, :stripe, Stripe
 config :code_corps, :stripe_env, :remote_dev
+config :code_corps, :stripe_redirect_uri, "http://www.pbqrpbecf-qri.org/oauth/stripe"
 
 # ## SSL Support
 #

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -46,6 +46,7 @@ config :sentry,
 # Configures stripe for staging
 config :code_corps, :stripe, Stripe
 config :code_corps, :stripe_env, :staging
+config :code_corps, :stripe_redirect_uri, "http://www.pbqrpbecf.org/oauth/stripe"
 
 # ## SSL Support
 #

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,6 +33,7 @@ config :code_corps, :analytics, CodeCorps.Analytics.TestAPI
 # Configures stripe for test mode
 config :code_corps, :stripe, CodeCorps.StripeTesting
 config :code_corps, :stripe_env, :test
+config :code_corps, :stripe_redirect_uri, "http://localhost:4200/oauth/stripe"
 
 config :code_corps, :icon_color_generator, CodeCorps.RandomIconColor.TestGenerator
 

--- a/test/controllers/stripe_auth_controller_test.exs
+++ b/test/controllers/stripe_auth_controller_test.exs
@@ -29,5 +29,18 @@ defmodule CodeCorps.StripeAuthControllerTest do
       conn = get conn, stripe_auth_path(conn, :stripe_auth, project)
       assert json_response(conn, 403)
     end
+
+    @tag :authenticated
+    test "sets redirect_uri from environment", %{conn: conn, current_user: current_user} do
+      Application.put_env(:code_corps, :stripe_redirect_uri, "https://example.com")
+      organization = insert(:organization)
+      insert(:organization_membership, role: "owner", member: current_user, organization: organization)
+      project = insert(:project, organization: organization)
+
+      conn = get conn, stripe_auth_path(conn, :stripe_auth, project)
+      url = json_response(conn, 200)["data"]["attributes"]["url"]
+      query = url |> URI.decode_query
+      assert query["redirect_uri"] == "https://example.com"
+    end
   end
 end

--- a/web/controllers/stripe_auth_controller.ex
+++ b/web/controllers/stripe_auth_controller.ex
@@ -4,7 +4,6 @@ defmodule CodeCorps.StripeAuthController do
   alias CodeCorps.Project
   alias CodeCorps.Repo
   alias CodeCorps.StripeAuth
-  alias CodeCorps.User
 
   plug :load_and_authorize_resource, model: Project, only: [:stripe_auth]
 

--- a/web/models/stripe_auth.ex
+++ b/web/models/stripe_auth.ex
@@ -36,6 +36,7 @@ defmodule CodeCorps.StripeAuth do
   defp url_params(organization, user, token) do
     %{
       state: token,
+      redirect_uri: redirect_uri,
       stripe_user: %{
         "business_name" => organization.name,
         "email" => user.email,
@@ -46,5 +47,9 @@ defmodule CodeCorps.StripeAuth do
         "url" => "https://www.codecorps.org/" <> organization.slug
       }
     }
+  end
+
+  defp redirect_uri do
+    Application.get_env(:code_corps, :stripe_redirect_uri)
   end
 end


### PR DESCRIPTION
# What's in this PR?

I've set urls for all environments. However, to have this work fully, we have to set our redirect uri field on our Stripe dashboard to a comma-separated list of these URls:

```
"http://localhost:4200/oauth/stripe" - test and dev
"http://www.codecorps.org/oauth/stripe" - production
"http://www.pbqrpbecf-qri.org/oauth/stripe" - remote dev
"http://www.pbqrpbecf.org/oauth/stripe" - staging
```

I did not make that change since we probably ought to merge this first.

## References
Fixes #504