### PR TITLE
Basic bamboo email integration

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -54,3 +54,6 @@ config :code_corps, :stripe_redirect_uri, "http://localhost:4200/oauth/stripe"
 
 config :sentry,
   environment_name: Mix.env || :dev
+
+config :code_corps, CodeCorps.Mailer,
+  adapter: Bamboo.LocalAdapter

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -49,6 +49,10 @@ config :code_corps, :stripe_redirect_uri, "http://www.codecorps.org/oauth/stripe
 config :sentry,
   environment_name: Mix.env || :prod
 
+# TODO: Replace with actual adapter
+config :code_corps, CodeCorps.Mailer,
+  adapter: Bamboo.LocalAdapter
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/remote-development.exs
+++ b/config/remote-development.exs
@@ -38,6 +38,9 @@ config :code_corps, :stripe, Stripe
 config :code_corps, :stripe_env, :remote_dev
 config :code_corps, :stripe_redirect_uri, "http://www.pbqrpbecf-qri.org/oauth/stripe"
 
+config :code_corps, CodeCorps.Mailer,
+  adapter: Bamboo.LocalAdapter
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -48,6 +48,9 @@ config :code_corps, :stripe, Stripe
 config :code_corps, :stripe_env, :staging
 config :code_corps, :stripe_redirect_uri, "http://www.pbqrpbecf.org/oauth/stripe"
 
+config :code_corps, CodeCorps.Mailer,
+  adapter: Bamboo.LocalAdapter
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/test.exs
+++ b/config/test.exs
@@ -42,3 +42,6 @@ config :code_corps, :corsica_log_level, [rejected: :debug]
 
 config :sentry,
   environment_name: Mix.env || :test
+
+config :code_corps, CodeCorps.Mailer,
+  adapter: Bamboo.TestAdapter

--- a/lib/code_corps/emails/test.ex
+++ b/lib/code_corps/emails/test.ex
@@ -1,0 +1,12 @@
+defmodule CodeCorps.Emails.Test do
+  import Bamboo.Email
+
+  def hello_world do
+    new_email
+    |> to("test_user@codecorps.org")
+    |> from("admin@codecorps.org")
+    |> subject("Hello World!")
+    |> html_body("<strong>Hello</strong> World!")
+    |> text_body("Hello World!")
+  end
+end

--- a/lib/code_corps/mailer.ex
+++ b/lib/code_corps/mailer.ex
@@ -1,0 +1,3 @@
+defmodule CodeCorps.Mailer do
+  use Bamboo.Mailer, otp_app: :code_corps
+end

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,7 @@ defmodule CodeCorps.Mixfile do
     [
       mod: {CodeCorps, []},
       applications: [
+        :bamboo,
         :phoenix,
         :phoenix_pubsub,
         :phoenix_html,
@@ -55,6 +56,7 @@ defmodule CodeCorps.Mixfile do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
+      {:bamboo, "~> 0.7"}, # emails
       {:phoenix, "~> 1.2.1"},
       {:phoenix_pubsub, "~> 1.0"},
       {:phoenix_ecto, "~> 3.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"arc": {:git, "https://github.com/stavro/arc.git", "354d4d2e1b86bcd6285db3528118fe3f5db36cf5", [ref: "354d4d2e1b86bcd6285db3528118fe3f5db36cf5"]},
   "arc_ecto": {:hex, :arc_ecto, "0.4.4", "2ea481a546ceb79090e90984de1a423a1a8a04fe78c871ab05b09f1dffcf9e35", [:mix], [{:arc, "~> 0.5.3", [hex: :arc, optional: false]}, {:ecto, "~> 2.0", [hex: :ecto, optional: false]}]},
+  "bamboo": {:hex, :bamboo, "0.7.0", "2722e395a396dfedc12d300c900f65b216f7d7bf9d430c5dd0235690997878b7", [:mix], [{:httpoison, "~> 0.9", [hex: :httpoison, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], []},
   "benchfella": {:hex, :benchfella, "0.3.3", "bbde48b5fe1ef556baa7ad933008e214e050e81ddb0916350715f5759fb35c0c", [:mix], []},
   "bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},

--- a/test/lib/code_corps/mailer_test.exs
+++ b/test/lib/code_corps/mailer_test.exs
@@ -1,0 +1,25 @@
+defmodule CodeCorps.MailerTest do
+  use ExUnit.Case
+  use Bamboo.Test
+
+  alias CodeCorps.Emails
+
+  alias CodeCorps.Mailer
+
+  test "hello_world email works" do
+    email = Emails.Test.hello_world
+
+    assert email.to == "test_user@codecorps.org"
+    assert email.from == "admin@codecorps.org"
+    assert email.subject =="Hello World!"
+    assert email.html_body == "<strong>Hello</strong> World!"
+    assert email.text_body == "Hello World!"
+  end
+
+  test "email can be sent" do
+    email = Emails.Test.hello_world
+    email |> Mailer.deliver_now
+
+    assert_delivered_email email
+  end
+end


### PR DESCRIPTION
# What's in this PR?

Adds basic integration for emailing using bamboo. Everything is setup to use the `Bamboo.LocalAdapter` at the moment, since the issue does not specify which email service we want to use.

A test `hello_world` email has also been set up, with 2 tests to ensure it works.

Not sure I can do much more at the moment.

## References
Progress on #524

