### PR TITLE
Add StripeConnectAccount update endpoint for assigning an external account

### DIFF
--- a/lib/code_corps/stripe_service/adapters/stripe_connect_account.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_connect_account.ex
@@ -66,6 +66,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter do
       stripe_account
       |> Map.from_struct
       |> transform_map(@stripe_mapping)
+      |> add_nested_attributes(stripe_account)
       |> keys_to_string
       |> add_non_stripe_attributes(attributes)
 
@@ -91,4 +92,13 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter do
     params
     |> Map.merge(attributes)
   end
+
+  defp add_nested_attributes(map, stripe_account) do
+    map
+    |> add_external_account(stripe_account)
+  end
+
+  defp add_external_account(map, %Stripe.Account{external_accounts: %{data: []}}), do: map
+  defp add_external_account(map, %Stripe.Account{external_accounts: %{data: [head | _]}}), do: map |> do_add_external_account(head)
+  defp do_add_external_account(map, %{"id" => id}), do: map |> Map.put(:external_account, id)
 end

--- a/lib/code_corps/stripe_testing/account.ex
+++ b/lib/code_corps/stripe_testing/account.ex
@@ -1,32 +1,83 @@
 defmodule CodeCorps.StripeTesting.Account do
   def create(_map) do
-    {:ok, do_create}
+    {:ok, create_stripe_record(%{})}
   end
 
-  def retrieve(_id) do
-    {:ok, do_create}
+  def retrieve(id) do
+    {:ok, create_stripe_record(%{"id" => id})}
   end
 
-  defp do_create do
-    %Stripe.Account{
-      business_name: "Code Corps PBC",
-      business_primary_color: nil,
-      business_url: "codecorps.org",
-      charges_enabled: true,
-      country: "US",
-      default_currency: "usd",
-      details_submitted: true,
-      display_name: "Code Corps Customer",
-      email: "volunteers@codecorps.org",
-      id: "acct_123",
-      managed: true,
-      metadata: %{},
-      statement_descriptor: "CODECORPS.ORG",
-      support_email: nil,
-      support_phone: "1234567890",
-      support_url: nil,
-      timezone: "America/Los_Angeles",
-      transfers_enabled: true
+  def update(id, attributes) do
+    attributes =
+      attributes
+      |> CodeCorps.MapUtils.keys_to_string
+      |> Map.merge(%{"id" => id})
+
+    {:ok, create_stripe_record(attributes)}
+  end
+
+  defp create_stripe_record(attributes) do
+    with attributes <- account_fixture |> Map.merge(attributes) |> add_nestings
+    do
+      Stripe.Account |> Stripe.Converter.stripe_map_to_struct(attributes)
+    end
+  end
+
+  defp account_fixture do
+    %{
+      "business_name" => "Code Corps PBC",
+      "business_primary_color" => nil,
+      "business_url" => "codecorps.org",
+      "charges_enabled" => true,
+      "country" => "US",
+      "default_currency" => "usd",
+      "details_submitted" => true,
+      "display_name" => "Code Corps Customer",
+      "email" => "volunteers@codecorps.org",
+      "external_accounts" => %{
+        "object" => "list",
+        "data" => [],
+        "has_more" => false,
+        "total_count" => 0,
+        "url" => "/v1/accounts/acct_123/external_accounts"
+      },
+      "id" => "acct_123",
+      "managed" => true,
+      "metadata" => %{},
+      "statement_descriptor" => "CODECORPS.ORG",
+      "support_email" => nil,
+      "support_phone" => "1234567890",
+      "support_url" => nil,
+      "timezone" => "America/Los_Angeles",
+      "transfers_enabled" => true
     }
+  end
+
+  defp add_nestings(map) do
+    map
+    |> add_external_account
+  end
+
+  defp add_external_account(%{"id" => account_id, "external_account" => external_account_id} = map) do
+    external_accounts_map = %{
+      "object" => "list",
+      "data" => [%{"id" => external_account_id}],
+      "has_more" => false,
+      "total_count" => 1,
+      "url" => "/v1/accounts/#{account_id}/external_accounts"
+    }
+
+    Map.put(map, "external_accounts", external_accounts_map)
+  end
+  defp add_external_account(%{"id" => account_id} = map) do
+    external_accounts_map = %{
+      "object" => "list",
+      "data" => [],
+      "has_more" => false,
+      "total_count" => 1,
+      "url" => "/v1/accounts/#{account_id}/external_accounts"
+    }
+
+    Map.put(map, "external_accounts", external_accounts_map)
   end
 end

--- a/priv/repo/migrations/20161219163909_add_external_account_to_stripe_connect_accounts.exs
+++ b/priv/repo/migrations/20161219163909_add_external_account_to_stripe_connect_accounts.exs
@@ -1,0 +1,9 @@
+defmodule CodeCorps.Repo.Migrations.AddExternalAccountToStripeConnectAccounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stripe_connect_accounts) do
+      add :external_account, :string
+    end
+  end
+end

