### PR TITLE
Fix issue with Adapters.StripeEvent.to_params for an event containing a balance object

### DIFF
--- a/test/lib/code_corps/stripe_service/adapters/stripe_event_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_event_test.exs
@@ -34,11 +34,47 @@ defmodule CodeCorps.StripeService.Adapters.StripeEventTest do
     "user_id" => "act_123"
   }
 
+  @stripe_event_for_balance_available %Stripe.Event{
+    api_version: nil,
+    created: nil,
+    data: %{
+      # NOTE: stripity_stripe does not serialize Balance objects yet.
+      # Once it does, this map should be replaced with a Stripe.Balance struct
+      object: %{
+        available: [%{amount: 0, currency: "usd", source_types: %{card: 0}}],
+        connect_reserved: [%{amount: 0, currency: "usd"}],
+        livemode: false,
+        object: "balance",
+        pending: [%{amount: 0, currency: "usd", source_types: %{card: 0}}]
+      }
+    },
+    id: "evt_balance",
+    livemode: false,
+    object: "event",
+    pending_webhooks: nil,
+    request: nil,
+    type: "balance.available",
+    user_id: "act_with_balance"
+  }
+
+  @local_map_for_balance_available %{
+    "endpoint" => "connect",
+    "id_from_stripe" => "evt_balance",
+    "object_id" => nil,
+    "object_type" => "balance",
+    "type" => "balance.available",
+    "user_id" => "act_with_balance"
+  }
+
   describe "to_params/2" do
     test "converts from stripe map to local properly" do
-
       {:ok, result} = to_params(@stripe_event, @attributes)
       assert result == @local_map
+    end
+
+    test "works with balance.available event" do
+      {:ok, result} = to_params(@stripe_event_for_balance_available, @attributes)
+      assert result == @local_map_for_balance_available
     end
   end
 end


### PR DESCRIPTION
# What's in this PR?

Simply put, a balance object does not have an id. Our code was expecting an id, to be stored as part of `StripeEvent.object_id`. With this change, a `nil` is allowed, so the adapter will not fail anymore.

We have a discussion in #689 about this fix being enough, or if more is needed.

## References
Fixes #689
