### PR TITLE
Added unique constraint to member/organization of organization membership

### DIFF
--- a/test/models/organization_membership_test.exs
+++ b/test/models/organization_membership_test.exs
@@ -80,5 +80,18 @@ defmodule CodeCorps.OrganizationMembershipTest do
       assert result == :error
       changeset |> assert_error_message(:member, "does not exist")
     end
+
+    test "ensures uniqueness of organization/member combination" do
+      existing = insert(:organization_membership)
+
+      changeset = OrganizationMembership.create_changeset(
+        %OrganizationMembership{},
+        %{member_id: existing.member_id, organization_id: existing.organization_id}
+      )
+
+      {:error, changeset} = changeset |> Repo.insert
+
+      changeset |> assert_error_message(:member, "has already been taken")
+    end
   end
 end

--- a/web/models/organization_membership.ex
+++ b/web/models/organization_membership.ex
@@ -24,6 +24,7 @@ defmodule CodeCorps.OrganizationMembership do
     |> validate_required([:member_id, :organization_id])
     |> assoc_constraint(:member)
     |> assoc_constraint(:organization)
+    |> unique_constraint(:member, name: :organization_memberships_member_id_organization_id_index)
     |> put_change(:role, "pending")
   end
 


### PR DESCRIPTION
# What's in this PR?

We already have a unique index for `{:member_id, :organization_id}`, so really, the constraint on the changeset was missing in order to generate the validation error correctly.

## References
Fixes #535