### PR TITLE
Update stripity_stripe. Update stripe fixtures to account for changes.

### DIFF
--- a/lib/code_corps/stripe_testing/account.ex
+++ b/lib/code_corps/stripe_testing/account.ex
@@ -6,7 +6,7 @@ defmodule CodeCorps.StripeTesting.Account do
   end
 
   def retrieve("account_with_multiple_external_accounts") do
-    {:ok, load_fixture(Stripe.Account, "account_with_multiple_external_accounts")}
+    {:ok, load_fixture("account_with_multiple_external_accounts")}
   end
 
   def retrieve(id) do
@@ -25,7 +25,7 @@ defmodule CodeCorps.StripeTesting.Account do
       |> add_nestings
 
 
-    Stripe.Account |> Stripe.Converter.stripe_map_to_struct(transformed_attributes)
+    Stripe.Converter.stripe_map_to_struct(transformed_attributes)
   end
 
   defp account_fixture do
@@ -47,6 +47,7 @@ defmodule CodeCorps.StripeTesting.Account do
         "url" => "/v1/accounts/acct_123/external_accounts"
       },
       "id" => "acct_123",
+      "object" => "account",
       "managed" => true,
       "metadata" => %{},
       "statement_descriptor" => "CODECORPS.ORG",

--- a/lib/code_corps/stripe_testing/charge.ex
+++ b/lib/code_corps/stripe_testing/charge.ex
@@ -2,6 +2,6 @@ defmodule CodeCorps.StripeTesting.Charge do
   import CodeCorps.StripeTesting.Helpers
 
   def retrieve(id, _opts) do
-    {:ok, load_fixture(Stripe.Charge, id)}
+    {:ok, load_fixture(id)}
   end
 end

--- a/lib/code_corps/stripe_testing/helpers.ex
+++ b/lib/code_corps/stripe_testing/helpers.ex
@@ -1,14 +1,18 @@
 defmodule CodeCorps.StripeTesting.Helpers do
+  @moduledoc """
+  Used to load JSON fitures which simulate Stripe API responses into
+  stripity_stripe structs
+  """
   @fixture_path "./lib/code_corps/stripe_testing/fixtures/"
 
   @doc """
   Load a stripe response fixture through stripity_stripe, into a
   stripity_stripe struct
   """
-  @spec load_fixture(module, String.t) :: struct
-  def load_fixture(module, id) do
+  @spec load_fixture(String.t) :: struct
+  def load_fixture(id) do
     fixture_map = id |> build_file_path |> File.read! |> Poison.decode!
-    Stripe.Converter.stripe_map_to_struct(module, fixture_map)
+    Stripe.Converter.stripe_map_to_struct(fixture_map)
   end
 
   defp build_file_path(id), do: id |> append_extension |> join_with_path

--- a/lib/code_corps/stripe_testing/invoice.ex
+++ b/lib/code_corps/stripe_testing/invoice.ex
@@ -2,6 +2,6 @@ defmodule CodeCorps.StripeTesting.Invoice do
   import CodeCorps.StripeTesting.Helpers
 
   def retrieve(id, _opts) do