--- a/test/lib/code_corps/stripe_service/adapters/stripe_connect_account_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_connect_account_test.exs
@@ -15,7 +15,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountTestAdapter do
     email: "volunteers@codecorps.org",
     external_accounts: %{
       object: "list",
-      data: [],
+      data: [%{"id" => "ba_123"}],
       has_more: false,
       total_count: 0,
       url: "/v1/accounts/acct_123/external_accounts"
@@ -56,6 +56,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountTestAdapter do
         status: "unverified"
       }
     },
+    id: "acct_123",
     managed: false,
     statement_descriptor: nil,
     support_email: nil,
@@ -86,6 +87,8 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountTestAdapter do
     "details_submitted" => false,
     "display_name" => "Code Corps",
     "email" => "volunteers@codecorps.org",
+
+    "external_account" => "ba_123",
 
     "legal_entity_address_city" => nil,
     "legal_entity_address_country" => "US",

--- a/test/lib/code_corps/stripe_service/stripe_connect_account_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_connect_account_service_test.exs
@@ -3,6 +3,7 @@ defmodule CodeCorps.StripeService.StripeConnectAccountServiceTest do
 
   use CodeCorps.ModelCase
 
+  alias CodeCorps.{StripeConnectAccount}
   alias CodeCorps.StripeService.StripeConnectAccountService
 
   describe "create" do
@@ -11,12 +12,22 @@ defmodule CodeCorps.StripeService.StripeConnectAccountServiceTest do
 
       attributes = %{"country" => "US", "organization_id" => organization.id}
 
-      {:ok, %CodeCorps.StripeConnectAccount{} = connect_account} =
-              StripeConnectAccountService.create(attributes)
+      {:ok, %StripeConnectAccount{} = connect_account} =
+        StripeConnectAccountService.create(attributes)
 
       assert connect_account.country == "US"
       assert connect_account.organization_id == organization.id
       assert connect_account.managed == true
+    end
+  end
+
+  describe "add_external_account/2" do
+    test "assigns the external_account property to the record" do
+      account = insert(:stripe_connect_account)
+
+      {:ok, %StripeConnectAccount{} = updated_account} =
+        StripeConnectAccountService.add_external_account(account, "ba_test123")
+      assert updated_account.external_account == "ba_test123"
     end
   end
 end

--- a/test/support/api_case.ex
+++ b/test/support/api_case.ex
@@ -119,6 +119,15 @@ defmodule CodeCorps.ApiCase do
         conn |> put(path, payload)
       end
 
+      # A temporary request_update that skips building a payload
+      # using our faulty json_payload strategy
+      # Only works with attributes, not relationships
+      def request_update(conn, resource_or_id, attrs, :skip_strategy) do
+        payload = %{data: %{attributes: attrs}, type: "#{factory_name}"}
+        path = conn |> path_for(:update, resource_or_id)
+        conn |> put(path, payload)
+      end
+
       def request_delete(conn), do: request_delete(conn, default_record)
       def request_delete(conn, :not_found), do: request_delete(conn, -1)
       def request_delete(conn, resource_or_id) do

--- a/web/models/stripe_connect_account.ex
+++ b/web/models/stripe_connect_account.ex
@@ -15,6 +15,8 @@ defmodule CodeCorps.StripeConnectAccount do
     field :display_name, :string
     field :email, :string
 
+    field :external_account, :string
+
     field :legal_entity_address_city, :string
     field :legal_entity_address_country, :string
     field :legal_entity_address_line1, :string
@@ -114,5 +116,18 @@ defmodule CodeCorps.StripeConnectAccount do
   def webhook_update_changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @webhook_update_params)
+  end
+
+  @update_params [
+    :business_name, :business_url, :charges_enabled, :country, :default_currency,
+    :details_submitted, :email, :external_account, :id_from_stripe,
+    :support_email, :support_phone, :support_url, :transfers_enabled,
+    :verification_disabled_reason, :verification_due_by,
+    :verification_fields_needed
+  ]
+
+  def stripe_update_changeset(struct, params) do
+    struct
+    |> cast(params, @update_params)
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -68,7 +68,7 @@ defmodule CodeCorps.Router do
     resources "/roles", RoleController, only: [:create]
     resources "/role-skills", RoleSkillController, only: [:create, :delete]
     resources "/skills", SkillController, only: [:create]
-    resources "/stripe-connect-accounts", StripeConnectAccountController, only: [:show, :create]
+    resources "/stripe-connect-accounts", StripeConnectAccountController, only: [:show, :create, :update]
     resources "/stripe-connect-plans", StripeConnectPlanController, only: [:show, :create]
     resources "/stripe-connect-subscriptions", StripeConnectSubscriptionController, only: [:show, :create]
     resources "/stripe-platform-cards", StripePlatformCardController, only: [:show, :create]


### PR DESCRIPTION
# What's in this PR?

Adds an update endpoint for StripeConnectAccount, which only allows assigning an external account. Everything else is reported as an unauthorized request.

## References
Fixes #572