### PR TITLE
Add approved column to organizations

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -8,7 +8,7 @@
   "canary": {:hex, :canary, "1.1.0", "3599012f5393c2fdb18c9129853a9fc6cd115ebfdcc0725af7b52398b9ed5c7b", [:mix], [{:canada, "~> 1.0.0", [hex: :canada, optional: false]}, {:ecto, ">= 1.1.0", [hex: :ecto, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "combine": {:hex, :combine, "0.9.3", "192e609b48b3f2210494e26f85db1712657be1a8f15795656710317ea43fc449", [:mix], []},
-  "comeonin": {:hex, :comeonin, "2.6.0", "74c288338b33205f9ce97e2117bb9a2aaab103a1811d243443d76fdb62f904ac", [:mix, :make, :make], []},
+  "comeonin": {:hex, :comeonin, "2.6.0", "74c288338b33205f9ce97e2117bb9a2aaab103a1811d243443d76fdb62f904ac", [:make, :mix], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "corsica": {:hex, :corsica, "0.5.0", "eb5b2fccc5bc4f31b8e2b77dd15f5f302aca5d63286c953e8e916f806056d50c", [:mix], [{:cowboy, ">= 1.0.0", [hex: :cowboy, optional: false]}, {:plug, ">= 0.9.0", [hex: :plug, optional: false]}]},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},

--- a/priv/repo/migrations/20161216051447_add_approved_to_organizations.exs
+++ b/priv/repo/migrations/20161216051447_add_approved_to_organizations.exs
@@ -1,0 +1,11 @@
+defmodule CodeCorps.Repo.Migrations.AddApprovedToOrganizations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:organizations) do
+      add :approved, :boolean, default: false
+    end
+
+    create index(:organizations, :approved)
+  end
+end

--- a/web/models/organization.ex
+++ b/web/models/organization.ex
@@ -16,6 +16,7 @@ defmodule CodeCorps.Organization do
     field :icon, CodeCorps.OrganizationIcon.Type
     field :name, :string
     field :slug, :string
+    field :approved, :boolean
 
     has_one :slugged_route, CodeCorps.SluggedRoute
     has_one :stripe_connect_account, CodeCorps.StripeConnectAccount


### PR DESCRIPTION
Making some progress towards #523

- Add an `approved` column to `organizations`
- Index `approved`