### PR TITLE
Add webhook for account external account created

### DIFF
--- a/lib/code_corps/stripe_service/adapters/stripe_external_account.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_external_account.ex
@@ -1,0 +1,20 @@
+defmodule CodeCorps.StripeService.Adapters.StripeExternalAccountAdapter do
+  import CodeCorps.MapUtils, only: [rename: 3]
+
+  @stripe_attributes [
+    :account, :account_holder_name, :account_holder_type, :bank_name, :country,
+    :currency, :default_for_currency, :fingerprint, :id, :last4,
+    :routing_number, :status
+  ]
+
+  def to_params(%Stripe.BankAccount{} = bank_account) do
+    params =
+      bank_account
+      |> Map.from_struct
+      |> Map.take(@stripe_attributes)
+      |> rename(:id, :id_from_stripe)
+      |> rename(:account, :account_id_from_stripe)
+
+    {:ok, params}
+  end
+end

--- a/lib/code_corps/stripe_service/events/external_account_created.ex
+++ b/lib/code_corps/stripe_service/events/external_account_created.ex
@@ -1,0 +1,5 @@
+defmodule CodeCorps.StripeService.Events.ExternalAccountCreated do
+  def handle(%{"data" => %{"object" => %{"id" => id_from_stripe}}}) do
+    CodeCorps.StripeService.StripeExternalAccountService.create(id_from_stripe)
+  end
+end

--- a/lib/code_corps/stripe_service/stripe_external_account_service.ex
+++ b/lib/code_corps/stripe_service/stripe_external_account_service.ex
@@ -1,0 +1,16 @@
+defmodule CodeCorps.StripeService.StripeExternalAccountService do
+  alias CodeCorps.{Repo, StripeExternalAccount}
+  alias CodeCorps.StripeService.Adapters.StripeExternalAccountAdapter
+
+  @api Application.get_env(:code_corps, :stripe)
+
+  def create(id_from_stripe) do
+    with {:ok, %Stripe.BankAccount{} = bank_account} <- @api.BankAccount.retrieve(id_from_stripe),
+         {:ok, params} <- StripeExternalAccountAdapter.to_params(bank_account)
+    do
+      %StripeExternalAccount{}
+      |> StripeExternalAccount.changeset(params)
+      |> Repo.insert
+    end
+  end
+end

--- a/lib/code_corps/stripe_service/webhook_processing/connect_event_handler.ex
+++ b/lib/code_corps/stripe_service/webhook_processing/connect_event_handler.ex
@@ -16,6 +16,7 @@ defmodule CodeCorps.StripeService.WebhookProcessing.ConnectEventHandler do
   def handle_event(%{"type" => type} = attributes), do: do_handle(type, attributes)
 
   defp do_handle("account.updated", attributes), do: Events.AccountUpdated.handle(attributes)
+  defp do_handle("account.external_account.created", attributes), do: Events.ExternalAccountCreated.handle(attributes)
   defp do_handle("customer.subscription.deleted", attributes), do: Events.CustomerSubscriptionDeleted.handle(attributes)
   defp do_handle("customer.subscription.updated", attributes), do: Events.CustomerSubscriptionUpdated.handle(attributes)
   defp do_handle(_, _), do: {:ok, :unhandled_event}

--- a/lib/code_corps/stripe_testing/bank_account.ex
+++ b/lib/code_corps/stripe_testing/bank_account.ex
@@ -1,0 +1,24 @@
+defmodule CodeCorps.StripeTesting.BankAccount do
+  def retrieve(id) do
+    {:ok, bank_account(id)}
+  end
+
+  defp bank_account(id) do
+    %Stripe.BankAccount{
+      id: id,
+      object: "bank_account",
+      account: "acct_1032D82eZvKYlo2C",
+      account_holder_name: "Jane Austen",
+      account_holder_type: "individual",
+      bank_name: "STRIPE TEST BANK",
+      country: "US",
+      currency: "usd",
+      default_for_currency: false,
+      fingerprint: "1JWtPxqbdX5Gamtc",
+      last4: "6789",
+      metadata: {},
+      routing_number: "110000000",
+      status: "new"
+    }
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -55,7 +55,7 @@
   "segment": {:git, "https://github.com/stueccles/analytics-elixir.git", "8fe520c16a8a9290d55c849bf4d67420396e1cdd", []},
   "sentry": {:hex, :sentry, "2.0.2", "f08638758f7bf891e238466009f6cd702fc26d87286663af26927a78ed149346", [:mix], [{:hackney, "~> 1.6.1", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: true]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}, {:uuid, "~> 1.0", [hex: :uuid, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:rebar, :make], []},
-  "stripity_stripe": {:git, "https://github.com/code-corps/stripity_stripe.git", "d26b09aff994a30a17bcd35eff6863cbaadf5ec8", [branch: "2.0"]},
+  "stripity_stripe": {:git, "https://github.com/code-corps/stripity_stripe.git", "df6c770882d74d76807e3aa91ba7ee2763a80e49", [branch: "2.0"]},
   "timber": {:hex, :timber, "0.4.7", "df3fcd79bcb4eb4b53874d906ef5f3a212937b4bc7b7c5b244745202cc389443", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: true]}, {:phoenix, "~> 1.2", [hex: :phoenix, optional: true]}, {:plug, "~> 1.2", [hex: :plug, optional: true]}, {:poison, "~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "timex": {:hex, :timex, "3.1.5", "413d6d8d6f0162a5d47080cb8ca520d790184ac43e097c95191c7563bf25b428", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
   "timex_ecto": {:hex, :timex_ecto, "3.0.5", "3ec6c25e10d2c0020958e5df64d2b5e690e441faa2c2259da8bc6bd3d7f39256", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: false]}, {:timex, "~> 3.0", [hex: :timex, optional: false]}]},

