### PR TITLE
Moved code from handler for "account.updated" into StripeConnectAccountService

### DIFF
--- a/lib/code_corps/stripe_service/events/account_updated.ex
+++ b/lib/code_corps/stripe_service/events/account_updated.ex
@@ -1,25 +1,5 @@
 defmodule CodeCorps.StripeService.Events.AccountUpdated do
-  alias CodeCorps.StripeService.Adapters.StripeConnectAccountAdapter
-  alias CodeCorps.StripeConnectAccount
-  alias CodeCorps.Repo
-
-  @api Application.get_env(:code_corps, :stripe)
-
   def handle(%{"data" => %{"object" => %{"id" => id_from_stripe}}}) do
-    with {:ok, %Stripe.Account{} = stripe_account} <-
-           @api.Account.retrieve(id_from_stripe),
-         %StripeConnectAccount{} = local_account <-
-           Repo.get_by(StripeConnectAccount, id_from_stripe: id_from_stripe),
-         {:ok, params} <-
-           stripe_account |> StripeConnectAccountAdapter.to_params(%{})
-    do
-      local_account
-      |> StripeConnectAccount.webhook_update_changeset(params)
-      |> Repo.update
-    else
-      {:error, %Stripe.APIErrorResponse{}} -> {:error, :stripe_error}
-      nil -> {:error, :not_found}
-      _ -> {:error, :unexpected}
-    end
+    CodeCorps.StripeService.StripeConnectAccountService.update_from_stripe(id_from_stripe)
   end
 end

--- a/lib/code_corps/stripe_service/stripe_connect_account.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_account.ex
@@ -4,28 +4,44 @@ defmodule CodeCorps.StripeService.StripeConnectAccountService do
 
   @api Application.get_env(:code_corps, :stripe)
 
+  @doc """
+  Used to create a remote `Stripe.Account` record as well as an associated local
+  `StripeConnectAccount` record.
+  """
   def create(attributes) do
     with {:ok, from_params} <- StripeConnectAccountAdapter.from_params(attributes),
          {:ok, %Stripe.Account{} = account} <- @api.Account.create(from_params),
          {:ok, params} <- StripeConnectAccountAdapter.to_params(account, attributes)
     do
-      %StripeConnectAccount{}
-      |> StripeConnectAccount.create_changeset(params)
-      |> Repo.insert
+      %StripeConnectAccount{} |> StripeConnectAccount.create_changeset(params) |> Repo.insert
     end
   end
 
+  @doc """
+  Used to update both the local `StripeConnectAccount` as well as the remote `Stripe.Account`,
+  using attributes sent by the client
+  """
   def update(%StripeConnectAccount{id_from_stripe: id_from_stripe} = account, %{} = attributes) do
     with {:ok, from_params} <- StripeConnectAccountAdapter.from_params(attributes),
          {:ok, %Stripe.Account{} = stripe_account} <- @api.Account.update(id_from_stripe, from_params),
-         {:ok, params} <- StripeConnectAccountAdapter.to_params(stripe_account, attributes),
-         {:ok, %StripeConnectAccount{} = updated_account} <- account |> StripeConnectAccount.webhook_update_changeset(params) |> Repo.update
+         {:ok, params} <- StripeConnectAccountAdapter.to_params(stripe_account, attributes)
     do
-      {:ok, updated_account}
+      account |> StripeConnectAccount.webhook_update_changeset(params) |> Repo.update
+    end
+  end
+
+  @doc """
+  Used to update the local `StripeConnectAccount` record using data retrieved from the Stripe API
+  """
+  def update_from_stripe(id_from_stripe) do
+    with {:ok, %Stripe.Account{} = stripe_account} <- @api.Account.retrieve(id_from_stripe),
+         %StripeConnectAccount{} = local_account <- Repo.get_by(StripeConnectAccount, id_from_stripe: id_from_stripe),
+         {:ok, params} <- stripe_account |> StripeConnectAccountAdapter.to_params(%{})
+    do
+      local_account |> StripeConnectAccount.webhook_update_changeset(params) |> Repo.update
     else
-      {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
-      {:error, %Stripe.APIErrorResponse{} = error} -> {:error, error}
-      _ -> {:error, :unhandled}
+      # Not found locally
+      nil -> {:error, :not_found}
     end
   end
 end


### PR DESCRIPTION
# What's in this PR?

Figured this out while working on #625 

For consistency, I moved the code from the "account.updated" handler into `StripeConnectAccountService.update_from_stripe`.

I also removed some `else` cases from all 3 functions there, since they either just propagate the error response (basically doing nothing), or they outright swallow errors.

We should also add an issue, good for contributors to add a test for `StripeConnectAccountService.update_from_stripe/1`  - created #628
