### PR TITLE
Handle customer.subscription.deleted webhook

### DIFF
--- a/lib/code_corps/stripe_service/events/customer_subscription_deleted.ex
+++ b/lib/code_corps/stripe_service/events/customer_subscription_deleted.ex
@@ -1,68 +1,7 @@
 defmodule CodeCorps.StripeService.Events.CustomerSubscriptionDeleted do
-  alias CodeCorps.Project
-  alias CodeCorps.Repo
-  alias CodeCorps.Services.DonationGoalsService
-  alias CodeCorps.Services.ProjectService
-  alias CodeCorps.StripeConnectAccount
-  alias CodeCorps.StripeConnectCustomer
-  alias CodeCorps.StripeConnectPlan
-  alias CodeCorps.StripeConnectSubscription
-  alias CodeCorps.StripeService.Adapters.StripeConnectSubscriptionAdapter
-
   @api Application.get_env(:code_corps, :stripe)
 
   def handle(%{"data" => %{"object" => %{"id" => stripe_sub_id, "customer" => connect_customer_id}}}) do
-    with %StripeConnectCustomer{stripe_connect_account: %StripeConnectAccount{id_from_stripe: connect_account_id}} <-
-           retrieve_connect_customer(connect_customer_id),
-
-         {:ok, %Stripe.Subscription{} = stripe_subscription} <-
-           @api.Subscription.retrieve(stripe_sub_id, connect_account: connect_account_id),
-
-         subscription <-
-           load_subscription(stripe_sub_id),
-
-         {:ok, params} <-
-           stripe_subscription |> StripeConnectSubscriptionAdapter.to_params(%{}),
-
-         _subscription <-
-           update_subscription(subscription, params),
-
-         project <-
-           get_project(subscription),
-
-         {:ok, project} <-
-           ProjectService.update_project_totals(project)
-    do
-      DonationGoalsService.update_project_goals(project)
-    else
-      {:error, %Stripe.APIErrorResponse{}} -> {:error, :stripe_error}
-      nil -> {:error, :not_found}
-      _ -> {:error, :unexpected}
-    end
-  end
-
-  defp retrieve_connect_customer(connect_customer_id) do
-    StripeConnectCustomer
-    |> Repo.get_by(id_from_stripe: connect_customer_id)
-    |> Repo.preload(:stripe_connect_account)
-  end
-
-  defp load_subscription(id_from_stripe) do
-    StripeConnectSubscription
-    |> Repo.get_by(id_from_stripe: id_from_stripe)
-  end
-
-  defp update_subscription(%StripeConnectSubscription{} = record, params) do
-    record
-    |> StripeConnectSubscription.webhook_update_changeset(params)
-    |> Repo.update
-  end
-
-  defp get_project(%StripeConnectSubscription{stripe_connect_plan_id: stripe_connect_plan_id}) do
-    plan =
-      StripeConnectPlan
-      |> Repo.get(stripe_connect_plan_id)
-
-    Project |> Repo.get(plan.project_id) |> Repo.preload(:stripe_connect_plan)
+    CodeCorps.StripeService.StripeConnectSubscriptionService.update_from_stripe(stripe_sub_id, connect_customer_id)
   end
 end

--- a/lib/code_corps/stripe_service/events/customer_subscription_deleted.ex
+++ b/lib/code_corps/stripe_service/events/customer_subscription_deleted.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.StripeService.Events.CustomerSubscriptionUpdated do
+defmodule CodeCorps.StripeService.Events.CustomerSubscriptionDeleted do
   alias CodeCorps.Project
   alias CodeCorps.Repo
   alias CodeCorps.Services.DonationGoalsService

--- a/lib/code_corps/stripe_service/events/customer_subscription_updated.ex
+++ b/lib/code_corps/stripe_service/events/customer_subscription_updated.ex
@@ -1,68 +1,7 @@
 defmodule CodeCorps.StripeService.Events.CustomerSubscriptionUpdated do
