### PR TITLE
Set proper order for default task lists of a project

### DIFF
--- a/test/models/project_test.exs
+++ b/test/models/project_test.exs
@@ -63,15 +63,19 @@ defmodule CodeCorps.ProjectTest do
       assert {:ok, 1} == changeset |> fetch_change(:organization_id)
     end
 
-    test "associates the default task lists to the project" do
+    test "associates the ordered default task lists to the project" do
       organization = insert(:organization)
-      changeset = Project.create_changeset(%Project{}, %{organization_id: organization.id, title: "Title"})
+      changeset = Project.create_changeset(
+        %Project{},
+        %{organization_id: organization.id, title: "Title"}
+      )
 
       {_, project} = Repo.insert(changeset)
 
-      orders = for task_list <- project.task_lists do; task_list.order; end
+      task_list_orders = for task_list <- project.task_lists, do: task_list.order
 
-      assert orders == [1, 2, 3, 4]
+      assert Enum.all?(task_list_orders), "some of the orders are not set (nil)"
+      assert task_list_orders == Enum.sort(task_list_orders), "task lists order does not correspond to their position"
     end
   end
 

--- a/test/models/project_test.exs
+++ b/test/models/project_test.exs
@@ -62,6 +62,17 @@ defmodule CodeCorps.ProjectTest do
       changeset = Project.create_changeset(%Project{}, %{organization_id: 1})
       assert {:ok, 1} == changeset |> fetch_change(:organization_id)
     end
+
+    test "associates the default task lists to the project" do
+      organization = insert(:organization)
+      changeset = Project.create_changeset(%Project{}, %{organization_id: organization.id, title: "Title"})
+
+      {_, project} = Repo.insert(changeset)
+
+      orders = for task_list <- project.task_lists do; task_list.order; end
+
+      assert orders == [1, 2, 3, 4]
+    end
   end
 
   describe "update_changeset/2" do

--- a/web/models/task_list.ex
+++ b/web/models/task_list.ex
@@ -16,7 +16,7 @@ defmodule CodeCorps.TaskList do
   end
 
   def default_task_lists() do
-    task_list_data = [
+    [
       %{
         name: "Inbox",
         position: 1
@@ -30,11 +30,7 @@ defmodule CodeCorps.TaskList do
         name: "Done",
         position: 4
       }
-    ]
-
-    for task_list <- task_list_data do
-      TaskList.changeset(%TaskList{}, task_list)
-    end
+    ] |> Enum.map(fn (params) -> changeset(%TaskList{}, params) end)
   end
 
   @doc """

--- a/web/models/task_list.ex
+++ b/web/models/task_list.ex
@@ -2,6 +2,8 @@ defmodule CodeCorps.TaskList do
   use CodeCorps.Web, :model
   import EctoOrdered
 
+  alias CodeCorps.TaskList
+
   schema "task_lists" do
     field :name, :string
     field :position, :integer, virtual: true
@@ -14,25 +16,25 @@ defmodule CodeCorps.TaskList do
   end
 
   def default_task_lists() do
-    [
+    task_list_data = [
       %{
         name: "Inbox",
-        position: 1,
-        order: 1
+        position: 1
       }, %{
         name: "Backlog",
-        position: 2,
-        order: 2
+        position: 2
       }, %{
         name: "In Progress",
-        position: 3,
-        order: 3
+        position: 3
       }, %{
         name: "Done",
-        position: 4,
-        order: 4
+        position: 4
       }
     ]
+
+    for task_list <- task_list_data do
+      TaskList.changeset(%TaskList{}, task_list)
+    end
   end
 
   @doc """

--- a/web/models/task_list.ex
+++ b/web/models/task_list.ex
@@ -17,16 +17,20 @@ defmodule CodeCorps.TaskList do
     [
       %{
         name: "Inbox",
-        position: 1
+        position: 1,
+        order: 1
       }, %{
         name: "Backlog",
-        position: 2
+        position: 2,
+        order: 2
       }, %{
         name: "In Progress",
-        position: 3
+        position: 3,
+        order: 3
       }, %{
         name: "Done",
-        position: 4
+        position: 4,
+        order: 4
       }
     ]
   end


### PR DESCRIPTION
# What's in this PR?

This PR changes `TaskList.default_task_lists/0` to return changesets, which means that the `order` of each `TaskList` is now properly set within the scope of a project via `TaskList.changeset/2`.

## References
Fixes #592 