### PR TITLE
Store object ids with events

### DIFF
--- a/lib/code_corps/stripe_service/adapters/stripe_event.ex
+++ b/lib/code_corps/stripe_service/adapters/stripe_event.ex
@@ -1,0 +1,61 @@
+defmodule CodeCorps.StripeService.Adapters.StripeEventAdapter do
+  import CodeCorps.MapUtils, only: [keys_to_string: 1]
+  import CodeCorps.StripeService.Util, only: [transform_map: 2]
+
+  # Mapping of stripe record attributes to locally stored attributes
+  # Format is {:local_key, [:nesting, :of, :stripe, :keys]}
+  @stripe_mapping [
+    {:id_from_stripe, [:id]},
+    {:type, [:type]},
+    {:user_id, [:user_id]}
+  ]
+
+  @doc """
+  Transforms a `%Stripe.Event{}` and a set of local attributes into a
+  map of parameters used to create or update a `StripeEvent` record.
+  """
+  def to_params(%Stripe.Event{} = stripe_event, %{} = attributes) do
+    result =
+      stripe_event
+      |> Map.from_struct
+      |> transform_map(@stripe_mapping)
+      |> add_non_stripe_attributes(attributes)
+      |> add_object_type(stripe_event)
+      |> add_object_id(stripe_event)
+      |> keys_to_string
+
+    {:ok, result}
+  end
+
+  # Names of attributes which we need to store localy,
+  # but are not part of the Stripe API record
+  @non_stripe_attributes ["endpoint", "status"]
+
+  defp add_non_stripe_attributes(%{} = params, %{} = attributes) do
+    attributes
+    |> get_non_stripe_attributes
+    |> add_to(params)
+  end
+
+  defp get_non_stripe_attributes(%{} = attributes) do
+    attributes |> Map.take(@non_stripe_attributes)
+  end
+
+  defp add_to(%{} = attributes, %{} = params) do
+    params |> Map.merge(attributes)
+  end
+
+  defp add_object_type(params, stripe_event) do
+    object_type =
+      stripe_event.data.object.__struct__
+      |> Module.split
+      |> List.last
+      |> Inflex.underscore
+
+    params |> Map.put(:object_type, object_type)
+  end
+
+  defp add_object_id(params, stripe_event) do
+    params |> Map.put(:object_id, stripe_event.data.object.id)
+  end
+end

--- a/lib/code_corps/stripe_testing/event.ex
+++ b/lib/code_corps/stripe_testing/event.ex
@@ -7,11 +7,15 @@ defmodule CodeCorps.StripeTesting.Event do
   end
 
   defp do_retrieve(_) do
-
     %Stripe.Event{
       api_version: "2016-07-06",
       created: 1479472835,
       id: "evt_123",
+      data: %{
+        object: %Stripe.Customer{
+          id: "cus_123"
+        }
+      },
       livemode: false,
       object: "event",
       pending_webhooks: 1,
@@ -25,6 +29,11 @@ defmodule CodeCorps.StripeTesting.Event do
       api_version: "2016-07-06",
       created: 1479472835,
       id: "evt_123",
+      data: %{
+        object: %Stripe.Customer{
+          id: "cus_123"
+        }
+      },
       livemode: false,
       object: "event",
       pending_webhooks: 1,

--- a/priv/repo/migrations/20170115035159_add_object_id_type_to_events.exs
+++ b/priv/repo/migrations/20170115035159_add_object_id_type_to_events.exs
@@ -1,0 +1,10 @@
+defmodule CodeCorps.Repo.Migrations.AddObjectIdTypeToEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stripe_events) do
+      add :object_id, :string, null: false
+      add :object_type, :string, null: false
+    end
+  end
+end

--- a/test/controllers/stripe_connect_events_controller_test.exs
+++ b/test/controllers/stripe_connect_events_controller_test.exs
@@ -107,7 +107,11 @@ defmodule CodeCorps.StripeConnectEventsControllerTest do
 
       wait_for_supervisor
 
-      assert StripeEvent |> Repo.aggregate(:count, :id) == 1
+      event =  StripeEvent |> Repo.one
+      {:ok, mock_api_event} = CodeCorps.StripeTesting.Event.retrieve("evt_123")
+
+      assert event.object_id == mock_api_event.data.object.id
+      assert event.object_type == "customer"
     end
 
     test "uses existing event if id exists", %{conn: conn} do

