### PR TITLE
Add status fields to stripe connect account

### DIFF
--- a/lib/code_corps/stripe_service/adapters/stripe_connect_account.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_connect_account.ex
@@ -21,6 +21,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter do
     {:details_submitted, [:details_submitted]},
     {:display_name, [:display_name]},
     {:email, [:email]},
+    {:external_account, [:external_account]},
     {:legal_entity_address_city, [:legal_entity, :address, :city]},
     {:legal_entity_address_country, [:legal_entity, :address, :country]},
     {:legal_entity_address_line1, [:legal_entity, :address, :line1]},
@@ -34,8 +35,8 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter do
     {:legal_entity_dob_month, [:legal_entity, :dob, :month]},
     {:legal_entity_dob_year, [:legal_entity, :dob, :year]},
     {:legal_entity_first_name, [:legal_entity, :first_name]},
-    {:legal_entity_last_name, [:legal_entity, :last_name]},
     {:legal_entity_gender, [:legal_entity, :gender]},
+    {:legal_entity_last_name, [:legal_entity, :last_name]},
     {:legal_entity_maiden_name, [:legal_entity, :maiden_name]},
     {:legal_entity_personal_address_city, [:legal_entity, :personal_address, :city]},
     {:legal_entity_personal_address_country, [:legal_entity, :personal_address, :country]},
@@ -47,6 +48,10 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter do
     {:legal_entity_personal_id_number_provided, [:legal_entity, :personal_id_number_provided]},
     {:legal_entity_ssn_last_4_provided, [:legal_entity, :ssn_last_4_provided]},
     {:legal_entity_type, [:legal_entity, :type]},
+    {:legal_entity_verification_details, [:legal_entity, :verification, :details]},
+    {:legal_entity_verification_details_code, [:legal_entity, :verification, :details_code]},
+    {:legal_entity_verification_document, [:legal_entity, :verification, :document]},
+    {:legal_entity_verification_status, [:legal_entity, :verification, :status]},
     {:managed, [:managed]},
     {:support_email, [:support_email]},
     {:support_phone, [:support_phone]},
@@ -94,9 +99,9 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter do
   end
 
   defp add_nested_attributes(map, stripe_account) do
-    map
-    |> add_external_account(stripe_account)
-  end
+  map
+  |> add_external_account(stripe_account)
+end
 
   defp add_external_account(map, %Stripe.Account{external_accounts: %{data: []}}), do: map
   defp add_external_account(map, %Stripe.Account{external_accounts: %{data: [head | _]}}), do: map |> do_add_external_account(head)

--- a/lib/code_corps/stripe_service/stripe_connect_account.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_account.ex
@@ -19,7 +19,7 @@ defmodule CodeCorps.StripeService.StripeConnectAccountService do
          {:ok, params} <- StripeConnectAccountAdapter.to_params(stripe_account, %{})
     do
       record
-      |> StripeConnectAccount.stripe_update_changeset(params)
+      |> StripeConnectAccount.webhook_update_changeset(params)
       |> Repo.update
     end
   end

--- a/priv/repo/migrations/20161220141753_add_status_fields_to_stripe_connect_accounts.exs
+++ b/priv/repo/migrations/20161220141753_add_status_fields_to_stripe_connect_accounts.exs
@@ -1,0 +1,12 @@
+defmodule CodeCorps.Repo.Migrations.AddStatusFieldsToStripeConnectAccounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stripe_connect_accounts) do
+      add :recipient_status, :string
+      add :verification_document_status, :string
+      add :personal_id_number_status, :string
+      add :bank_account_status, :string
+    end
+  end
+end