-  alias CodeCorps.Project
-  alias CodeCorps.Repo
-  alias CodeCorps.Services.DonationGoalsService
-  alias CodeCorps.Services.ProjectService
-  alias CodeCorps.StripeConnectAccount
-  alias CodeCorps.StripeConnectCustomer
-  alias CodeCorps.StripeConnectPlan
-  alias CodeCorps.StripeConnectSubscription
-  alias CodeCorps.StripeService.Adapters.StripeConnectSubscriptionAdapter
-
   @api Application.get_env(:code_corps, :stripe)
 
   def handle(%{"data" => %{"object" => %{"id" => stripe_sub_id, "customer" => connect_customer_id}}}) do
-    with %StripeConnectCustomer{stripe_connect_account: %StripeConnectAccount{id_from_stripe: connect_account_id}} <-
-           retrieve_connect_customer(connect_customer_id),
-
-         {:ok, %Stripe.Subscription{} = stripe_subscription} <-
-           @api.Subscription.retrieve(stripe_sub_id, connect_account: connect_account_id),
-
-         subscription <-
-           load_subscription(stripe_sub_id),
-
-         {:ok, params} <-
-           stripe_subscription |> StripeConnectSubscriptionAdapter.to_params(%{}),
-
-         _subscription <-
-           update_subscription(subscription, params),
-
-         project <-
-           get_project(subscription),
-
-         {:ok, project} <-
-           ProjectService.update_project_totals(project)
-    do
-      DonationGoalsService.update_project_goals(project)
-    else
-      {:error, %Stripe.APIErrorResponse{}} -> {:error, :stripe_error}
-      nil -> {:error, :not_found}
-      _ -> {:error, :unexpected}
-    end
-  end
-
-  defp retrieve_connect_customer(connect_customer_id) do
-    StripeConnectCustomer
-    |> Repo.get_by(id_from_stripe: connect_customer_id)
-    |> Repo.preload(:stripe_connect_account)
-  end
-
-  defp load_subscription(id_from_stripe) do
-    StripeConnectSubscription
-    |> Repo.get_by(id_from_stripe: id_from_stripe)
-  end
-
-  defp update_subscription(%StripeConnectSubscription{} = record, params) do
-    record
-    |> StripeConnectSubscription.webhook_update_changeset(params)
-    |> Repo.update
-  end
-
-  defp get_project(%StripeConnectSubscription{stripe_connect_plan_id: stripe_connect_plan_id}) do
-    plan =
-      StripeConnectPlan
-      |> Repo.get(stripe_connect_plan_id)
-
-    Project |> Repo.get(plan.project_id) |> Repo.preload(:stripe_connect_plan)
+    CodeCorps.StripeService.StripeConnectSubscriptionService.update_from_stripe(stripe_sub_id, connect_customer_id)
   end
 end

--- a/lib/code_corps/stripe_service/stripe_connect_subscription.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_subscription.ex
@@ -2,89 +2,56 @@ defmodule CodeCorps.StripeService.StripeConnectSubscriptionService do
   import Ecto.Query
 
   alias CodeCorps.{
-    Organization, Project, Repo, StripeConnectAccount,StripeConnectCard,
-    StripeConnectCustomer, StripeConnectPlan, StripeConnectSubscription,
-    StripePlatformCard, StripePlatformCustomer, User
+    Project, Repo, StripeConnectCard, StripeConnectCustomer,
+    StripeConnectPlan, StripeConnectSubscription, User
   }
   alias CodeCorps.Services.ProjectService
-  alias CodeCorps.StripeService.{
-    StripeConnectCardService, StripeConnectCustomerService
-  }
+  alias CodeCorps.StripeService.{StripeConnectCardService, StripeConnectCustomerService}
   alias CodeCorps.StripeService.Adapters.StripeConnectSubscriptionAdapter
+  alias CodeCorps.StripeService.Validators.{ProjectSubscribable, UserCanSubscribe}
 
   @api Application.get_env(:code_corps, :stripe)
 
