### PR TITLE
Add tracking tests

### DIFF
--- a/test/controllers/organization_membership_controller_test.exs
+++ b/test/controllers/organization_membership_controller_test.exs
@@ -45,7 +45,16 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
     test "creates and renders resource when data is valid", %{conn: conn, current_user: member} do
       organization = insert(:organization)
       attrs = @valid_attrs |> Map.merge(%{organization: organization, member: member})
+
       assert conn |> request_create(attrs) |> json_response(201)
+
+      user_id = member.id
+      tracking_properties = %{
+        organization: organization.name,
+        organization_id: organization.id
+      }
+
+      assert_received {:track, ^user_id, "Requested Organization Membership", ^tracking_properties}
     end
 
     @tag :authenticated
@@ -75,6 +84,14 @@ defmodule CodeCorps.OrganizationMembershipControllerTest do
       insert(:organization_membership, organization: organization, member: current_user, role: "owner")
 
       assert conn |> request_update(membership, @valid_attrs) |> json_response(200)
+
+      user_id = current_user.id
+      tracking_properties = %{
+        organization: organization.name,
+        organization_id: organization.id
+      }
+
+      assert_received {:track, ^user_id, "Approved Organization Membership", ^tracking_properties}
     end
 
     test "doesn't update and renders 401 when unauthenticated", %{conn: conn} do

--- a/test/controllers/stripe_connect_account_controller_test.exs
+++ b/test/controllers/stripe_connect_account_controller_test.exs
@@ -37,6 +37,9 @@ defmodule CodeCorps.StripeConnectAccountControllerTest do
         organization: organization
       }
       assert conn |> request_create(attrs) |> json_response(201)
+
+      user_id = current_user.id
+      assert_received {:track, ^user_id, "Created Stripe Connect Account", %{}}
     end
 
     test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do

--- a/test/controllers/stripe_connect_plan_controller_test.exs
+++ b/test/controllers/stripe_connect_plan_controller_test.exs
@@ -44,6 +44,9 @@ defmodule CodeCorps.StripeConnectPlanControllerTest do
       insert(:donation_goal, project: project)
 
       assert conn |> request_create(%{project: project}) |> json_response(201)
+
+      user_id = current_user.id
+      assert_received {:track, ^user_id, "Created Stripe Connect Plan", %{}}
     end
 
     test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do

--- a/test/controllers/stripe_platform_card_controller_test.exs
+++ b/test/controllers/stripe_platform_card_controller_test.exs
@@ -56,7 +56,11 @@ defmodule CodeCorps.StripePlatformCardControllerTest do
     test "creates and renders resource when data is valid", %{conn: conn, current_user: current_user} do
       insert(:stripe_platform_customer, user: current_user)
       valid_attrs = %{stripe_token: "tok_test123456", user: current_user}
+
       assert conn |> make_create_request(valid_attrs) |> json_response(201)
+
+      user_id = current_user.id
+      assert_received {:track, ^user_id, "Created Stripe Platform Card", %{}}
     end
 
     test "renders 401 when unauthenticated", %{conn: conn} do

--- a/test/controllers/stripe_platform_customer_controller_test.exs
+++ b/test/controllers/stripe_platform_customer_controller_test.exs
@@ -34,6 +34,9 @@ defmodule CodeCorps.StripePlatformCustomerControllerTest do
     @tag :authenticated
     test "creates and renders resource user is authenticated and authorized", %{conn: conn, current_user: current_user} do
       assert conn |> request_create(%{user: current_user}) |> json_response(201)
+
+      user_id = current_user.id
+      assert_received {:track, ^user_id, "Created Stripe Platform Customer", %{}}
     end
 
     test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do

--- a/test/controllers/task_controller_test.exs
+++ b/test/controllers/task_controller_test.exs
@@ -145,6 +145,16 @@ defmodule CodeCorps.TaskControllerTest do
       # ensure record is reloaded from database before serialized, since number is added
       # on database level upon insert
       assert json["data"]["attributes"]["number"] == 1
+
+      user_id = current_user.id
+      tracking_properties = %{
+        task: @valid_attrs.title,
+        task_id: String.to_integer(json["data"]["id"]),
+        task_type: @valid_attrs.task_type,
+        project_id: project.id
+      }
+
+      assert_received {:track, ^user_id, "Created Task", ^tracking_properties}
     end
 
     @tag :authenticated
@@ -164,6 +174,16 @@ defmodule CodeCorps.TaskControllerTest do
     test "updates and renders chosen resource when data is valid", %{conn: conn, current_user: current_user} do
       task = insert(:task, user: current_user)
       assert conn |> request_update(task, @valid_attrs) |> json_response(200)
+
+      user_id = current_user.id
+      tracking_properties = %{
+        task: task.title,
+        task_id: task.id,
+        task_type: task.task_type,
+        project_id: task.project.id
+      }
+
+      assert_received {:track, ^user_id, "Edited Task", ^tracking_properties}
     end
 
     @tag :authenticated

--- a/test/controllers/token_controller_test.exs
+++ b/test/controllers/token_controller_test.exs
@@ -22,9 +22,12 @@ defmodule CodeCorps.TokenControllerTest do
       user = build(:user, %{password: "password"}) |> set_password("password") |> insert
       conn = post conn, token_path(conn, :create), create_payload(user.email, user.password)
 
+      user_id = user.id
       response = json_response(conn, 201)
       assert response["token"]
-      assert response["user_id"] == user.id
+      assert response["user_id"] == user_id
+
+      assert_received {:track, ^user_id, "Signed In", %{}}
     end
 
     test "does not authenticate and renders errors when the password is wrong", %{conn: conn} do


### PR DESCRIPTION
# What's in this PR?

Adds coverage for analytics tracking in controllers

## References

Fixes #463 

## Checklist

- [x] `web/controllers/comment_controller.ex`
- [x] `web/controllers/organization_membership_controller.ex`
- [x] `web/controllers/stripe_connect_account_controller.ex`
- [x] `web/controllers/stripe_connect_plan_controller.ex`
- [x] `web/controllers/stripe_platform_customer_controller.ex`
- [x] `web/controllers/stripe_platform_card_controller.ex`
- [x] `web/controllers/token_controller.ex`
- [x] `web/controllers/task_controller.ex`
- [x] `web/controllers/user_category_controller.ex`
- [x] `web/controllers/user_role_controller.ex`
- [x] `web/controllers/user_skill_controller.ex`

- ~~`web/controllers/stripe_connect_subscription_controller.ex`~~ To be handled separately, see comments
- ~~`web/controllers/user_controller.ex`~~ Already tested
