### PR TITLE
Handle customer.updated platform event and propagate from platform to connect customers

### DIFF
--- a/lib/code_corps/stripe_service/events/customer_updated.ex
+++ b/lib/code_corps/stripe_service/events/customer_updated.ex
@@ -1,0 +1,5 @@
+defmodule CodeCorps.StripeService.Events.CustomerUpdated do
+  def handle(%{"data" => %{"object" => %{"id" => id_from_stripe}}}) do
+    CodeCorps.StripeService.StripePlatformCustomerService.update_from_stripe(id_from_stripe)
+  end
+end

--- a/lib/code_corps/stripe_service/stripe_platform_customer.ex
+++ b/lib/code_corps/stripe_service/stripe_platform_customer.ex
@@ -1,8 +1,10 @@
 defmodule CodeCorps.StripeService.StripePlatformCustomerService do
   alias CodeCorps.Repo
+  alias CodeCorps.{StripeConnectCustomer, StripePlatformCustomer, User}
   alias CodeCorps.StripeService.Adapters.StripePlatformCustomerAdapter
-  alias CodeCorps.StripePlatformCustomer
-  alias CodeCorps.User
+  alias CodeCorps.StripeService.StripeConnectCustomerService
+
+  alias Ecto.Multi
 
   @api Application.get_env(:code_corps, :stripe)
 
@@ -18,7 +20,15 @@ defmodule CodeCorps.StripeService.StripePlatformCustomerService do
   end
 
   @doc """
+  Updates a `CodeCorps.StripePlatformCustomer` local and associated `%Stripe.Customer{} API record
+  with provided attributes
 
+  Returns
+
+  - `{:ok, %CodeCorps.StriePlatformCustomer{}, %Stripe.Customer{}}` if everything was updated
+  - `{:error, %Ecto.Changeset{}}` -if there was a validation issue while updating the local record
+  - `{:error, %Stripe.APIErrorResposne{}}` - if there was a problem with updating the API record
+  - `{:error, :unhandled}` -if something unexpected went wrong
   """
   def update(%StripePlatformCustomer{id_from_stripe: id_from_stripe} = customer, attributes) do
     with {:ok, %Stripe.Customer{} = stripe_customer} <- @api.Customer.update(id_from_stripe, attributes),
@@ -33,8 +43,84 @@ defmodule CodeCorps.StripeService.StripePlatformCustomerService do
     end
   end
 
+  @doc """
+  Updates a `CodeCorps.StripePlatformCustomer` local record using `%Stripe.Customer{} API record
+  retrieved from API using the provided Stripe ID
+
+  Returns
+
+  - `{:ok, %CodeCorps.StripePlatformCustomer{}}` if the local record was updated
+  - `{:error, :not_found}` - If there was no record witht he specified Stripe ID
+  - `{:error, %Ecto.Changeset{}}` -if there was a validation issue while updating the local record
+  - `{:error, %Stripe.APIErrorResposne{}}` - if there was a problem with retrieving the API record
+  - `{:error, :unhandled}` -if something unexpected went wrong
+  """
+  def update_from_stripe(id_from_stripe) do
+    with customer                                            <- Repo.get_by(StripePlatformCustomer, id_from_stripe: id_from_stripe),
+         {:ok, %Stripe.Customer{} = stripe_customer}         <- @api.Customer.retrieve(id_from_stripe),
+         {:ok, params}                                       <- StripePlatformCustomerAdapter.to_params(stripe_customer, %{}),
+         {:ok, %StripePlatformCustomer{} = platform_customer, connect_customer_updates} <- perform_update(customer, params)
+    do
+      {:ok, platform_customer, connect_customer_updates}
+    else
+      nil -> {:error, :not_found}
+      {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
+      {:error, %Stripe.APIErrorResponse{} = error} -> {:error, error}
+      _ -> {:error, :unhandled}
+    end
+  end
+
   defp build_stripe_attributes(%{"user_id" => user_id}) do
     %User{email: email} = Repo.get(User, user_id)
     %{email: email}
+  end
+
+  defp perform_update(customer, params) do
+    changeset = StripePlatformCustomer.update_changeset(customer, params)
+    do_update(changeset)
+  end
+
+  defp do_update(%Ecto.Changeset{changes: %{email: _email}} = changeset) do
+    multi =
+      Multi.new
+      |> Multi.update(:update_platform_customer, changeset)
+      |> Multi.run(:update_connect_customers, &update_connect_customers/1)
+
+    case Repo.transaction(multi) do
+      {:ok, %{update_platform_customer: platform_customer, update_connect_customers: update_connect_customers_results}} ->
+        {:ok, platform_customer, update_connect_customers_results}
+      {:error, :update_platform_customer, %Ecto.Changeset{} = changeset, %{}} ->
+        {:error, changeset}
+      {:error, _failed_operation, _failed_value, _changes_so_far} ->
+        {:error, :unhandled}
+    end
+  end
+
+  defp do_update(%Ecto.Changeset{} = changeset) do
+    with {:ok, platform_customer} <- Repo.update(changeset) do
+      {:ok, platform_customer, nil}
+    else
+      {:error, changeset} -> {:error, changeset}
+      _ -> {:error, :unhandled}
+    end
+  end
+
+  defp update_connect_customers(%{update_platform_customer: %StripePlatformCustomer{email: email} = stripe_platform_customer }) do
+    case do_update_connect_customers(stripe_platform_customer, %{email: email}) do
+      [_h | _t] = results -> {:ok, results}
+      [] -> {:ok, nil}
+    end
+  end
+
+  defp do_update_connect_customers(stripe_platform_customer, attributes) do
+    stripe_platform_customer
+    |> Repo.preload([stripe_connect_customers: :stripe_connect_account])
+    |> Map.get(:stripe_connect_customers)
+    |> Enum.map(&do_update_connect_customer(&1, attributes))
+  end
+
+  defp do_update_connect_customer(%StripeConnectCustomer{} = stripe_connect_customer, attributes) do
+    stripe_connect_customer
+    |> StripeConnectCustomerService.update(attributes)
   end
 end

--- a/lib/code_corps/stripe_testing/customer.ex
+++ b/lib/code_corps/stripe_testing/customer.ex
@@ -7,6 +7,10 @@ defmodule CodeCorps.StripeTesting.Customer do
     {:ok, do_update(id, map)}
   end
 
+  def retrieve(id) do
+    {:ok, do_retrieve(id) }
+  end
+
   defp do_create(_) do
     {:ok, created} = DateTime.from_unix(1479472835)
 
@@ -36,6 +40,23 @@ defmodule CodeCorps.StripeTesting.Customer do
       delinquent: false,
       description: nil,
       email: map.email,
+      livemode: false,
+      metadata: %{}
+    }
+  end
+
+  defp do_retrieve(id) do
+    {:ok, created} = DateTime.from_unix(1479472835)
+
+    %Stripe.Customer{
+      id: id,
+      account_balance: 0,
+      created: created,
+      currency: "usd",
+      default_source: nil,
+      delinquent: false,
+      description: nil,
+      email: "hardcoded@test.com",
       livemode: false,
       metadata: %{}
     }