--- a/test/lib/code_corps/stripe_service/adapters/stripe_connect_account_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_connect_account_test.exs
@@ -79,6 +79,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountTestAdapter do
 
   @local_map %{
     "id_from_stripe" => "acct_123",
+
     "business_name" => "Code Corps PBC",
     "business_url" => "codecorps.org",
     "charges_enabled" => false,
@@ -105,6 +106,11 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountTestAdapter do
     "legal_entity_dob_month" => nil,
     "legal_entity_dob_year" => nil,
 
+    "legal_entity_first_name" => nil,
+    "legal_entity_gender" => nil,
+    "legal_entity_last_name" => nil,
+    "legal_entity_maiden_name" => nil,
+
     "legal_entity_personal_address_city" => nil,
     "legal_entity_personal_address_country" => "US",
     "legal_entity_personal_address_line2" => nil,
@@ -113,21 +119,24 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountTestAdapter do
     "legal_entity_personal_address_state" => nil,
 
     "legal_entity_personal_id_number_provided" => false,
-    "legal_entity_ssn_last_4_provided" => false,
 
     "legal_entity_phone_number" => nil,
 
+    "legal_entity_ssn_last_4_provided" => false,
+
     "legal_entity_type" => nil,
 
-    "legal_entity_first_name" => nil,
-    "legal_entity_last_name" => nil,
-    "legal_entity_gender" => nil,
-    "legal_entity_maiden_name" => nil,
+    "legal_entity_verification_details" => nil,
+    "legal_entity_verification_details_code" => "failed_other",
+    "legal_entity_verification_document" => "fil_12345",
+    "legal_entity_verification_status" => "unverified",
 
     "managed" => false,
+
     "support_email" => nil,
     "support_phone" => "1234567890",
     "support_url" => nil,
+
     "transfers_enabled" => false,
 
     "verification_disabled_reason" => "fields_needed",

--- a/test/lib/code_corps/stripe_service/stripe_connect_account_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_connect_account_service_test.exs
@@ -26,8 +26,8 @@ defmodule CodeCorps.StripeService.StripeConnectAccountServiceTest do
       account = insert(:stripe_connect_account)
 
       {:ok, %StripeConnectAccount{} = updated_account} =
-        StripeConnectAccountService.add_external_account(account, "ba_test123")
-      assert updated_account.external_account == "ba_test123"
+        StripeConnectAccountService.add_external_account(account, "ba_123")
+      assert updated_account.external_account == "ba_123"
     end
   end
 end

--- a/test/views/stripe_connect_account_view_test.exs
+++ b/test/views/stripe_connect_account_view_test.exs
@@ -16,6 +16,7 @@ defmodule CodeCorps.StripeConnectAccountViewTest do
     expected_json = %{
       "data" => %{
         "attributes" => %{
+          "bank-account-status" => "pending_requirement",
           "business-name" => account.business_name,
           "business-url" => account.business_url,
           "can-accept-donations" => true,
@@ -28,12 +29,15 @@ defmodule CodeCorps.StripeConnectAccountViewTest do
           "id-from-stripe" => account.id_from_stripe,
           "inserted-at" => account.inserted_at,
           "managed" => account.managed,
+          "personal-id-number-status" => "pending_requirement",
+          "recipient-status" => "required",
           "support-email" => account.support_email,
           "support-phone" => account.support_phone,
           "support-url" => account.support_url,
           "transfers-enabled" => account.transfers_enabled,
           "updated-at" => account.updated_at,
           "verification-disabled-reason" => account.verification_disabled_reason,
+          "verification-document-status" => "pending_requirement",
           "verification-due-by" => account.verification_due_by,
           "verification-fields-needed" => account.verification_fields_needed
         },
@@ -86,5 +90,174 @@ defmodule CodeCorps.StripeConnectAccountViewTest do
     rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
     assert rendered_json["data"]["attributes"]["can-accept-donations"] == true
     assert rendered_json["data"]["attributes"]["charges-enabled"] == false
+  end
+
+  describe "recipient-status" do
+    test "renders as 'required' by default" do
+      account = insert(:stripe_connect_account)
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["recipient-status"] == "required"
+    end
+
+    test "renders as 'verifying' when appropriate" do
+      account = insert(:stripe_connect_account, legal_entity_verification_status: "pending")
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["recipient-status"] == "verifying"
+    end
+
+    test "renders as 'verified' when appropriate" do
+      account = insert(:stripe_connect_account, legal_entity_verification_status: "verified")
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["recipient-status"] == "verified"
+    end
+  end
+
+  describe "verification-document-status" do
+    test "renders as 'pending_requirement' by default" do
+      account = insert(:stripe_connect_account)
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["verification-document-status"] == "pending_requirement"
+    end
+
+    test "renders as 'pending_requirement' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_verification_document: nil,
+        verification_fields_needed: ["legal_entity.type"])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["verification-document-status"] == "pending_requirement"
+    end
+
+    test "renders as 'required' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_verification_document: nil,
+        verification_fields_needed: ["legal_entity.verification.document"])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["verification-document-status"] == "required"
+    end
+
+    test "renders as 'verifying' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_verification_document: "file_123",
+        legal_entity_verification_status: "pending")
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["verification-document-status"] == "verifying"
+    end
+
+    test "renders as 'verified' when no fields" do
+      account = insert(
+        :stripe_connect_account,
+        verification_fields_needed: nil)
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["verification-document-status"] == "verified"
+    end
+
+    test "renders as 'verified' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_verification_document: "file_123",
+        verification_fields_needed: ["legal_entity.personal_id_number"])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["verification-document-status"] == "verified"
+    end
+
+    test "renders as 'errored' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_verification_document: "file_123",
+        verification_fields_needed: ["legal_entity.verification.document"])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["verification-document-status"] == "errored"
+    end
+  end
+
+  describe "personal-id-number-status" do
+    @account_default %Stripe.Account{}
+    test "renders as 'pending_requirement' by default" do
+      account = insert(:stripe_connect_account)
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["personal-id-number-status"] == "pending_requirement"
+    end
+
+    test "renders as 'pending_requirement' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_personal_id_number_provided: false,
+        verification_fields_needed: ["legal_entity.type"])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["personal-id-number-status"] == "pending_requirement"
+    end
+
+    test "renders as 'required' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_personal_id_number_provided: false,
+        verification_fields_needed: ["legal_entity.personal_id_number"])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["personal-id-number-status"] == "required"
+    end
+
+    test "renders as 'verifying' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_personal_id_number_provided: true,
+        legal_entity_verification_status: "pending")
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["personal-id-number-status"] == "verifying"
+    end
+
+    test "renders as 'verified' when no fields" do
+      account = insert(
+        :stripe_connect_account,
+        verification_fields_needed: nil)
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["personal-id-number-status"] == "verified"
+    end
+
+    test "renders as 'verified' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_personal_id_number_provided: true,
+        verification_fields_needed: ["external_account"])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["personal-id-number-status"] == "verified"
+    end
+  end
+
+  describe "bank-account-status" do
+    test "renders as 'pending_requirement' by default" do
+      account = insert(:stripe_connect_account)
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["bank-account-status"] == "pending_requirement"
+    end
+
+    test "renders as 'pending_requirement' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_verification_status: "pending",
+        verification_fields_needed: ["external_account"])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["bank-account-status"] == "pending_requirement"
+    end
+
+    test "renders as 'required' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_verification_status: "verified",
+        verification_fields_needed: ["external_account"])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["bank-account-status"] == "required"
+    end
+
+    test "renders as 'verified' when appropriate" do
+      account = insert(
+        :stripe_connect_account,
+        legal_entity_verification_status: "verified",
+        verification_fields_needed: [])
+      rendered_json = render(CodeCorps.StripeConnectAccountView, "show.json-api", data: account)
+      assert rendered_json["data"]["attributes"]["bank-account-status"] == "verified"
+    end
   end
 end

