### PR TITLE
Limit to 22 chars in statement descriptor

### DIFF
--- a/lib/code_corps/stripe_service/stripe_connect_plan.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_plan.ex
@@ -29,7 +29,7 @@ defmodule CodeCorps.StripeService.StripeConnectPlanService do
       id: "month",
       interval: "month",
       name: "Monthly donation",
-      statement_descriptor: "CODECORPS.ORG Monthly Donation"
+      statement_descriptor: "CODECORPS.ORG Donation" # No more than 22 chars
     }
   end
 


### PR DESCRIPTION
# What's in this PR?

Limits to fix error with statement descriptor.