--- a/test/lib/code_corps/stripe_service/adapters/stripe_event_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_event_test.exs
@@ -1,0 +1,43 @@
+defmodule CodeCorps.StripeService.Adapters.StripeEventTest do
+  use CodeCorps.ModelCase
+
+  import CodeCorps.StripeService.Adapters.StripeEventAdapter, only: [to_params: 2]
+
+  @stripe_event %Stripe.Event{
+    api_version: nil,
+    created: nil,
+    data: %{
+      object: %Stripe.Customer{
+        id: "cus_123"
+      }
+    },
+    id: "evt_123",
+    livemode: false,
+    object: "event",
+    pending_webhooks: nil,
+    request: nil,
+    type: "some.event",
+    user_id: "act_123"
+  }
+
+  @attributes %{
+    "endpoint" => "connect"
+  }
+
+  @local_map %{
+    "endpoint" => "connect",
+    "id_from_stripe" => "evt_123",
+    "object_id" => "cus_123",
+    "object_type" => "customer",
+    "type" => "some.event",
+    "user_id" => "act_123"
+  }
+
+  describe "to_params/2" do
+    test "converts from stripe map to local properly" do
+
+      {:ok, result} = to_params(@stripe_event, @attributes)
+      assert result == @local_map
+    end
+  end
+end

--- a/test/models/stripe_event_test.exs
+++ b/test/models/stripe_event_test.exs
@@ -4,20 +4,29 @@ defmodule CodeCorps.StripeEventTest do
   alias CodeCorps.StripeEvent
 
   describe "create_changeset/2" do
-    @valid_attrs %{endpoint: "connect", id_from_stripe: "evt_123", type: "any.event"}
+    @valid_attrs %{
+      endpoint: "connect",
+      id_from_stripe: "evt_123",
+      object_id: "cus_123",
+      object_type: "customer",
+      type: "any.event"
+    }
 
     test "reports as valid when attributes are valid" do
       changeset = StripeEvent.create_changeset(%StripeEvent{}, @valid_attrs)
       assert changeset.valid?
     end
 
-    test "requires :id_from_stripe, :type" do
+    test "required params" do
       changeset = StripeEvent.create_changeset(%StripeEvent{}, %{})
 
       refute changeset.valid?
-      assert_error_message(changeset, :endpoint, "can't be blank")
-      assert_error_message(changeset, :id_from_stripe, "can't be blank")
-      assert_error_message(changeset, :type, "can't be blank")
+
+      assert_validation_triggered(changeset, :endpoint, :required)
+      assert_validation_triggered(changeset, :id_from_stripe, :required)
+      assert_validation_triggered(changeset, :object_id, :required)
+      assert_validation_triggered(changeset, :object_type, :required)
+      assert_validation_triggered(changeset, :type, :required)
     end
 
     test "sets :status to 'processing'" do

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -156,6 +156,8 @@ defmodule CodeCorps.Factories do
     %CodeCorps.StripeEvent{
       endpoint: sequence(:endpoint, fn(_) -> Enum.random(~w{ connect platform }) end),
       id_from_stripe: sequence(:id_from_stripe, &"stripe_id_#{&1}"),
+      object_id: "cus_123",
+      object_type: "customer",
       status: sequence(:status, fn(_) -> Enum.random(~w{ unprocessed processed errored }) end),
       type: "test.type"
     }

--- a/web/models/stripe_event.ex
+++ b/web/models/stripe_event.ex
@@ -24,6 +24,8 @@ defmodule CodeCorps.StripeEvent do
   schema "stripe_events" do
     field :endpoint, :string, null: false
     field :id_from_stripe, :string, null: false
+    field :object_id, :string
+    field :object_type, :string
     field :status, :string, default: "unprocessed"
     field :type, :string, null: false
     field :user_id, :string
@@ -37,8 +39,8 @@ defmodule CodeCorps.StripeEvent do
   """
   def create_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:endpoint, :id_from_stripe, :type, :user_id])
-    |> validate_required([:endpoint, :id_from_stripe, :type])
+    |> cast(params, [:endpoint, :id_from_stripe, :object_id, :object_type, :type, :user_id])
+    |> validate_required([:endpoint, :id_from_stripe, :object_id, :object_type, :type])
     |> put_change(:status, "processing")
     |> validate_inclusion(:status, states)
     |> validate_inclusion(:endpoint, endpoints)


### PR DESCRIPTION
# What's in this PR?

Added everything needed to store object ids and types with an event record.

This means that when a webhook event is stored locally, we also store information about the id and type of the object contained in the event.

## References
Fixes #617