-  def find_or_create(%{"project_id" => project_id, "quantity" => quantity, "user_id" => user_id} = attributes) do
-    with %Project{
-           stripe_connect_plan: %StripeConnectPlan{} = plan,
-           organization: %Organization{
-             stripe_connect_account: %StripeConnectAccount{} = connect_account
-           }
-         } = project <-
-           get_project(project_id),
-         %User{
-           stripe_platform_card: %StripePlatformCard{} = platform_card,
-           stripe_platform_customer: %StripePlatformCustomer{} = platform_customer
-         } = user <-
-           get_user(user_id),
-         {:ok, %StripeConnectSubscription{} = stripe_connect_subscription} <-
-           do_find_or_create(attributes, connect_account, plan, project, platform_card, platform_customer, quantity, user),
-         _project <-
-           ProjectService.update_project_totals(project)
+  def find_or_create(%{"project_id" => project_id, "quantity" => _, "user_id" => user_id} = attributes) do
+    with {:ok, %Project{} = project} <- get_project_with_preloads(project_id) |> ProjectSubscribable.validate,
+         {:ok, %User{} = user} <- get_user_with_preloads(user_id) |> UserCanSubscribe.validate
     do
+      {:ok, %StripeConnectSubscription{} = stripe_connect_subscription} = do_find_or_create(project, user, attributes)
+      ProjectService.update_project_totals(project)
       {:ok, stripe_connect_subscription}
     else
+      {:error, :project_not_ready} -> {:error, :project_not_ready}
+      {:error, :user_not_ready} -> {:error, :user_not_ready}
       {:error, error} -> {:error, error}
       nil -> {:error, :not_found}
     end
   end
 
-  defp do_find_or_create(
-    %{"project_id" => _, "quantity" => _, "user_id" => _} = attributes,
-    %StripeConnectAccount{} = connect_account,
-    %StripeConnectPlan{} = plan,
-    %Project{} = project,
-    %StripePlatformCard{} = platform_card,
-    %StripePlatformCustomer{} = platform_customer,
-    quantity,
-    %User{} = user
-  ) do
-    case find(plan, user) do
-      nil -> create(attributes, connect_account, plan, project, platform_card, platform_customer, quantity, user)
+  defp do_find_or_create(%Project{} = project, %User{} = user, %{} = attributes) do
+    case find(project, user) do
+      nil -> create(project, user, attributes)
       %StripeConnectSubscription{} = subscription -> {:ok, subscription}
     end
   end
 
-  defp find(%StripeConnectPlan{} = plan, %User{} = user) do
+  defp find(%Project{} = project, %User{} = user) do
     StripeConnectSubscription
-    |> where([s], s.stripe_connect_plan_id == ^plan.id and s.user_id == ^user.id)
+    |> where([s], s.stripe_connect_plan_id == ^project.stripe_connect_plan.id and s.user_id == ^user.id)
     |> Repo.one
   end
 
-  defp create(
-    %{"project_id" => _, "quantity" => _, "user_id" => _} = attributes,
-    %StripeConnectAccount{} = connect_account,
-    %StripeConnectPlan{} = plan,
-    %Project{} = project,
-    %StripePlatformCard{} = platform_card,
-    %StripePlatformCustomer{} = platform_customer,
-    quantity,
-    %User{} = user
-  ) do
-    with {:ok, connect_customer} <-
-           StripeConnectCustomerService.find_or_create(platform_customer, connect_account),
-         {:ok, connect_card} <-
-           StripeConnectCardService.find_or_create(platform_card, connect_customer, platform_customer, connect_account),
-         create_attributes <-
-           to_create_attributes(connect_card, connect_customer, plan, quantity),
-         {:ok, subscription} <-
-           @api.Subscription.create(create_attributes, connect_account: connect_account.id_from_stripe),
-         insert_attributes <-
-           to_insert_attributes(attributes, plan),
-         {:ok, params} <-
-           StripeConnectSubscriptionAdapter.to_params(subscription, insert_attributes),
-         {:ok, %StripeConnectSubscription{} = stripe_connect_subscription} <-
-           insert_subscription(params)
+  defp create(%Project{} = project, %User{} = user, attributes) do
+    with platform_card <- user.stripe_platform_card,
+         platform_customer <- user.stripe_platform_customer,
+         connect_account <- project.organization.stripe_connect_account,
+         plan <- project.stripe_connect_plan,
+         {:ok, connect_customer} <- StripeConnectCustomerService.find_or_create(platform_customer, connect_account),
+         {:ok, connect_card} <- StripeConnectCardService.find_or_create(platform_card, connect_customer, platform_customer, connect_account),
+         create_attributes <- to_create_attributes(connect_card, connect_customer, plan, attributes),
+         {:ok, subscription} <- @api.Subscription.create(create_attributes, connect_account: connect_account.id_from_stripe),
+         insert_attributes <- to_insert_attributes(attributes, plan),
+         {:ok, params} <- StripeConnectSubscriptionAdapter.to_params(subscription, insert_attributes),
+         {:ok, %StripeConnectSubscription{} = stripe_connect_subscription} <- insert_subscription(params)
     do
       {:ok, stripe_connect_subscription}
     else
