### PR TITLE
Fix issues with charges enabled and change redirect URI on prod

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -44,7 +44,7 @@ config :code_corps, :analytics, CodeCorps.Analytics.SegmentAPI
 # Configures stripe for production
 config :code_corps, :stripe, Stripe
 config :code_corps, :stripe_env, :prod
-config :code_corps, :stripe_redirect_uri, "http://www.codecorps.org/oauth/stripe"
+config :code_corps, :stripe_redirect_uri, "https://www.codecorps.org/oauth/stripe"
 
 config :sentry,
   environment_name: Mix.env || :prod

--- a/lib/code_corps/stripe_service/validators/project_can_enable_donations.ex
+++ b/lib/code_corps/stripe_service/validators/project_can_enable_donations.ex
@@ -14,7 +14,11 @@ defmodule CodeCorps.StripeService.Validators.ProjectCanEnableDonations do
   These are:
 
   * At least one `CodeCorps.DonationGoal`
-  * `Organization` with a `StripeConnectAccount`, which has `charges_enabled: true`
+
+  and only one of:
+
+  - `Organization` with a `StripeConnectAccount`, in production env, which has `charges_enabled: true`
+  - `Organization` with a `StripeConnectAccount`, not in production env
 
   If the project has these relationships set up, it returns `{:ok, project}`
 
@@ -28,5 +32,16 @@ defmodule CodeCorps.StripeService.Validators.ProjectCanEnableDonations do
     donation_goals: [_h | _t],
     organization: %Organization{stripe_connect_account: %StripeConnectAccount{charges_enabled: true}}
   } = project), do: {:ok, project}
+
+  defp do_validate(%Project{
+    donation_goals: [_h | _t],
+    organization: %Organization{stripe_connect_account: %StripeConnectAccount{}}
+  } = project) do
+    case Application.get_env(:code_corps, :stripe_env) do
+      :prod -> @invalid
+      _ -> {:ok, project}
+    end
+  end
+
   defp do_validate(_), do: @invalid
 end

--- a/test/views/stripe_connect_account_view_test.exs
+++ b/test/views/stripe_connect_account_view_test.exs
@@ -1,0 +1,84 @@
+defmodule CodeCorps.StripeConnectAccountViewTest do
+  use CodeCorps.ConnCase, async: true
+
+  import Phoenix.View, only: [render: 3]
+
+  test "renders all attributes and relationships properly" do
+    organization = insert(:organization)
+    account = insert(:stripe_connect_account, organization: organization)
+
+    rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+
+    expected_json = %{
+      "data" => %{
+        "attributes" => %{
+          "access-code" => account.access_code,
+          "business-name" => account.business_name,
+          "business-url" => account.business_url,
+          "can-accept-donations" => true,
+          "charges-enabled" => account.charges_enabled,
+          "country" => account.country,
+          "default-currency" => account.default_currency,
+          "details-submitted" => account.details_submitted,
+          "display-name" => account.display_name,
+          "email" => account.email,
+          "id-from-stripe" => account.id_from_stripe,
+          "inserted-at" => account.inserted_at,
+          "managed" => account.managed,
+          "support-email" => account.support_email,
+          "support-phone" => account.support_phone,
+          "support-url" => account.support_url,
+          "transfers-enabled" => account.transfers_enabled,
+          "updated-at" => account.updated_at
+        },
+        "id" => account.id |> Integer.to_string,
+        "relationships" => %{
+          "organization" => %{
+            "data" => %{"id" => organization.id |> Integer.to_string, "type" => "organization"}
+          }
+        },
+        "type" => "stripe-connect-account",
+      },
+      "jsonapi" => %{
+        "version" => "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+
+  test "renders can-accept-donations as true in prod when charges-enabled is true" do
+    Application.put_env(:code_corps, :stripe_env, :prod)
+
+    organization = insert(:organization)
+    account = insert(:stripe_connect_account, organization: organization, charges_enabled: true)
+
+    rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+    assert rendered_json["data"]["attributes"]["can-accept-donations"] == true
+    assert rendered_json["data"]["attributes"]["charges-enabled"] == true
+
+    Application.put_env(:code_corps, :stripe_env, :test)
+  end
+
+  test "renders can-accept-donations as false in prod when charges-enabled is false" do
+    Application.put_env(:code_corps, :stripe_env, :prod)
+
+    organization = insert(:organization)
+    account = insert(:stripe_connect_account, organization: organization, charges_enabled: false)
+
+    rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+    assert rendered_json["data"]["attributes"]["can-accept-donations"] == false
+    assert rendered_json["data"]["attributes"]["charges-enabled"] == false
+
+    Application.put_env(:code_corps, :stripe_env, :test)
+  end
+
+  test "renders can-accept-donations as true in test when charges-enabled is false" do
+    organization = insert(:organization)
+    account = insert(:stripe_connect_account, organization: organization, charges_enabled: false)
+
+    rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+    assert rendered_json["data"]["attributes"]["can-accept-donations"] == true
+    assert rendered_json["data"]["attributes"]["charges-enabled"] == false
+  end
+end

--- a/web/views/stripe_connect_account_view.ex
+++ b/web/views/stripe_connect_account_view.ex
@@ -4,11 +4,19 @@ defmodule CodeCorps.StripeConnectAccountView do
   use JaSerializer.PhoenixView
 
   attributes [
-    :access_code, :business_name, :business_url, :charges_enabled, :country,
-    :default_currency, :details_submitted, :display_name, :email,
-    :id_from_stripe, :managed, :support_email, :support_phone, :support_url,
-    :transfers_enabled
+    :access_code, :business_name, :business_url, :can_accept_donations,
+    :charges_enabled, :country, :default_currency, :details_submitted,
+    :display_name, :email, :id_from_stripe, :inserted_at, :managed,
+    :support_email, :support_phone, :support_url, :transfers_enabled,
+    :updated_at
   ]
 
   has_one :organization, serializer: CodeCorps.OrganizationView
+
+  def can_accept_donations(stripe_connect_account, _conn) do
+    case Application.get_env(:code_corps, :stripe_env) do
+      :prod -> stripe_connect_account.charges_enabled
+      _ -> true
+    end
+  end
 end


### PR DESCRIPTION
# What's in this PR?

- Changes redirect URL for Stripe OAuth on prod
- Adds in `canAcceptDonations` to `StripeConnectAccount`'s view and add's a view test
- Changes acceptance behavior for creating donations to `charges_enabled` being `true` _or_ this being a non-production Stripe account (where `charges_enabled` can _never_ be `true` on Stripe's API, since this means for a _live_ account)