### PR TITLE
Add verification to StripeConnectAccount

### DIFF
--- a/priv/repo/migrations/20161218005913_add_verification_fields_to_stripe_connect_account.exs
+++ b/priv/repo/migrations/20161218005913_add_verification_fields_to_stripe_connect_account.exs
@@ -1,0 +1,11 @@
+defmodule CodeCorps.Repo.Migrations.AddVerificationFieldsToStripeConnectAccount do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stripe_connect_accounts) do
+      add :verification_disabled_reason, :string
+      add :verification_due_by, :datetime
+      add :verification_fields_needed, {:array, :string}
+    end
+  end
+end

--- a/test/models/stripe_connect_account_test.exs
+++ b/test/models/stripe_connect_account_test.exs
@@ -29,13 +29,28 @@ defmodule CodeCorps.StripeConnectAccountTest do
     test "ensures associations link to records that exist" do
       attrs =  @valid_attrs |> Map.merge(%{organization_id: -1})
 
-      { result, changeset } =
+      { :error, changeset } =
         StripeConnectAccount.create_changeset(%StripeConnectAccount{}, attrs)
         |> Repo.insert
 
-      assert result == :error
       refute changeset.valid?
       assert changeset.errors[:organization] == {"does not exist", []}
+    end
+
+    test "accepts list of values as verification_fields_needed" do
+      organization_id = insert(:organization).id
+      list = ["legal_entity.first_name", "legal_entity.last_name"]
+      map = %{
+        organization_id: organization_id,
+        verification_fields_needed: list
+      }
+      attrs =  @valid_attrs |> Map.merge(map)
+
+      { :ok, record } =
+        StripeConnectAccount.create_changeset(%StripeConnectAccount{}, attrs)
+        |> Repo.insert
+
+      assert record.verification_fields_needed == list
     end
   end
 end

--- a/test/views/stripe_connect_account_view_test.exs
+++ b/test/views/stripe_connect_account_view_test.exs
@@ -5,7 +5,11 @@ defmodule CodeCorps.StripeConnectAccountViewTest do
 
   test "renders all attributes and relationships properly" do
     organization = insert(:organization)
-    account = insert(:stripe_connect_account, organization: organization)
+    account = insert(:stripe_connect_account,
+      organization: organization,
+      verification_disabled_reason: "fields_needed",
+      verification_fields_needed: ["legal_entity.first_name", "legal_entity.last_name"]
+    )
 
     rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
 
@@ -29,7 +33,10 @@ defmodule CodeCorps.StripeConnectAccountViewTest do
           "support-phone" => account.support_phone,
           "support-url" => account.support_url,
           "transfers-enabled" => account.transfers_enabled,
-          "updated-at" => account.updated_at
+          "updated-at" => account.updated_at,
+          "verification-disabled-reason" => account.verification_disabled_reason,
+          "verification-due-by" => account.verification_due_by,
+          "verification-fields-needed" => account.verification_fields_needed
         },
         "id" => account.id |> Integer.to_string,
         "relationships" => %{

--- a/web/models/stripe_connect_account.ex
+++ b/web/models/stripe_connect_account.ex
@@ -20,6 +20,9 @@ defmodule CodeCorps.StripeConnectAccount do
     field :support_phone, :string
     field :support_url, :string
     field :transfers_enabled, :boolean
+    field :verification_disabled_reason, :string
+    field :verification_due_by, Ecto.DateTime
+    field :verification_fields_needed, {:array, :string}
 
     field :access_code, :string, virtual: true
 
@@ -31,7 +34,9 @@ defmodule CodeCorps.StripeConnectAccount do
   @insert_params [
     :business_name, :business_url, :charges_enabled, :country, :default_currency,
     :details_submitted, :email, :id_from_stripe, :managed, :organization_id,
-    :support_email, :support_phone, :support_url, :transfers_enabled
+    :support_email, :support_phone, :support_url, :transfers_enabled,
+    :verification_disabled_reason, :verification_due_by,
+    :verification_fields_needed
   ]
 
   def create_changeset(struct, params \\ %{}) do
@@ -44,7 +49,9 @@ defmodule CodeCorps.StripeConnectAccount do
   @webhook_update_params [
     :business_name, :business_url, :charges_enabled, :country,
     :default_currency, :details_submitted, :email, :managed, :support_email,
-    :support_phone, :support_url, :transfers_enabled
+    :support_phone, :support_url, :transfers_enabled,
+    :verification_disabled_reason, :verification_due_by,
+    :verification_fields_needed
   ]
 
   def webhook_update_changeset(struct, params \\ %{}) do

--- a/web/views/stripe_connect_account_view.ex
+++ b/web/views/stripe_connect_account_view.ex
@@ -8,7 +8,8 @@ defmodule CodeCorps.StripeConnectAccountView do
     :charges_enabled, :country, :default_currency, :details_submitted,
     :display_name, :email, :id_from_stripe, :inserted_at, :managed,
     :support_email, :support_phone, :support_url, :transfers_enabled,
-    :updated_at
+    :updated_at, :verification_disabled_reason, :verification_due_by,
+    :verification_fields_needed
   ]
 
   has_one :organization, serializer: CodeCorps.OrganizationView


### PR DESCRIPTION
# What's in this PR?

This adds some verification fields for translating Stripe's information (https://stripe.com/docs/api/curl#account_object-verification) into our own storage.

This does not attempt to do an adapter layer for reading from Stripe. (We will _not_ have to write these fields to Stripe as they are read-only)

## References
Fixes #568 