@@ -93,17 +60,20 @@ defmodule CodeCorps.StripeService.StripeConnectSubscriptionService do
     end
   end
 
-  defp get_project(project_id) do
+  @default_project_preloads [:stripe_connect_plan, [{:organization, :stripe_connect_account}]]
+
+  defp get_project_with_preloads(project_id, preloads \\ @default_project_preloads) do
     Project
     |> Repo.get(project_id)
-    |> Repo.preload([:stripe_connect_plan, [{:organization, :stripe_connect_account}]])
+    |> Repo.preload(preloads)
   end
 
-  defp get_user(user_id) do
+  @default_user_preloads [:stripe_platform_customer, [{:stripe_platform_card, :stripe_connect_cards}]]
+
+  defp get_user_with_preloads(user_id, preloads \\ @default_user_preloads) do
     User
     |> Repo.get(user_id)
-    |> Repo.preload([stripe_platform_card: :stripe_connect_cards])
-    |> Repo.preload(:stripe_platform_customer)
+    |> Repo.preload(preloads)
   end
 
   defp insert_subscription(params) do
@@ -112,7 +82,12 @@ defmodule CodeCorps.StripeService.StripeConnectSubscriptionService do
     |> Repo.insert
   end
 
-  defp to_create_attributes(%StripeConnectCard{} = card, %StripeConnectCustomer{} = customer, %StripeConnectPlan{} = plan, quantity) do
+  defp to_create_attributes(
+    %StripeConnectCard{} = card,
+    %StripeConnectCustomer{} = customer,
+    %StripeConnectPlan{} = plan,
+    %{"quantity" => quantity}
+  ) do
     %{
       application_fee_percent: 5,
       customer: customer.id_from_stripe,

--- a/lib/code_corps/stripe_service/validators/project_subscribable.ex
+++ b/lib/code_corps/stripe_service/validators/project_subscribable.ex
@@ -1,0 +1,33 @@
+defmodule CodeCorps.StripeService.Validators.ProjectSubscribable do
+  @moduledoc """
+  Ensures a `CodeCorps.Project` is able to receive subscriptions.
+  """
+
+  alias CodeCorps.{Organization, Project, StripeConnectAccount, StripeConnectPlan}
+
+  @doc """
+  Determines if the provided `CodeCorps.Project` is able to
+  get a subscription by a `CodeCorps.User`
+
+  For a project to be able to receive subscriptions,
+  it needs to have proper associations set up.
+
+  These are:
+
+  * `StripeConnectPlan`
+  * `Organization` with a `StripeConnectAccount`
+
+  If the project has these relationships set up, it returns `{:ok, project}`
+
+  In any other case, it returns {:error, :project_not_ready}
+  """
+  def validate(%Project{} = project), do: do_validate(project)
+
+  @invalid {:error, :project_not_ready}
+
+  defp do_validate(%Project{
+    stripe_connect_plan: %StripeConnectPlan{},
+    organization: %Organization{stripe_connect_account: %StripeConnectAccount{}}
+  } = project), do: {:ok, project}
+  defp do_validate(_), do: @invalid
+end

--- a/lib/code_corps/stripe_service/validators/user_can_subscribe.ex
+++ b/lib/code_corps/stripe_service/validators/user_can_subscribe.ex
@@ -1,0 +1,33 @@
+defmodule CodeCorps.StripeService.Validators.UserCanSubscribe do
+  @moduledoc """
+  Ensures a `CodeCorps.User` is able to subscribe to a `CodeCorps.Project`.
+  """
+
+  alias CodeCorps.{User, StripePlatformCard, StripePlatformCustomer}
+
+  @doc """
+  Determines if the provided `CodeCorps.User` is able to
+  subscribe to a `CodeCorps.Project`
+
+  For a user to be able to create subscriptions, they need to have
+  their associated records properly set up
+
+  These are:
+
+  * `StripePlatformCard`
+  * `StripePlatformCustomer`
+
+  If the user has these relationships set up, it returns `{:ok, user}`
+
+  In any other case, it returns {:error, :user_not_ready}
+  """
+  def validate(%User{} = user), do: do_validate(user)
+
+  @invalid {:error, :user_not_ready}
+
+  defp do_validate(%User{
+    stripe_platform_card: %StripePlatformCard{},
+    stripe_platform_customer: %StripePlatformCustomer{}
+  } = user), do: {:ok, user}
+  defp do_validate(_), do: @invalid
+end

--- a/test/controllers/stripe_connect_events_controller_test.exs
+++ b/test/controllers/stripe_connect_events_controller_test.exs
@@ -50,22 +50,18 @@ defmodule CodeCorps.StripeConnectEventsControllerTest do
         transfers_enabled: false
       )
 
