### PR TITLE
Add inbox flag to task lists

### DIFF
--- a/priv/repo/migrations/20170106013143_add_editable_to_task_lists.exs
+++ b/priv/repo/migrations/20170106013143_add_editable_to_task_lists.exs
@@ -1,0 +1,25 @@
+defmodule CodeCorps.Repo.Migrations.AddEditableToTaskLists do
+  alias CodeCorps.{Repo, TaskList}
+
+  import Ecto.Query
+
+  use Ecto.Migration
+
+  def up do
+    alter table(:task_lists) do
+      add :inbox, :boolean, default: false
+    end
+
+    flush
+
+    TaskList
+    |> where([task_list], task_list.name == "Inbox")
+    |> Repo.update_all(set: [inbox: true])
+  end
+
+  def down do
+    alter table(:task_lists) do
+      remove :inbox
+    end
+  end
+end

--- a/test/lib/code_corps/services/markdown_renderer_test.exs
+++ b/test/lib/code_corps/services/markdown_renderer_test.exs
@@ -7,6 +7,7 @@ defmodule CodeCorps.Services.MarkdownRendererServiceTest do
 
   @valid_attrs %{
     title: "Test task",
+    task_list_id: 1,
     task_type: "issue",
     markdown: "A **strong** body",
     status: "open"

--- a/test/models/task_list_test.exs
+++ b/test/models/task_list_test.exs
@@ -15,4 +15,13 @@ defmodule CodeCorps.TaskListTest do
     changeset = TaskList.changeset(%TaskList{}, @invalid_attrs)
     refute changeset.valid?
   end
+
+  test "is not inbox by default" do
+    {:ok, record} =
+      %TaskList{}
+      |> TaskList.changeset(@valid_attrs)
+      |> CodeCorps.Repo.insert
+
+    refute record.inbox
+  end
 end

--- a/test/views/task_list_view_test.exs
+++ b/test/views/task_list_view_test.exs
@@ -13,6 +13,7 @@ defmodule CodeCorps.TaskListViewTest do
     expected_json = %{
       "data" => %{
         "attributes" => %{
+          "inbox" => task_list.inbox,
           "name" => task_list.name,
           "order" => 1000,
           "inserted-at" => task_list.inserted_at,

--- a/web/models/task.ex
+++ b/web/models/task.ex
@@ -7,16 +7,18 @@ defmodule CodeCorps.Task do
     field :body, :string
     field :markdown, :string
     field :number, :integer, read_after_writes: true
-    field :task_type, :string
+    field :order, :integer
     field :state, :string
     field :status, :string, default: "open"
+    field :task_type, :string
     field :title, :string
+
     field :position, :integer, virtual: true
-    field :order, :integer
 
     belongs_to :project, CodeCorps.Project
-    belongs_to :user, CodeCorps.User
     belongs_to :task_list, CodeCorps.TaskList
+    belongs_to :user, CodeCorps.User
+
     has_many :comments, CodeCorps.Comment
 
     timestamps()
@@ -25,7 +27,7 @@ defmodule CodeCorps.Task do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:title, :markdown, :task_type, :task_list_id, :position])
-    |> validate_required([:title, :markdown, :task_type])
+    |> validate_required([:title, :markdown, :task_list_id, :task_type])
     |> validate_inclusion(:task_type, task_types)
     |> assoc_constraint(:task_list)
     |> apply_position()
@@ -37,7 +39,7 @@ defmodule CodeCorps.Task do
     struct
     |> changeset(params)
     |> cast(params, [:project_id, :user_id])
-    |> validate_required([:project_id, :user_id, :task_list_id])
+    |> validate_required([:project_id, :user_id])
     |> assoc_constraint(:project)
     |> assoc_constraint(:user)
     |> put_change(:state, "published")

--- a/web/models/task_list.ex
+++ b/web/models/task_list.ex
@@ -3,9 +3,10 @@ defmodule CodeCorps.TaskList do
   import EctoOrdered
 
   schema "task_lists" do
+    field :inbox, :boolean, default: false
     field :name, :string
-    field :position, :integer, virtual: true
     field :order, :integer
+    field :position, :integer, virtual: true
 
     belongs_to :project, CodeCorps.Project
     has_many :tasks, CodeCorps.Task
@@ -16,15 +17,19 @@ defmodule CodeCorps.TaskList do
   def default_task_lists() do
     [
       %{
+        inbox: true,
         name: "Inbox",
         position: 1
       }, %{
+        inbox: false,
         name: "Backlog",
         position: 2
       }, %{
+        inbox: false,
         name: "In Progress",
         position: 3
       }, %{
+        inbox: false,
         name: "Done",
         position: 4
       }

--- a/web/views/task_list_view.ex
+++ b/web/views/task_list_view.ex
@@ -3,7 +3,7 @@ defmodule CodeCorps.TaskListView do
   use CodeCorps.Web, :view
   use JaSerializer.PhoenixView
 
-  attributes [:name, :order, :inserted_at, :updated_at]
+  attributes [:inbox, :name, :order, :inserted_at, :updated_at]
 
   has_one :project, serializer: CodeCorps.ProjectView
 


### PR DESCRIPTION
# What's in this PR?

This adds the concept of `inbox` `true | false` to `TaskList` for determining whether a list is the inbox for new tasks in the project.