### PR TITLE
Set proper order for default task lists of a project

### DIFF
--- a/test/models/project_test.exs
+++ b/test/models/project_test.exs
@@ -62,6 +62,21 @@ defmodule CodeCorps.ProjectTest do
       changeset = Project.create_changeset(%Project{}, %{organization_id: 1})
       assert {:ok, 1} == changeset |> fetch_change(:organization_id)
     end
+
+    test "associates the ordered default task lists to the project" do
+      organization = insert(:organization)
+      changeset = Project.create_changeset(
+        %Project{},
+        %{organization_id: organization.id, title: "Title"}
+      )
+
+      {_, project} = Repo.insert(changeset)
+
+      task_list_orders = for task_list <- project.task_lists, do: task_list.order
+
+      assert Enum.all?(task_list_orders), "some of the orders are not set (nil)"
+      assert task_list_orders == Enum.sort(task_list_orders), "task lists order does not correspond to their position"
+    end
   end
 
   describe "update_changeset/2" do

--- a/web/models/task_list.ex
+++ b/web/models/task_list.ex
@@ -2,6 +2,8 @@ defmodule CodeCorps.TaskList do
   use CodeCorps.Web, :model
   import EctoOrdered
 
+  alias CodeCorps.TaskList
+
   schema "task_lists" do
     field :inbox, :boolean, default: false
     field :name, :string
@@ -33,7 +35,7 @@ defmodule CodeCorps.TaskList do
         name: "Done",
         position: 4
       }
-    ]
+    ] |> Enum.map(fn (params) -> changeset(%TaskList{}, params) end)
   end
 
   @doc """


### PR DESCRIPTION
# What's in this PR?

This PR changes `TaskList.default_task_lists/0` to return changesets, which means that the `order` of each `TaskList` is now properly set within the scope of a project via `TaskList.changeset/2`.

## References
Fixes #592 

Is effectively #622 but trying to rebase/squash.