### PR TITLE
Add stripe tracking for some basic cases

### DIFF
--- a/test/controllers/donation_goal_controller_test.exs
+++ b/test/controllers/donation_goal_controller_test.exs
@@ -42,11 +42,17 @@ defmodule CodeCorps.DonationGoalControllerTest do
   end
 
   describe "create" do
-    @tag authenticated: :admin
-    test "creates and renders resource when data is valid", %{conn: conn} do
-      project = insert(:project)
+    @tag :authenticated
+    test "creates and renders resource when data is valid", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      insert(:organization_membership, member: current_user, organization: organization, role: "owner")
+      project = insert(:project, organization: organization)
+
       attrs = @valid_attrs |> Map.merge(%{project: project})
       assert conn |> request_create(attrs) |> json_response(201)
+
+      user_id = current_user.id
+      assert_received {:track, ^user_id, "Created Donation Goal", %{}}
     end
 
     @tag authenticated: :admin
@@ -65,11 +71,19 @@ defmodule CodeCorps.DonationGoalControllerTest do
   end
 
   describe "update" do
-    @tag authenticated: :admin
-    test "updates and renders chosen resource when data is valid", %{conn: conn} do
-      project = insert(:project)
+    @tag :authenticated
+    test "updates and renders chosen resource when data is valid", %{conn: conn, current_user: current_user} do
+      organization = insert(:organization)
+      insert(:organization_membership, member: current_user, organization: organization, role: "owner")
+      project = insert(:project, organization: organization)
+
+      donation_goal = insert(:donation_goal, project: project)
+
       attrs = @valid_attrs |> Map.merge(%{project: project})
-      assert conn |> request_update(attrs) |> json_response(200)
+      assert conn |> request_update(donation_goal, attrs) |> json_response(200)
+
+      user_id = current_user.id
+      assert_received {:track, ^user_id, "Updated Donation Goal", %{}}
     end
 
     @tag authenticated: :admin

--- a/test/controllers/stripe_connect_subscription_controller_test.exs
+++ b/test/controllers/stripe_connect_subscription_controller_test.exs
@@ -1,0 +1,53 @@
+defmodule CodeCorps.StripeConnectSubscriptionControllerTest do
+  use CodeCorps.ApiCase, resource_name: :stripe_connect_subscription
+
+  defp build_payload(user, project, quantity) do
+    %{
+      "data" => %{
+        "attributes" => %{
+          "quantity" => quantity,
+          "project-id" => project.id
+        },
+        "relationships" => %{
+          "user" => %{"data" => %{"id" => user.id}}
+        }
+      }
+    }
+  end
+
+  defp make_create_request(conn, payload) do
+    path = conn |> stripe_connect_subscription_path(:create)
+
+    conn |> post(path, payload)
+  end
+
+  describe "create" do
+    @tag :authenticated
+    test "creates and renders resource when user is authenticated and authorized", %{conn: conn, current_user: current_user} do
+      # make project ready to accept donations
+      organization = insert(:organization)
+      insert(:stripe_connect_account, organization: organization, charges_enabled: true)
+      project = insert(:project, organization: organization)
+      insert(:stripe_connect_plan, project: project)
+
+      # make user ready to donate
+      insert(:stripe_platform_customer, user: current_user)
+      insert(:stripe_platform_card, user: current_user)
+
+      payload = build_payload(current_user, project, 10)
+      assert conn |> make_create_request(payload) |> json_response(201)
+
+      user_id = current_user.id
+      assert_received {:track, ^user_id, "Created Stripe Connect Subscription", %{}}
+    end
+
+    test "does not create resource and renders 401 when unauthenticated", %{conn: conn} do
+      assert conn |> request_create |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "does not create resource and renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_create |> json_response(403)
+    end
+  end
+end

--- a/web/controllers/donation_goal_controller.ex
+++ b/web/controllers/donation_goal_controller.ex
@@ -13,13 +13,15 @@ defmodule CodeCorps.DonationGoalController do
 
   def filter(_conn, query, "id", id_list), do: id_filter(query, id_list)
 
-  def handle_create(_conn, attributes) do
+  def handle_create(conn, attributes) do
     attributes
     |> DonationGoalsService.create
+    |> CodeCorps.Analytics.Segment.track(:created, conn)
   end
 
-  def handle_update(_conn, record, attributes) do
+  def handle_update(conn, record, attributes) do
     record
     |> DonationGoalsService.update(attributes)
+    |> CodeCorps.Analytics.Segment.track(:updated, conn)
   end
 end


### PR DESCRIPTION
# What's in this PR?

PR adds missing tracking calls and tests for the basic cases related to the whole stripe process:

* stripe connect subscription testing - tracking was already in
* donation goals create - wasn't tracked or tested
* donation goals update - wasn't tracked or tested

## References
Progress on: #525