--- a/priv/repo/migrations/20161219160401_change_external_account_default_for_currency_to_boolean.exs
+++ b/priv/repo/migrations/20161219160401_change_external_account_default_for_currency_to_boolean.exs
@@ -1,0 +1,10 @@
+defmodule CodeCorps.Repo.Migrations.ChangeExternalAccountDefaultForCurrencyToBoolean do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stripe_external_accounts) do
+      remove :default_for_currency
+      add :default_for_currency, :boolean
+    end
+  end
+end

--- a/test/lib/code_corps/stripe_service/adapters/stripe_external_account_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_external_account_test.exs
@@ -1,0 +1,44 @@
+defmodule CodeCorps.StripeService.Adapters.StripeExternalAccountTestAdapter do
+  use ExUnit.Case, async: true
+
+  import CodeCorps.StripeService.Adapters.StripeExternalAccountAdapter, only: [to_params: 1]
+
+  @stripe_connect_account %Stripe.BankAccount{
+    id: "ba_19SSZG2eZvKYlo2CXnmzYU5H",
+    object: "bank_account",
+    account: "acct_1032D82eZvKYlo2C",
+    account_holder_name: "Jane Austen",
+    account_holder_type: "individual",
+    bank_name: "STRIPE TEST BANK",
+    country: "US",
+    currency: "usd",
+    default_for_currency: false,
+    fingerprint: "1JWtPxqbdX5Gamtc",
+    last4: "6789",
+    metadata: {},
+    routing_number: "110000000",
+    status: "new"
+  }
+
+  @local_map %{
+    id_from_stripe: "ba_19SSZG2eZvKYlo2CXnmzYU5H",
+    account_id_from_stripe: "acct_1032D82eZvKYlo2C",
+    account_holder_name: "Jane Austen",
+    account_holder_type: "individual",
+    bank_name: "STRIPE TEST BANK",
+    country: "US",
+    currency: "usd",
+    default_for_currency: false,
+    fingerprint: "1JWtPxqbdX5Gamtc",
+    last4: "6789",
+    routing_number: "110000000",
+    status: "new"
+  }
+
+  describe "to_params/2" do
+    test "converts from stripe map to local properly" do
+      {:ok, result} = to_params(@stripe_connect_account)
+      assert result == @local_map
+    end
+  end
+end

--- a/test/lib/code_corps/stripe_service/stripe_connect_account_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_connect_account_service_test.exs
@@ -3,7 +3,6 @@ defmodule CodeCorps.StripeService.StripeConnectAccountServiceTest do
 
   use CodeCorps.ModelCase
 
-  alias CodeCorps.StripeConnectAccount
   alias CodeCorps.StripeService.StripeConnectAccountService
 
   describe "create" do

--- a/test/lib/code_corps/stripe_service/stripe_external_account_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_external_account_service_test.exs
@@ -1,0 +1,18 @@
+defmodule CodeCorps.StripeService.StripeExternalAccountServiceTest do
+  use ExUnit.Case, async: true
+
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.StripeService.StripeExternalAccountService
+
+  describe "create" do
+    test "creates a StripeExternalAccount" do
+      id_from_stripe = "ba_testing123"
+
+      {:ok, %CodeCorps.StripeExternalAccount{} = bank_account} =
+        StripeExternalAccountService.create(id_from_stripe)
+
+      assert bank_account.id_from_stripe == id_from_stripe
+    end
+  end
+end

--- a/web/models/stripe_external_account.ex
+++ b/web/models/stripe_external_account.ex
@@ -9,7 +9,7 @@ defmodule CodeCorps.StripeExternalAccount do
     field :bank_name, :string
     field :country, :string
     field :currency, :string
-    field :default_for_currency, :string
+    field :default_for_currency, :boolean
     field :fingerprint, :string
     field :last4, :string
     field :routing_number, :string
@@ -18,12 +18,19 @@ defmodule CodeCorps.StripeExternalAccount do
     timestamps()
   end
 
+  @create_params [
+    :id_from_stripe, :account_id_from_stripe, :account_holder_name, :account_holder_type, :bank_name,
+    :country, :currency, :default_for_currency, :fingerprint, :last4, :routing_number, :status
+  ]
+
+  @required_create_params [:id_from_stripe, :account_id_from_stripe]
+
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:id_from_stripe, :account_id_from_stripe, :account_holder_name, :account_holder_type, :bank_name, :country, :currency, :default_for_currency, :fingerprint, :last4, :routing_number, :status])
-    |> validate_required([:id_from_stripe, :account_id_from_stripe])
+    |> cast(params, @create_params)
+    |> validate_required(@required_create_params)
   end
 end


### PR DESCRIPTION
# What's in this PR?

Handling for the "account.external_account.created" webhook event.

Closes #573 