--- a/web/models/stripe_connect_account.ex
+++ b/web/models/stripe_connect_account.ex
@@ -6,6 +6,7 @@ defmodule CodeCorps.StripeConnectAccount do
   use CodeCorps.Web, :model
 
   schema "stripe_connect_accounts" do
+    field :bank_account_status, :string
     field :business_name, :string
     field :business_url, :string
     field :charges_enabled, :boolean
@@ -53,7 +54,10 @@ defmodule CodeCorps.StripeConnectAccount do
     field :legal_entity_verification_status, :string
 
     field :id_from_stripe, :string, null: false
+
     field :managed, :boolean, default: true
+
+    field :personal_id_number_status, :string
 
     field :support_email, :string
     field :support_phone, :string
@@ -63,7 +67,7 @@ defmodule CodeCorps.StripeConnectAccount do
 
     field :verification_disabled_reason, :string
     field :verification_due_by, Ecto.DateTime
-    field :verification_fields_needed, {:array, :string}
+    field :verification_fields_needed, {:array, :string}, default: []
 
     belongs_to :organization, CodeCorps.Organization
 
@@ -71,63 +75,72 @@ defmodule CodeCorps.StripeConnectAccount do
   end
 
   @insert_params [
-    :business_name, :business_url, :charges_enabled, :country, :default_currency,
-    :details_submitted, :email, :id_from_stripe, :managed, :organization_id,
-    :support_email, :support_phone, :support_url, :transfers_enabled,
-    :verification_disabled_reason, :verification_due_by,
+    :id_from_stripe, :organization_id
+  ]
+
+  @stripe_params [
+    :business_name,
+    :business_url,
+    :charges_enabled,
+    :country,
+    :default_currency,
+    :details_submitted,
+    :display_name,
+    :email,
+    :external_account,
+    :legal_entity_address_city,
+    :legal_entity_address_country,
+    :legal_entity_address_line1,
+    :legal_entity_address_line2,
+    :legal_entity_address_postal_code,
+    :legal_entity_address_state,
+    :legal_entity_business_name,
+    :legal_entity_business_tax_id_provided,
+    :legal_entity_business_vat_id_provided,
+    :legal_entity_dob_day,
+    :legal_entity_dob_month,
+    :legal_entity_dob_year,
+    :legal_entity_first_name,
+    :legal_entity_last_name,
+    :legal_entity_gender,
+    :legal_entity_maiden_name,
+    :legal_entity_personal_address_city,
+    :legal_entity_personal_address_country,
+    :legal_entity_personal_address_line1,
+    :legal_entity_personal_address_line2,
+    :legal_entity_personal_address_postal_code,
+    :legal_entity_personal_address_state,
+    :legal_entity_phone_number,
+    :legal_entity_personal_id_number_provided,
+    :legal_entity_ssn_last_4_provided,
+    :legal_entity_type,
+    :legal_entity_verification_details,
+    :legal_entity_verification_details_code,
+    :legal_entity_verification_document,
+    :legal_entity_verification_status,
+    :managed,
+    :support_email,
+    :support_phone,
+    :support_url,
+    :transfers_enabled,
+    :verification_disabled_reason,
+    :verification_due_by,
     :verification_fields_needed
   ]
 
   def create_changeset(struct, params \\ %{}) do