--- a/test/controllers/stripe_platform_events_controller_test.exs
+++ b/test/controllers/stripe_platform_events_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule CodeCorps.StripePlatformEventsControllerTest do
   use CodeCorps.ConnCase
 
+  alias CodeCorps.StripePlatformCustomer
+
   setup do
     conn =
       %{build_conn | host: "api."}
@@ -31,6 +33,27 @@ defmodule CodeCorps.StripePlatformEventsControllerTest do
       event = event_for(%{}, "any.event")
       path = conn |> stripe_platform_events_path(:create)
       assert conn |> post(path, event) |> response(200)
+    end
+  end
+
+  describe "customer.updated" do
+    @customer %{
+      "id" => "cus_1234567"
+    }
+
+    test "returns 200 and updates platform customer", %{conn: conn} do
+      stripe_id = @customer["id"]
+      platform_customer = insert(:stripe_platform_customer, id_from_stripe: stripe_id)
+
+      event = event_for(@customer, "customer.updated")
+
+      path = conn |> stripe_platform_events_path(:create)
+      assert conn |> post(path, event) |> response(200)
+
+      platform_customer = Repo.get(StripePlatformCustomer, platform_customer.id)
+
+      # hardcoded in StripeTesting.Customer
+      assert platform_customer.email == "hardcoded@test.com"
     end
   end
 end

--- a/test/lib/code_corps/stripe_service/stripe_platform_customer_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_platform_customer_service_test.exs
@@ -24,4 +24,42 @@ defmodule CodeCorps.StripeService.StripePlatformCustomerServiceTest do
       refute changeset.valid?
     end
   end
+
+  describe "update_from_stripe" do
+    test "performs update using information from Stripe API" do
+      customer = insert(:stripe_platform_customer)
+      {:ok, %StripePlatformCustomer{} = updated_customer, nil} =
+        StripePlatformCustomerService.update_from_stripe(customer.id_from_stripe)
+
+      # Hardcoded in StripeTesting.Customer
+      assert updated_customer.email == "hardcoded@test.com"
+      customer = Repo.get(StripePlatformCustomer, customer.id)
+      assert customer.email == "hardcoded@test.com"
+    end
+
+    test "also performs update of connect customers if any" do
+      platform_customer = insert(:stripe_platform_customer)
+
+      [connect_customer_1, connect_customer_2] =
+        insert_pair(:stripe_connect_customer, stripe_platform_customer: platform_customer)
+
+      {:ok, %StripePlatformCustomer{} = updated_customer, connect_updates} =
+        StripePlatformCustomerService.update_from_stripe(platform_customer.id_from_stripe)
+
+      # Hardcoded in StripeTesting.Customer
+      assert updated_customer.email == "hardcoded@test.com"
+      platform_customer = Repo.get(StripePlatformCustomer, platform_customer.id)
+      assert platform_customer.email == "hardcoded@test.com"
+
+      [
+        {:ok, %Stripe.Customer{} = stripe_record_1},
+        {:ok, %Stripe.Customer{} = stripe_record_2}
+      ] = connect_updates
+
+      assert stripe_record_1.id == connect_customer_1.id_from_stripe
+      assert stripe_record_1.email == "hardcoded@test.com"
+      assert stripe_record_2.id == connect_customer_2.id_from_stripe
+      assert stripe_record_2.email == "hardcoded@test.com"
+    end
+  end
 end


### PR DESCRIPTION
# What's in this PR?

Theres a decent amount of code duplication from `UserService` here. I could use some advice on how to dry it up. Other than that, should be good to review.

As with user update propagation, the email is the only thing that changes here for now, I think.

## References
Fixes #476