### PR TITLE
Add unit test for CodeCorps.Helpers.CloudinaryUrl and RandomIconColor

### DIFF
--- a/lib/code_corps/helpers/cloudex_test.ex
+++ b/lib/code_corps/helpers/cloudex_test.ex
@@ -1,0 +1,13 @@
+defmodule Cloudex.CloudinaryApi.Test do
+  @moduledoc """
+  Testing stub for `Cloudex`,
+
+  Each function should have the same signature as `Cloudex`.
+  """
+
+  defmodule Url do
+    def for(public_id, options) do
+      {public_id, options}
+    end
+  end
+end

--- a/lib/code_corps/helpers/cloudinary_url.ex
+++ b/lib/code_corps/helpers/cloudinary_url.ex
@@ -1,9 +1,11 @@
 defmodule CodeCorps.Helpers.CloudinaryUrl do
 
+  @cloudex Application.get_env(:cloudex, :cloudinary_api)
+
   def for(nil, _options, version, default_color, type) do
     "#{Application.get_env(:code_corps, :asset_host)}/icons/#{type}_default_#{version}_#{default_color}.png"
   end
   def for(public_id, options, _version, _default_color, _type) do
-    Cloudex.Url.for(public_id, options)
+    @cloudex.Url.for(public_id, options)
   end
 end

--- a/test/lib/code_corps/helpers/cloudinary_url_test.exs
+++ b/test/lib/code_corps/helpers/cloudinary_url_test.exs
@@ -1,0 +1,15 @@
+defmodule CodeCorps.Helpers.CloudinaryUrlTest do
+  use ExUnit.Case, async: true
+
+  test "calls Cloudex.Url.for with correct arguments" do
+    expected_args = {:test_public_id, %{test_option: nil}}
+    args = CodeCorps.Helpers.CloudinaryUrl.for(:test_public_id, %{test_option: nil}, nil, nil, nil)
+    assert expected_args == args
+  end
+
+  test "returns correct url if called without public_id" do
+    expected_url = "#{Application.get_env(:code_corps, :asset_host)}/icons/type1_default_version1_color1.png"
+    url = CodeCorps.Helpers.CloudinaryUrl.for(nil, %{}, "version1", "color1", "type1")
+    assert expected_url == url
+  end
+end

--- a/test/lib/code_corps/helpers/random_icon_color_test.exs
+++ b/test/lib/code_corps/helpers/random_icon_color_test.exs
@@ -1,0 +1,17 @@
+defmodule CodeCorps.RandomIconColor.RandomIconColorTest do
+  use ExUnit.Case, async: true
+  import CodeCorps.Helpers.RandomIconColor
+  import Ecto.Changeset
+
+  test "inserts color into changeset" do
+    changeset = generate_icon_color(cast({%{}, %{}}, %{}, []), :color_key)
+    assert get_field(changeset, :color_key) == "blue"
+  end
+
+  test "ignores invalid changeset" do
+    changeset = {%{}, %{color_key: :required}}
+      |> cast(%{}, [])
+      |> validate_required(:color_key)
+    assert generate_icon_color(changeset, :color_key) == changeset
+  end
+end


### PR DESCRIPTION
Added tests for:
lib/code_corps/helpers/cloudinary_url.ex
lib/code_corps/helpers/random_icon_color.ex

Moved `Cloudex` to configuration to allow testing.
## References
Closes #675 
