### PR TITLE
Cleanup formatting & error handling in various stripe services

### DIFF
--- a/lib/code_corps/stripe_service/stripe_connect_account.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_account.ex
@@ -14,6 +14,8 @@ defmodule CodeCorps.StripeService.StripeConnectAccountService do
          {:ok, params} <- StripeConnectAccountAdapter.to_params(account, attributes)
     do
       %StripeConnectAccount{} |> StripeConnectAccount.create_changeset(params) |> Repo.insert
+    else
+      failure -> failure
     end
   end
 
@@ -40,8 +42,8 @@ defmodule CodeCorps.StripeService.StripeConnectAccountService do
     do
       local_account |> StripeConnectAccount.webhook_update_changeset(params) |> Repo.update
     else
-      # Not found locally
       nil -> {:error, :not_found}
+      failure -> failure
     end
   end
 end

--- a/lib/code_corps/stripe_service/stripe_connect_card.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_card.ex
@@ -10,10 +10,8 @@ defmodule CodeCorps.StripeService.StripeConnectCardService do
 
   def find_or_create(%StripePlatformCard{} = platform_card, %StripeConnectCustomer{} = connect_customer, %StripePlatformCustomer{} = platform_customer, %StripeConnectAccount{} = connect_account) do
     case get_from_db(connect_account.id, platform_card.id) do
-      %StripeConnectCard{} = existing_card ->
-        {:ok, existing_card}
-      nil ->
-        create(platform_card, connect_customer, platform_customer, connect_account)
+      %StripeConnectCard{} = existing_card -> {:ok, existing_card}
+      nil -> create(platform_card, connect_customer, platform_customer, connect_account)
     end
   end
 
@@ -22,8 +20,7 @@ defmodule CodeCorps.StripeService.StripeConnectCardService do
     do
       {:ok, updated_stripe_card}
     else
-      {:error, %Stripe.APIErrorResponse{} = error} -> {:error, error}
-      _ -> {:error, :unhandled}
+      failure -> failure
     end
   end
 

--- a/lib/code_corps/stripe_service/stripe_connect_customer.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_customer.ex
@@ -32,6 +32,8 @@ defmodule CodeCorps.StripeService.StripeConnectCustomerService do
       %StripeConnectCustomer{}
       |> StripeConnectCustomer.create_changeset(params)
       |> Repo.insert
+    else
+      failure -> failure
     end
   end
 

--- a/lib/code_corps/stripe_service/stripe_connect_external_account_service.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_external_account_service.ex
@@ -12,6 +12,8 @@ defmodule CodeCorps.StripeService.StripeConnectExternalAccountService do
       %StripeExternalAccount{}
       |> StripeExternalAccount.changeset(params)
       |> Repo.insert
+    else
+      failure -> failure
     end
   end
 

--- a/lib/code_corps/stripe_service/stripe_connect_plan.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_plan.ex
@@ -5,20 +5,31 @@ defmodule CodeCorps.StripeService.StripeConnectPlanService do
 
   @api Application.get_env(:code_corps, :stripe)
 
+  @doc """
+  Creates a new `Stripe.Plan` record on Stripe API, as well as an associated local
+  `StripeConnectPlan` record
+
+  # Possible return values
+
+  - `{:ok, %StripeConnectPlan{}}` - the created record.
+  - `{:error, %Ecto.Changeset{}}` - the record was not created due to validation issues.
+  - `{:error, :project_not_ready}` - the associated project does not meed the prerequisites for creating a plan.
+  - `{:error, %Stripe.APIErrorResponse{}}` - there was a problem with the stripe request
+  - `{:error, :not_found}` - one of the associated records was not found
+  """
   def create(%{"project_id" => project_id} = attributes) do
     with {:ok, %Project{} = project} <- get_project(project_id) |> ProjectCanEnableDonations.validate,
-         %{} = create_attributes     <- get_create_attributes(project_id),
-         connect_account_id          <- project.organization.stripe_connect_account.id_from_stripe,
-         {:ok, plan}                 <- @api.Plan.create(create_attributes, connect_account: connect_account_id),
-         {:ok, params}               <- StripeConnectPlanAdapter.to_params(plan, attributes)
+         %{} = create_attributes <- get_create_attributes(project_id),
+         connect_account_id <- project.organization.stripe_connect_account.id_from_stripe,
+         {:ok, plan} <- @api.Plan.create(create_attributes, connect_account: connect_account_id),
+         {:ok, params} <- StripeConnectPlanAdapter.to_params(plan, attributes)
     do
       %StripeConnectPlan{}
       |> StripeConnectPlan.create_changeset(params)
       |> Repo.insert
     else
-      {:error, :project_not_ready} -> {:error, :project_not_ready}
-      {:error, error} -> {:error, error}
       nil -> {:error, :not_found}
+      failure -> failure
     end
   end
 

--- a/lib/code_corps/stripe_service/stripe_invoice_service.ex
+++ b/lib/code_corps/stripe_service/stripe_invoice_service.ex
@@ -15,6 +15,8 @@ defmodule CodeCorps.StripeService.StripeInvoiceService do
       |> StripeInvoice.create_changeset(params)
       |> Repo.insert
       |> CodeCorps.Analytics.Segment.track(:payment_succeeded, nil)
+    else
+      failure -> failure
     end
   end
 


### PR DESCRIPTION
# What's in this PR?

Cleans up formatting and error handling in our `StripeService.xService` modules

Mostly what's done here is

* replaced some inline comments with actual `@doc` blocks
* removed all error handling that takes in a specific value type and returns it unchanged
* removed all `_ -> {:error, :unhandled}` statements, since this basically swallows error information and makes sentry useless for these cases
* added `failure -> failure` to all else blocks, so sentry can catch and log them at controller level.
* Got rid of vertically aligned formatting in the few modules that use it.
