### PR TITLE
Add syntax highlighting to markdown

### DIFF
--- a/lib/code_corps/services/markdown_renderer.ex
+++ b/lib/code_corps/services/markdown_renderer.ex
@@ -16,7 +16,9 @@ defmodule CodeCorps.Services.MarkdownRendererService do
 
   @spec convert_into_html(String.t) :: String.t
   defp convert_into_html(markdown) do
-    Earmark.as_html!(markdown)
+    # Prism.js requires a `language-` prefix in code classes
+    # See: https://github.com/pragdave/earmark#syntax-highlightning
+    Earmark.as_html!(markdown, %Earmark.Options{code_class_prefix: "language-"})
   end
 
   @spec put_into(String.t, Changeset.t, atom) :: Changeset.t

--- a/test/lib/code_corps/services/markdown_renderer_test.exs
+++ b/test/lib/code_corps/services/markdown_renderer_test.exs
@@ -21,6 +21,16 @@ defmodule CodeCorps.Services.MarkdownRendererServiceTest do
     assert changeset |> Ecto.Changeset.get_change(:body) == "<p>A <strong>strong</strong> body</p>\n"
   end
 
+  test "adds the right css class prefixes" do
+    attrs = @valid_attrs |> Map.merge(%{markdown: "```css\nspan {}\n```"})
+    changeset =
+      %Task{}
+      |> Task.changeset(attrs)
+      |> render_markdown_to_html(:markdown, :body)
+
+    assert changeset |> Ecto.Changeset.get_change(:body) == "<pre><code class=\"css language-css\">span {}</code></pre>\n"
+  end
+
   test "returns changeset when changeset is invalid" do
     changeset =
       %Task{}


### PR DESCRIPTION
# What's in this PR?

Adds syntax highlighting to markdown rendering via the appropriate CSS class name prefixes.