### PR TITLE
Change bank accounts to external accounts

### DIFF
--- a/lib/code_corps/stripe_service/adapters/stripe_external_account.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_external_account.ex
@@ -7,7 +7,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeExternalAccountAdapter do
     :routing_number, :status
   ]
 
-  def to_params(%Stripe.BankAccount{} = bank_account) do
+  def to_params(%Stripe.ExternalAccount{} = bank_account) do
     params =
       bank_account
       |> Map.from_struct

--- a/lib/code_corps/stripe_service/events/connect_external_account_created.ex
+++ b/lib/code_corps/stripe_service/events/connect_external_account_created.ex
@@ -1,0 +1,5 @@
+defmodule CodeCorps.StripeService.Events.ConnectExternalAccountCreated do
+  def handle(%{"data" => %{"object" => %{"account" => account_id_from_stripe, "id" => id_from_stripe}}}) do
+    CodeCorps.StripeService.StripeConnectExternalAccountService.create(id_from_stripe, account_id_from_stripe)
+  end
+end

--- a/lib/code_corps/stripe_service/events/external_account_created.ex
+++ b/lib/code_corps/stripe_service/events/external_account_created.ex
@@ -1,5 +1,0 @@
-defmodule CodeCorps.StripeService.Events.ExternalAccountCreated do
-  def handle(%{"data" => %{"object" => %{"id" => id_from_stripe}}}) do
-    CodeCorps.StripeService.StripeExternalAccountService.create(id_from_stripe)
-  end
-end

--- a/lib/code_corps/stripe_service/stripe_connect_external_account_service.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_external_account_service.ex
@@ -1,11 +1,11 @@
-defmodule CodeCorps.StripeService.StripeExternalAccountService do
+defmodule CodeCorps.StripeService.StripeConnectExternalAccountService do
   alias CodeCorps.{Repo, StripeExternalAccount}
   alias CodeCorps.StripeService.Adapters.StripeExternalAccountAdapter
 
   @api Application.get_env(:code_corps, :stripe)
 
-  def create(id_from_stripe) do
-    with {:ok, %Stripe.BankAccount{} = bank_account} <- @api.BankAccount.retrieve(id_from_stripe),
+  def create(id_from_stripe, account_id_from_stripe) do
+    with {:ok, %Stripe.ExternalAccount{} = bank_account} <- @api.ExternalAccount.retrieve(id_from_stripe, connect_account: account_id_from_stripe),
          {:ok, params} <- StripeExternalAccountAdapter.to_params(bank_account)
     do
       %StripeExternalAccount{}

--- a/lib/code_corps/stripe_service/webhook_processing/connect_event_handler.ex
+++ b/lib/code_corps/stripe_service/webhook_processing/connect_event_handler.ex
@@ -16,7 +16,7 @@ defmodule CodeCorps.StripeService.WebhookProcessing.ConnectEventHandler do
   def handle_event(%{"type" => type} = attributes), do: do_handle(type, attributes)
 
   defp do_handle("account.updated", attributes), do: Events.AccountUpdated.handle(attributes)
-  defp do_handle("account.external_account.created", attributes), do: Events.ExternalAccountCreated.handle(attributes)
+  defp do_handle("account.external_account.created", attributes), do: Events.ConnectExternalAccountCreated.handle(attributes)
   defp do_handle("customer.subscription.deleted", attributes), do: Events.CustomerSubscriptionDeleted.handle(attributes)
   defp do_handle("customer.subscription.updated", attributes), do: Events.CustomerSubscriptionUpdated.handle(attributes)
   defp do_handle(_, _), do: {:ok, :unhandled_event}

--- a/lib/code_corps/stripe_testing/external_account.ex
+++ b/lib/code_corps/stripe_testing/external_account.ex
@@ -1,10 +1,10 @@
-defmodule CodeCorps.StripeTesting.BankAccount do
-  def retrieve(id) do
+defmodule CodeCorps.StripeTesting.ExternalAccount do
+  def retrieve(id, _) do
     {:ok, bank_account(id)}
   end
 
   defp bank_account(id) do
