### PR TITLE
Add test support for Cloudex

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -61,3 +61,12 @@ config :code_corps, CodeCorps.Mailer,
 
 config :code_corps,
   postmark_receipt_template: "123"
+
+# If the dev environment has no CLOUDEX_API_KEY set, we want the app to still run,
+# with cloudex in test API mode
+if System.get_env("CLOUDEX_API_KEY") == nil do
+  config :cloudex, :cloudinary_api, Cloudex.CloudinaryApi.Test
+  config :cloudex, api_key: "test_key", secret: "test_secret", cloud_name: "test_cloud_name"
+
+  IO.puts("NOTE: No Cloudex configuration found. Cloudex is runnning in test mode.")
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -49,3 +49,6 @@ config :code_corps, CodeCorps.Mailer,
 
 config :code_corps,
   postmark_receipt_template: "123"
+
+config :cloudex, :cloudinary_api, Cloudex.CloudinaryApi.Test
+config :cloudex, api_key: "test_key", secret: "test_secret", cloud_name: "test_cloud_name"


### PR DESCRIPTION
# What's in this PR?

This PR makes it so Cloudex can run in dev and test mode, even if the API keys are missing. Without this, the application will not start in either of the two modes.

I thought we had an issue for this, but I cannot find it. With this and #694, Cloudex should work much better.