+    valid_params = Enum.concat(@insert_params, @stripe_params)
     struct
-    |> cast(params, @insert_params)
+    |> cast(params, valid_params)
     |> validate_required([:id_from_stripe, :organization_id])
     |> assoc_constraint(:organization)
   end
-
-  # Fields that get updated when we handle an "account.updated" webhook
-  @webhook_update_params [
-    :business_name, :business_url, :charges_enabled, :country,
-    :default_currency, :details_submitted, :display_name, :email,
-    :legal_entity_address_city, :legal_entity_address_country,
-    :legal_entity_address_line1, :legal_entity_address_line2,
-    :legal_entity_address_postal_code, :legal_entity_address_state,
-    :legal_entity_business_name,
-    :legal_entity_business_tax_id_provided, :legal_entity_business_vat_id_provided,
-    :legal_entity_dob_day, :legal_entity_dob_month, :legal_entity_dob_year,
-    :legal_entity_first_name, :legal_entity_last_name,
-    :legal_entity_gender, :legal_entity_maiden_name,
-    :legal_entity_personal_address_city, :legal_entity_personal_address_country,
-    :legal_entity_personal_address_line1, :legal_entity_personal_address_line2,
-    :legal_entity_personal_address_postal_code, :legal_entity_personal_address_state,
-    :legal_entity_phone_number,
-    :legal_entity_personal_id_number_provided, :legal_entity_ssn_last_4_provided,
-    :legal_entity_type,
-    :legal_entity_verification_details, :legal_entity_verification_details_code,
-    :legal_entity_verification_document, :legal_entity_verification_status,
-    :managed, :support_email, :support_phone, :support_url,
-    :transfers_enabled,
-    :verification_disabled_reason, :verification_due_by, :verification_fields_needed
-  ]
 
   @doc """
   Changeset used to update the record while handling an "account.updated" webhook
   """
   def webhook_update_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @webhook_update_params)
-  end
-
-  @update_params [
-    :business_name, :business_url, :charges_enabled, :country, :default_currency,
-    :details_submitted, :email, :external_account, :id_from_stripe,
-    :support_email, :support_phone, :support_url, :transfers_enabled,
-    :verification_disabled_reason, :verification_due_by,
-    :verification_fields_needed
-  ]
-
-  def stripe_update_changeset(struct, params) do
-    struct
-    |> cast(params, @update_params)
+    |> cast(params, @stripe_params)
   end
 end

--- a/web/views/stripe_connect_account_view.ex
+++ b/web/views/stripe_connect_account_view.ex
@@ -3,12 +3,32 @@ defmodule CodeCorps.StripeConnectAccountView do
   use CodeCorps.Web, :view
   use JaSerializer.PhoenixView
 
+  alias CodeCorps.StripeConnectAccount
+
   attributes [
-    :business_name, :business_url, :can_accept_donations,
-    :charges_enabled, :country, :default_currency, :details_submitted,
-    :display_name, :email, :id_from_stripe, :inserted_at, :managed,
-    :support_email, :support_phone, :support_url, :transfers_enabled,
-    :updated_at, :verification_disabled_reason, :verification_due_by,
+    :bank_account_status,
+    :business_name,
+    :business_url,
+    :can_accept_donations,
+    :charges_enabled,
+    :country,
+    :default_currency,
+    :details_submitted,
+    :display_name,
+    :email,
+    :id_from_stripe,
+    :inserted_at,
+    :managed,
+    :personal_id_number_status,
+    :recipient_status,
+    :support_email,
+    :support_phone,
+    :support_url,
+    :transfers_enabled,
+    :updated_at,
+    :verification_disabled_reason,
+    :verification_due_by,
+    :verification_document_status,
     :verification_fields_needed
   ]
 
