### PR TITLE
Add user filter by first, last, username

### DIFF
--- a/lib/code_corps/helpers/query.ex
+++ b/lib/code_corps/helpers/query.ex
@@ -65,6 +65,21 @@ defmodule CodeCorps.Helpers.Query do
 
   # end comment queries
 
+  # user queries
+
+  def user_filter(query, %{"query" => query_string}) do
+    query
+    |> where(
+      [object],
+      ilike(object.first_name, ^"%#{query_string}%") or
+      ilike(object.last_name, ^"%#{query_string}%") or
+      ilike(object.username, ^"%#{query_string}%")
+    )
+  end
+  def user_filter(query, _), do: query
+
+  # end user queries
+
   # sorting
 
   def sort_by_newest_first(query), do: query |> order_by([desc: :inserted_at])

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -44,6 +44,32 @@ defmodule CodeCorps.UserControllerTest do
       |> json_response(200)
       |> assert_ids_from_response([user_1.id, user_2.id])
     end
+
+    test "returns search results on index", %{conn: conn} do
+      user_1 = insert(:user, first_name: "Joe")
+      user_2 = insert(:user, username: "joecoder")
+      user_3 = insert(:user, last_name: "Jacko")
+      insert(:user, first_name: "Max")
+
+      params = %{"query" => "j"}
+      path = conn |> user_path(:index, params)
+
+      conn
+      |> get(path)
+      |> json_response(200)
+      |> assert_ids_from_response([user_1.id, user_2.id, user_3.id])
+    end
+
+    test "limit filter limits results on index", %{conn: conn} do
+      insert_list(6, :user)
+
+      params = %{"limit" => 5}
+      path = conn |> user_path(:index, params)
+      json = conn |> get(path) |> json_response(200)
+
+      returned_users_length = json["data"] |> length
+      assert returned_users_length == 5
+    end
   end
 
   describe "show" do

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -2,7 +2,7 @@ defmodule CodeCorps.UserController do
   use CodeCorps.Web, :controller
   use JaResource
 
-  import CodeCorps.Helpers.Query, only: [id_filter: 2]
+  import CodeCorps.Helpers.Query, only: [id_filter: 2, user_filter: 2, limit_filter: 2]
 
   alias CodeCorps.User
   alias CodeCorps.Services.UserService
@@ -13,6 +13,12 @@ defmodule CodeCorps.UserController do
 
   def filter(_conn, query, "id", id_list) do
     query |> id_filter(id_list)
+  end
+
+  def handle_index(_conn, params) do
+    User
+    |> user_filter(params)
+    |> limit_filter(params)
   end
 
   def handle_create(_conn, attributes) do


### PR DESCRIPTION
# What's in this PR?

Adds the ability to do basic filtering on the user endpoint. The query filters by first name, last name or username and limits to 5 results. I have little to no experience  with elastic search so this felt like a preferable first step, with the intention of pushing it out as quickly as possible.
