### PR TITLE
Changed link for USAGE.md to link to /USAGE.md, rather than /docs/USA…

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -102,7 +102,7 @@ Note: some browsers like Safari and Firefox may ask to download a file instead o
 
 ### Next steps
 
-Now that you're set up, you should [read more about how to develop with the API](USAGE.md).
+Now that you're set up, you should [read more about how to develop with the API](../USAGE.md).
 
 ### Issues installing?
 


### PR DESCRIPTION
# Link fix for USAGE.md
linked to USAGE.md in root, rather than in sub directory "/docs"
## References
Fixes #515 