@@ -20,4 +40,84 @@ defmodule CodeCorps.StripeConnectAccountView do
       _ -> true
     end
   end
+
+  # recipient_status mapping
+
+  def recipient_status(stripe_connect_account, _conn) do
+    get_recipient_status(stripe_connect_account)
+  end
+
+  defp get_recipient_status(%StripeConnectAccount{legal_entity_verification_status: "pending"}), do: "verifying"
+  defp get_recipient_status(%StripeConnectAccount{legal_entity_verification_status: "verified"}), do: "verified"
+  defp get_recipient_status(_), do: "required"
+
+  # verification_document_status
+
+  def verification_document_status(stripe_connect_account, _conn) do
+    get_verification_document_status(stripe_connect_account)
+  end
+
+  defp get_verification_document_status(%StripeConnectAccount{verification_fields_needed: nil
+  }), do: "verified"
+  defp get_verification_document_status(%StripeConnectAccount{
+    legal_entity_verification_document: nil, verification_fields_needed: fields
+  }) do
+    case Enum.member?(fields, "legal_entity.verification.document") do
+      true -> "required"
+      false -> "pending_requirement"
+    end
+  end
+  defp get_verification_document_status(%StripeConnectAccount{
+    legal_entity_verification_document: _, legal_entity_verification_status: "pending"
+  }), do: "verifying"
+  defp get_verification_document_status(%StripeConnectAccount{
+    legal_entity_verification_document: _,
+    verification_fields_needed: fields
+  }) do
+    case Enum.member?(fields, "legal_entity.verification.document") do
+      true -> "errored"
+      false -> "verified"
+    end
+  end
+  defp get_verification_document_status(_), do: "pending_requirement"
+
+  # personal_id_number_status
+
+  def personal_id_number_status(stripe_connect_account, _conn) do
+    get_personal_id_number_status(stripe_connect_account)
+  end
+
+  defp get_personal_id_number_status(%StripeConnectAccount{verification_fields_needed: nil}), do: "verified"
+  defp get_personal_id_number_status(%StripeConnectAccount{
+    legal_entity_personal_id_number_provided: false,
+    verification_fields_needed: fields
+  }) do
+    case Enum.member?(fields, "legal_entity.personal_id_number") do
+      true -> "required"
+      false -> "pending_requirement"
+    end
+  end
+  defp get_personal_id_number_status(%StripeConnectAccount{
+    legal_entity_personal_id_number_provided: true,
+    legal_entity_verification_status: "pending"
+  }), do: "verifying"
+  defp get_personal_id_number_status(%StripeConnectAccount{legal_entity_personal_id_number_provided: true}), do: "verified"
+  defp get_personal_id_number_status(_), do: "pending_requirement"
+
+  # bank_account_status
+
+  def bank_account_status(stripe_connect_account, _conn) do
+    get_bank_account_status(stripe_connect_account)
+  end
+
+  defp get_bank_account_status(%StripeConnectAccount{
+    legal_entity_verification_status: "verified",
+    verification_fields_needed: fields
+  }) do
+    case Enum.member?(fields, "external_account") do
+      true -> "required"
+      false -> "verified"
+    end
+  end
+  defp get_bank_account_status(_), do: "pending_requirement"
 end


### PR DESCRIPTION
# What's in this PR?

This PR adds the four status fields required for fully setting up a stripe connect account.

A work in progress

## References
Fixes #579

# Notes

The issue states the following for the `personal_id_number_status` field:

* `required`
  * `legal_entity.personal_id_number_provided` is `false`
  * `verification[fields_needed]` contains `"legal_entity.personal_id_number"`
* `verifying`
  * `legal_entity.personal_id_number_provided` is `true`
  * `verification[fields_needed]` contains `"legal_entity.verification. personal_id_number"`
* `verified`
  * `legal_entity.personal_id_number_provided` is `true`
  * `legal_entity[verification][status]` is `"pending"`

This seems strange to me.

Wouldn't the proper condition for `verifying` and `verified` be something like:

* `verifying`
  * `legal_entity.personal_id_number_provided` is `true`
  * `verification[status]` is equal to `"pending"`
* `verified`
  * `legal_entity.personal_id_number_provided` is `true`
  * `verification[fields_needed]` does not contain `"legal_entity.personal_id_number"`