### PR TITLE
Expose task skills on task model and view

### DIFF
--- a/test/views/task_view_test.exs
+++ b/test/views/task_view_test.exs
@@ -4,6 +4,7 @@ defmodule CodeCorps.TaskViewTest do
   test "renders all attributes and relationships properly" do
     task = insert(:task, order: 1000)
     comment = insert(:comment, task: task)
+    task_skill = insert(:task_skill, task: task)
 
     rendered_json =  render(CodeCorps.TaskView, "show.json-api", data: task)
 
@@ -36,6 +37,14 @@ defmodule CodeCorps.TaskViewTest do
               "id" => task.project_id |> Integer.to_string,
               "type" => "project"
             }
+          },
+          "task-skills" => %{
+            "data" => [
+              %{
+                "id" => task_skill.id |> Integer.to_string,
+                "type" => "task-skill"
+              }
+            ]
           },
           "user" => %{
             "data" => %{

--- a/web/models/task.ex
+++ b/web/models/task.ex
@@ -24,6 +24,7 @@ defmodule CodeCorps.Task do
     belongs_to :user, CodeCorps.User
 
     has_many :comments, CodeCorps.Comment
+    has_many :task_skills, CodeCorps.TaskSkill
 
     timestamps()
   end

--- a/web/views/task_view.ex
+++ b/web/views/task_view.ex
@@ -1,5 +1,6 @@
 defmodule CodeCorps.TaskView do
-  use CodeCorps.PreloadHelpers, default_preloads: [:project, :user, :task_list, :comments]
+  use CodeCorps.PreloadHelpers,
+      default_preloads: [:project, :user, :task_list, :task_skills, :comments]
   use CodeCorps.Web, :view
   use JaSerializer.PhoenixView
 
@@ -10,4 +11,5 @@ defmodule CodeCorps.TaskView do
   has_one :task_list, serializer: CodeCorps.TaskListView
 
   has_many :comments, serializer: CodeCorps.CommentView, identifiers: :always
+  has_many :task_skills, serializer: CodeCorps.TaskSkillView, identifiers: :always
 end


### PR DESCRIPTION
# What's in this PR?

Exposes task skills on task model and view. We missed this on the first pass of adding task-skill endpoints.

## References
Required for code-corps/code-corps-ember#1045
