### PR TITLE
Deleted DateTime.from_unix, deleted stringify_keys, deleted DatTime f…

### DIFF
--- a/lib/code_corps/map_utils.ex
+++ b/lib/code_corps/map_utils.ex
@@ -9,7 +9,6 @@ defmodule CodeCorps.MapUtils do
 
   # Goes through a list and stringifies keys of any map member
   def stringify_keys(nil), do: nil
-  def stringify_keys(%DateTime{} = val), do: val
   def stringify_keys(map = %{}) do
     map
     |> Enum.map(fn {k, v} -> {stringify_key(k), stringify_keys(v)} end)

--- a/lib/code_corps/stripe_testing/customer.ex
+++ b/lib/code_corps/stripe_testing/customer.ex
@@ -42,7 +42,7 @@ defmodule CodeCorps.StripeTesting.Customer do
   end
 
   defp do_retrieve(id) do
-    {:ok, created} = DateTime.from_unix(1479472835)
+    created = 1479472835
 
     %Stripe.Customer{
       id: id,

--- a/test/lib/code_corps/stripe_service/adapters/stripe_connect_plan_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_connect_plan_test.exs
@@ -3,7 +3,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectPlanTest do
 
   import CodeCorps.StripeService.Adapters.StripeConnectPlanAdapter, only: [to_params: 2]
 
-  {:ok, timestamp} = DateTime.from_unix(1479472835)
+  timestamp = 1479472835
 
   @stripe_connect_plan %Stripe.Plan{
     id: "month",

--- a/test/lib/code_corps/stripe_service/adapters/stripe_connect_subscription_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_connect_subscription_test.exs
@@ -3,7 +3,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectSubscriptionTest do
 
   import CodeCorps.StripeService.Adapters.StripeConnectSubscriptionAdapter, only: [to_params: 2]
 
-  {:ok, date} = DateTime.from_unix(1479472835)
+  date = 1479472835
 
   @stripe_connect_subscription %Stripe.Subscription{
     application_fee_percent: 5.0,

--- a/test/lib/code_corps/stripe_service/adapters/stripe_platform_customer_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_platform_customer_test.exs
@@ -3,7 +3,7 @@ defmodule CodeCorps.StripeService.Adapters.StripePlatformCustomerTest do
 
   import CodeCorps.StripeService.Adapters.StripePlatformCustomerAdapter, only: [to_params: 2]
 
-  {:ok, timestamp} = DateTime.from_unix(1479472835)
+  timestamp = 1479472835
 
   @stripe_platform_customer %Stripe.Customer{
     id: "cus_123",


### PR DESCRIPTION
…rom test/lib/code_corps/stripe_service/adapters

# What's in this PR?

Removed DateTime.from_unix(), replaced with integer value.
Removed stringify_keys(%DateTime{})
Removed DateTime.from_unix() in tests, replaced with integer value.

Make sure any changes to code include changes to documentation.

## References
Fixes #623 

Progress on: #623 
