### PR TITLE
Couple of minor fixes to codebase, post merge of connect account changes

### DIFF
--- a/lib/code_corps/stripe_service/stripe_connect_account.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_account.ex
@@ -2,6 +2,8 @@ defmodule CodeCorps.StripeService.StripeConnectAccountService do
   alias CodeCorps.{Repo, StripeConnectAccount, StripeFileUpload}
   alias CodeCorps.StripeService.Adapters.{StripeConnectAccountAdapter, StripeFileUploadAdapter}
 
+  alias Ecto.Multi
+
   @api Application.get_env(:code_corps, :stripe)
 
   def create(%{"country" => country_code, "organization_id" => _} = attributes) do

--- a/priv/repo/migrations/20161226213600_remove_obsolete_status_fields_from_connect_account.exs
+++ b/priv/repo/migrations/20161226213600_remove_obsolete_status_fields_from_connect_account.exs
@@ -1,0 +1,12 @@
+defmodule CodeCorps.Repo.Migrations.RemoveObsoleteStatusFieldsFromConnectAccount do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stripe_connect_accounts) do
+      remove :recipient_status
+      remove :verification_document_status
+      remove :personal_id_number_status
+      remove :bank_account_status
+    end
+  end
+end

--- a/web/models/stripe_connect_account.ex
+++ b/web/models/stripe_connect_account.ex
@@ -6,7 +6,6 @@ defmodule CodeCorps.StripeConnectAccount do
   use CodeCorps.Web, :model
 
   schema "stripe_connect_accounts" do
-    field :bank_account_status, :string
     field :business_name, :string
     field :business_url, :string
     field :charges_enabled, :boolean
@@ -56,8 +55,6 @@ defmodule CodeCorps.StripeConnectAccount do
     field :id_from_stripe, :string, null: false
 
     field :managed, :boolean, default: true
-
-    field :personal_id_number_status, :string
 
     field :support_email, :string
     field :support_phone, :string


### PR DESCRIPTION
# What's in this PR?

This PR removes remnants of the status columns we temporarily had on our `StripeConnectAccount` model. This should resolve errors appearing on staging.

It also adds a missing alias to `Ecto.Multi` to our `StripeConnectAccount`
 service. Without it, the service was basically broken.