-      conn = post conn, stripe_connect_events_path(conn, :create), event
+      path = stripe_connect_events_path(conn, :create)
+      assert conn |> post(path, event) |> response(200)
 
-      assert response(conn, 200)
-
-      updated_account =
-        StripeConnectAccount
-        |> Repo.get_by(id_from_stripe: stripe_id)
-
+      updated_account = Repo.get_by(StripeConnectAccount, id_from_stripe: stripe_id)
       assert updated_account.transfers_enabled
     end
 
     test "returns 400 when doesn't match an existing account", %{conn: conn} do
       event = event_for(@account, "account.updated")
-      conn = post conn, stripe_connect_events_path(conn, :create), event
 
-      assert response(conn, 400)
+      path = stripe_connect_events_path(conn, :create)
+      assert conn |> post(path, event) |> response(400)
     end
   end
 
@@ -90,19 +86,15 @@ defmodule CodeCorps.StripeConnectEventsControllerTest do
         id_from_stripe: stripe_id,
         stripe_connect_plan: plan)
 
-      conn = post conn, stripe_connect_events_path(conn, :create), event
+      path = stripe_connect_events_path(conn, :create)
+      assert conn |> post(path, event) |> response(200)
 
-      assert response(conn, 200)
-
-      updated_project =
-        Project
-        |> Repo.get_by(id: project.id)
-
+      updated_project = Repo.get_by(Project, id: project.id)
       assert updated_project.total_monthly_donated == 0
     end
   end
 
-  describe "customer.subscription.updated" do
+  describe "customer.subscription.deleted" do
     test "returns 200 and sets subscription to inactive when one matches", %{conn: conn} do
       event = event_for(@subscription, "customer.subscription.deleted")
       stripe_id =  @subscription["id"]
@@ -123,14 +115,10 @@ defmodule CodeCorps.StripeConnectEventsControllerTest do
         id_from_stripe: stripe_id,
         stripe_connect_plan: plan)
 
-      conn = post conn, stripe_connect_events_path(conn, :create), event
+      path = stripe_connect_events_path(conn, :create)
+      assert conn |> post(path, event) |> response(200)
 
-      assert response(conn, 200)
-
-      updated_project =
-        Project
-        |> Repo.get_by(id: project.id)
-
+      updated_project = Repo.get_by(Project, id: project.id)
       assert updated_project.total_monthly_donated == 0
     end
   end

