### PR TITLE
Add `approved` to projects

### DIFF
--- a/priv/repo/migrations/20161205024856_add_approved_to_projects.exs
+++ b/priv/repo/migrations/20161205024856_add_approved_to_projects.exs
@@ -1,0 +1,10 @@
+defmodule CodeCorps.Repo.Migrations.AddApprovedToProjects do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :approved, :boolean, default: false
+    end
+    create index(:projects, [:approved])
+  end
+end

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -11,6 +11,7 @@ defmodule CodeCorps.Project do
   alias CodeCorps.Services.MarkdownRendererService
 
   schema "projects" do
+    field :approved, :boolean
     field :base64_icon_data, :string, virtual: true
     field :description, :string
     field :icon, CodeCorps.ProjectIcon.Type


### PR DESCRIPTION
Add `approved` to projects and added an index to enable future scoping, seemed likely to be needed given @JoshSmith's [comment](https://github.com/code-corps/code-corps-api/pull/530#issuecomment-264745483) on #523. 

Hat tip to @dleve123, who made a similar change in his [PR yesterday for organizations](https://github.com/code-corps/code-corps-api/pull/530) that addressed #523.

## References
Resolves #521 