-    {:ok, load_fixture(Stripe.Invoice, id)}
+    {:ok, load_fixture(id)}
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -60,7 +60,7 @@
   "segment": {:hex, :segment, "0.1.1", "47bf9191590e7a533c105d1e21518e0d6da47c91e8d98ebb649c624db5dfc359", [:mix], [{:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}, {:poison, "~> 1.3 or ~> 2.0", [hex: :poison, optional: false]}]},
   "sentry": {:hex, :sentry, "2.1.0", "51e7ca261b519294ac73b30763893c4a7ad2005205514aefa5bf37ccb83e44ea", [:mix], [{:hackney, "~> 1.6.1", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: true]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}, {:uuid, "~> 1.0", [hex: :uuid, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
-  "stripity_stripe": {:git, "https://github.com/code-corps/stripity_stripe.git", "fab5b573f327f760d51949488bab30c2eae346b5", [branch: "2.0"]},
+  "stripity_stripe": {:git, "https://github.com/code-corps/stripity_stripe.git", "6a394e8254551b4da112236e529cd829926534d1", [branch: "2.0"]},
   "sweet_xml": {:hex, :sweet_xml, "0.6.4", "5d613e63033b1d6362898f3f1d65f70a352b32d4b32e1367bb20b8c2e30ba79d", [:mix], []},
   "timber": {:hex, :timber, "0.4.7", "df3fcd79bcb4eb4b53874d906ef5f3a212937b4bc7b7c5b244745202cc389443", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: true]}, {:phoenix, "~> 1.2", [hex: :phoenix, optional: true]}, {:plug, "~> 1.2", [hex: :plug, optional: true]}, {:poison, "~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "timex": {:hex, :timex, "3.0.8", "71d5ebafcdc557c6c866cdc196c5054f587e7cd1118ad8937e2293d51fc85608", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},

--- a/test/lib/code_corps/emails/receipt_email_test.exs
+++ b/test/lib/code_corps/emails/receipt_email_test.exs
@@ -5,7 +5,7 @@ defmodule CodeCorps.Emails.ReceiptEmailTest do
   alias CodeCorps.Emails.ReceiptEmail
 
   test "receipt email works" do
-    invoice_fixture = CodeCorps.StripeTesting.Helpers.load_fixture(Stripe.Invoice, "invoice")
+    invoice_fixture = CodeCorps.StripeTesting.Helpers.load_fixture("invoice")
 
     user = insert(:user, email: "jimmy@mail.com", first_name: "Jimmy")
 

--- a/test/lib/code_corps/stripe_service/adapters/stripe_connect_account_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_connect_account_test.exs
@@ -6,7 +6,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectAccountTest do
   defp test_account() do
     # If a `Stripe.Account` has multiple `Stripe.ExternalAccount` records, we want
     # the adapter to deal with that by only taking one, so we load the appropriate fixture
-    CodeCorps.StripeTesting.Helpers.load_fixture(Stripe.Account, "account_with_multiple_external_accounts")
+    CodeCorps.StripeTesting.Helpers.load_fixture("account_with_multiple_external_accounts")
   end
 
   @local_map %{

--- a/test/lib/code_corps/stripe_service/adapters/stripe_connect_charge_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_connect_charge_test.exs
@@ -6,7 +6,7 @@ defmodule CodeCorps.StripeService.Adapters.StripeConnectChargeTest do
   describe "to_params/2" do
     test "adds customer and user id if those records exist" do
       # load a predefined fixture to use for adapter testing
-      fixture = CodeCorps.StripeTesting.Helpers.load_fixture(Stripe.Charge, "charge")
+      fixture = CodeCorps.StripeTesting.Helpers.load_fixture("charge")
 
       account = insert(:stripe_connect_account)
 

--- a/test/lib/code_corps/stripe_service/events/connect_charge_succeeded_test.exs
+++ b/test/lib/code_corps/stripe_service/events/connect_charge_succeeded_test.exs
@@ -14,11 +14,11 @@ defmodule CodeCorps.StripeService.Events.ConnectChargeSucceededTest do
   test "handling event creates charge and sends receipt" do
     account = insert(:stripe_connect_account)
 
-    charge_fixture = StripeTesting.Helpers.load_fixture(Stripe.Charge, "charge")
+    charge_fixture = StripeTesting.Helpers.load_fixture("charge")
 
     insert(:stripe_connect_customer, id_from_stripe: charge_fixture.customer)
 
-    invoice_fixture = StripeTesting.Helpers.load_fixture(Stripe.Invoice, charge_fixture.invoice)
+    invoice_fixture = StripeTesting.Helpers.load_fixture(charge_fixture.invoice)
     insert(:stripe_connect_subscription, id_from_stripe: invoice_fixture.subscription)
 
     project = Repo.one(Project)

--- a/test/lib/code_corps/stripe_service/stripe_connect_charge_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_connect_charge_service_test.exs
@@ -9,7 +9,7 @@ defmodule CodeCorps.StripeService.StripeConnectChargeServiceTest do
   describe "create" do
     test "creates a StripeConnectCharge, with proper associations" do
       # we load in the fixture we will be using, so we have access to the data it contains
-      fixture = StripeTesting.Helpers.load_fixture(Stripe.Charge, "charge")
+      fixture = StripeTesting.Helpers.load_fixture("charge")
       customer = insert(:stripe_connect_customer, id_from_stripe: fixture.customer)
 
       # service expects a Stripe.Charge id, so we pass in an id for a predefined fixture we have

--- a/test/lib/code_corps/stripe_service/stripe_invoice_service_test.exs
+++ b/test/lib/code_corps/stripe_service/stripe_invoice_service_test.exs
@@ -8,7 +8,7 @@ defmodule CodeCorps.StripeService.StripeInvoiceServiceTest do
 
   describe "create" do
     test "creates a StripeInvoice" do
-      invoice_fixture = CodeCorps.StripeTesting.Helpers.load_fixture(Stripe.Invoice, "invoice")
+      invoice_fixture = CodeCorps.StripeTesting.Helpers.load_fixture("invoice")
 
       subscription = insert(:stripe_connect_subscription, id_from_stripe: invoice_fixture.subscription)
       connect_customer = insert(:stripe_connect_customer, id_from_stripe: invoice_fixture.customer)

--- a/test/lib/code_corps/stripe_service/webhook_processing/event_handler_test.exs
+++ b/test/lib/code_corps/stripe_service/webhook_processing/event_handler_test.exs
@@ -82,10 +82,10 @@ defmodule CodeCorps.StripeService.WebhookProcessing.EventHandlerTest do
     test "handles charge.succeeded as processed when everything is in order" do
       connect_account = insert(:stripe_connect_account)
 
-      charge_fixture = StripeTesting.Helpers.load_fixture(Stripe.Charge, "charge")
+      charge_fixture = StripeTesting.Helpers.load_fixture("charge")
       insert(:stripe_connect_customer, id_from_stripe: charge_fixture.customer)
 
-      invoice_fixture = StripeTesting.Helpers.load_fixture(Stripe.Invoice, charge_fixture.invoice)
+      invoice_fixture = StripeTesting.Helpers.load_fixture(charge_fixture.invoice)
       insert(:stripe_connect_subscription, id_from_stripe: invoice_fixture.subscription)
 
       project = Repo.one(Project)
@@ -101,7 +101,7 @@ defmodule CodeCorps.StripeService.WebhookProcessing.EventHandlerTest do
 
     test "handles charge.succeeded as errored when something goes wrong with email" do
       connect_account = insert(:stripe_connect_account)
-      charge_fixture = StripeTesting.Helpers.load_fixture(Stripe.Charge, "charge")
+      charge_fixture = StripeTesting.Helpers.load_fixture("charge")
 
       insert(:stripe_connect_customer, id_from_stripe: charge_fixture.customer)
 
@@ -114,7 +114,7 @@ defmodule CodeCorps.StripeService.WebhookProcessing.EventHandlerTest do
     end
 
     test "handles charge.succeeded as errored when something goes wrong with creating a charge" do
-      charge_fixture = StripeTesting.Helpers.load_fixture(Stripe.Charge, "charge")
+      charge_fixture = StripeTesting.Helpers.load_fixture("charge")
 
       event = build_event("charge.succeeded", "charge", charge_fixture, "bad_account")
       {:ok, event} = EventHandler.handle(event, ConnectEventHandler, "bad_account")
@@ -185,7 +185,7 @@ defmodule CodeCorps.StripeService.WebhookProcessing.EventHandlerTest do
     end
 
     test "handles invoice.payment_succeeded" do
-      fixture = StripeTesting.Helpers.load_fixture(Stripe.Invoice, "invoice")
+      fixture = StripeTesting.Helpers.load_fixture("invoice")
 
       insert(:stripe_connect_subscription, id_from_stripe: fixture.subscription)
 


### PR DESCRIPTION
# What's in this PR?

We've updated stripity_stripe internally to remove reliance on passing in the module for `Converter.stripe_map_to_struct`. Sadly, since we're forced to use those internals for our own testing here, I had to do some minor updates around our testing code to make it work with the new version.