--- a/test/controllers/stripe_connect_events_controller_test.exs
+++ b/test/controllers/stripe_connect_events_controller_test.exs
@@ -70,8 +70,41 @@ defmodule CodeCorps.StripeConnectEventsControllerTest do
   end
 
   describe "customer.subscription.updated" do
-    test "returns 200 and updates account when one matches", %{conn: conn} do
+    test "returns 200 and updates subscription when one matches", %{conn: conn} do
       event = event_for(@subscription, "customer.subscription.updated")
+      stripe_id =  @subscription["id"]
+      connect_customer_id = @subscription["customer"]
+
+      project = insert(:project, total_monthly_donated: 1000)
+      account = insert(:stripe_connect_account)
+      platform_customer = insert(:stripe_platform_customer)
+
+      insert(:stripe_connect_customer,
+        id_from_stripe: connect_customer_id,
+        stripe_connect_account: account,
+        stripe_platform_customer: platform_customer)
+
+      plan = insert(:stripe_connect_plan, project: project)
+
+      insert(:stripe_connect_subscription,
+        id_from_stripe: stripe_id,
+        stripe_connect_plan: plan)
+
+      conn = post conn, stripe_connect_events_path(conn, :create), event
+
+      assert response(conn, 200)
+
+      updated_project =
+        Project
+        |> Repo.get_by(id: project.id)
+
+      assert updated_project.total_monthly_donated == 0
+    end
+  end
+
+  describe "customer.subscription.updated" do
+    test "returns 200 and sets subscription to inactive when one matches", %{conn: conn} do
+      event = event_for(@subscription, "customer.subscription.deleted")
       stripe_id =  @subscription["id"]
       connect_customer_id = @subscription["customer"]
 

--- a/web/controllers/stripe_connect_events_controller.ex
+++ b/web/controllers/stripe_connect_events_controller.ex
@@ -23,6 +23,7 @@ defmodule CodeCorps.StripeConnectEventsController do
   end
 
   def do_handle(%{"type" => "account.updated"} = attributes), do: Events.AccountUpdated.handle(attributes)
+  def do_handle(%{"type" => "customer.subscription.deleted"} = attributes), do: Events.CustomerSubscriptionDeleted.handle(attributes)
   def do_handle(%{"type" => "customer.subscription.updated"} = attributes), do: Events.CustomerSubscriptionUpdated.handle(attributes)
   def do_handle(_attributes), do: {:ok, :unhandled_event}
 


### PR DESCRIPTION
# What's in this PR?

This PR adds handling of the `customer.subscription.deleted` event.

Since the actual subscription stripe record is not deleted, instead simply removed from the customer account, and it's status set to cancelled, the solution was to simply handle it identically to `customer.subscription.updated`.

This raises a question, though.

**Should our API, when requesting a user's subscriptions, only return those that are active, or all of them?**

If the answer is **all of them**, then we need to modify our client logic so that the donate UI is hidden/redirected from only if there is an **active** subscription, not just any subscription as it is right now.

If the answer is **only those that are active**, then we need to modify our user/project views.

## Implementation

The logical place to put the update code was `CodeCorps.StripeService.StripeConnectSubscriptionService`. 

However, I found the code there difficult to understand and manage, so adding additional code there would make it even worse. 

In an attempt to remedy this, I refactored the module:

I rewrote a few methods

I added validator modules - `ProjectSubscribable` and `UserCanSubscribe`. 

These both have a `validate/1` method, which receives a `Project` or `User` record respectively. It either returns back an `{:ok, record}` or an `{:error, :project_not_ready}` / `{:error, :user_not_ready}` if the two records do not have the necessary stripe relationships set up.  

The idea is that these validators are a simple blackbox that determines if a user or a project is able to participate in the donation system. It allows us to have less checks in the subscription creation process reduces the required size of method signatures there, making the code more readable.

Once that was in, I cleaned up further and then moved the logic from `Events.CustomerSubscriptionUpdated` into `StripeConnectSubscriptionService.update_from_stripe/2`. This same method is then used by `Events.CustomerSubscriptionDeleted`.

## References
Fixes #509

Progress on: #