-    %Stripe.BankAccount{
+    %Stripe.ExternalAccount{
       id: id,
       object: "bank_account",
       account: "acct_1032D82eZvKYlo2C",

--- a/mix.lock
+++ b/mix.lock
@@ -56,7 +56,7 @@
   "segment": {:hex, :segment, "0.1.1", "47bf9191590e7a533c105d1e21518e0d6da47c91e8d98ebb649c624db5dfc359", [:mix], [{:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}, {:poison, "~> 1.3 or ~> 2.0", [hex: :poison, optional: false]}]},
   "sentry": {:hex, :sentry, "2.1.0", "51e7ca261b519294ac73b30763893c4a7ad2005205514aefa5bf37ccb83e44ea", [:mix], [{:hackney, "~> 1.6.1", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: true]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}, {:uuid, "~> 1.0", [hex: :uuid, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
-  "stripity_stripe": {:git, "https://github.com/code-corps/stripity_stripe.git", "bffefa3195d4fc75dafece4094d697506dc72c07", [branch: "2.0"]},
+  "stripity_stripe": {:git, "https://github.com/code-corps/stripity_stripe.git", "f325778c8fb2af3bc04c9d894daef0c47c1500de", [branch: "2.0"]},
   "sweet_xml": {:hex, :sweet_xml, "0.6.3", "814265792baeb163421811c546581c522dfdcb9d1767b1e59959c52906414e80", [:mix], []},
   "timber": {:hex, :timber, "0.4.7", "df3fcd79bcb4eb4b53874d906ef5f3a212937b4bc7b7c5b244745202cc389443", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: true]}, {:phoenix, "~> 1.2", [hex: :phoenix, optional: true]}, {:plug, "~> 1.2", [hex: :plug, optional: true]}, {:poison, "~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "timex": {:hex, :timex, "3.1.5", "413d6d8d6f0162a5d47080cb8ca520d790184ac43e097c95191c7563bf25b428", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},

--- a/test/lib/code_corps/stripe_service/adapters/stripe_external_account_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_external_account_test.exs
@@ -3,7 +3,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeExternalAccountTestAdapter do
 
   import CodeCorps.StripeService.Adapters.StripeExternalAccountAdapter, only: [to_params: 1]
 
-  @stripe_connect_account %Stripe.BankAccount{
+  @stripe_connect_account %Stripe.ExternalAccount{
     id: "ba_19SSZG2eZvKYlo2CXnmzYU5H",
     object: "bank_account",
     account: "acct_1032D82eZvKYlo2C",

--- a/test/lib/code_corps/stripe_service/stripe_connect_external_account_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_connect_external_account_service_test.exs
@@ -1,16 +1,17 @@
-defmodule CodeCorps.StripeService.StripeExternalAccountServiceTest do
+defmodule CodeCorps.StripeService.StripeConnectExternalAccountServiceTest do
   use ExUnit.Case, async: true
 
   use CodeCorps.ModelCase
 
-  alias CodeCorps.StripeService.StripeExternalAccountService
+  alias CodeCorps.StripeService.StripeConnectExternalAccountService
 
   describe "create" do
     test "creates a StripeExternalAccount" do
       id_from_stripe = "ba_testing123"
+      account_id_from_stripe = "acct_123"
 
       {:ok, %CodeCorps.StripeExternalAccount{} = bank_account} =
-        StripeExternalAccountService.create(id_from_stripe)
+        StripeConnectExternalAccountService.create(id_from_stripe, account_id_from_stripe)
 
       assert bank_account.id_from_stripe == id_from_stripe
     end

--- a/test/lib/code_corps/stripe_service/stripe_platform_customer_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_platform_customer_service_test.exs
@@ -1,4 +1,6 @@
 defmodule CodeCorps.StripeService.StripePlatformCustomerServiceTest do
+  @moduledoc false
+  
   use CodeCorps.ModelCase
 
   alias CodeCorps.StripePlatformCustomer

--- a/test/models/stripe_connect_account_test.exs
+++ b/test/models/stripe_connect_account_test.exs
@@ -1,11 +1,13 @@
 defmodule CodeCorps.StripeConnectAccountTest do
+  @moduledoc false
+
   use CodeCorps.ModelCase
 
   alias CodeCorps.StripeConnectAccount
 
   @valid_attrs %{
     id_from_stripe: "abc123",
-    tos_acceptance_date: 1234567
+    tos_acceptance_date: 1_234_567
   }
 
   @invalid_attrs %{}
@@ -31,8 +33,9 @@ defmodule CodeCorps.StripeConnectAccountTest do
     test "ensures associations link to records that exist" do
       attrs =  @valid_attrs |> Map.merge(%{organization_id: -1})
 
-      { :error, changeset } =
-        StripeConnectAccount.create_changeset(%StripeConnectAccount{}, attrs)
+      {:error, changeset} =
+        %StripeConnectAccount{}
+        |> StripeConnectAccount.create_changeset(attrs)
         |> Repo.insert
 
       refute changeset.valid?
@@ -48,8 +51,9 @@ defmodule CodeCorps.StripeConnectAccountTest do
       }
       attrs =  @valid_attrs |> Map.merge(map)
 
-      { :ok, record } =
-        StripeConnectAccount.create_changeset(%StripeConnectAccount{}, attrs)
+      {:ok, record} =
+        %StripeConnectAccount{}
+        |> StripeConnectAccount.create_changeset(attrs)
         |> Repo.insert
 
       assert record.verification_fields_needed == list

--- a/web/models/role.ex
+++ b/web/models/role.ex
@@ -1,4 +1,10 @@
 defmodule CodeCorps.Role do
+  @moduledoc """
+  This module defines a "role" on Code Corps.
+
+  Examples of roles are "Backend Developer" and "Front End Developer".
+  """
+
   use CodeCorps.Web, :model
 
   schema "roles" do


### PR DESCRIPTION
# What's in this PR?

Changes to ExternalAccount to accommodate misunderstanding of Stripe's API.