### PR TITLE
Allow setting user state to 'signed_up_donating' on registration

### DIFF
--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -63,6 +63,17 @@ defmodule CodeCorps.UserTest do
       refute changeset.valid?
       assert_error_message(changeset, :username, "has already been taken")
     end
+
+    test "allows setting state to 'signed_up_donating'" do
+      attrs = @valid_attrs |> Map.put(:state, "signed_up_donating")
+      changeset = User.registration_changeset(%User{}, attrs)
+      assert changeset.valid?
+      assert changeset |> Ecto.Changeset.get_change(:state) == "signed_up_donating"
+
+      attrs = @valid_attrs |> Map.put(:state, "selected_skills")
+      changeset = User.registration_changeset(%User{}, attrs)
+      refute changeset.valid?
+    end
   end
 
   describe "update_changeset" do

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -71,11 +71,11 @@ defmodule CodeCorps.User do
   def registration_changeset(struct, params) do
     struct
     |> changeset(params)
-    |> cast(params, [:password, :username])
-    |> validate_required(:password)
-    |> validate_required(:username)
+    |> cast(params, [:password, :username, :state])
+    |> validate_required([:password, :username])
     |> validate_length(:password, min: 6)
     |> validate_length(:username, min: 1, max: 39)
+    |> validate_inclusion(:state, ["signed_up_donating"])
     |> validate_slug(:username)
     |> unique_constraint(:username, name: :users_lower_username_index)
     |> unique_constraint(:email)


### PR DESCRIPTION
# What's in this PR?

This PR makes some progress on #706, but it diverges from the task description.

The problem is, there is no `"signed_up"` `state_transition`. There is the `"signed_up"` `state`, which is the user model default. With that in mind, it's much easier to simply allow for initial setting of `state` to something like `signed_up_donating` instead of falling back to default.

The advantages of this are

- There is no need to migrate existing data.
- The normal flow is `signed_up -> edited_profile -> selected_categories -> selected_roles -> selected_skills`.
- The changes add an alternative path, which replaces the `signed_up` step with `signed_up_donating > donated`. This means that the state transition is kept relatively simple.

On the client side, we have additional flexibility with this. Right now, there is no enforcement to go back to donating once signed up from the donate page. 

Instead, the client session service will simply redirect back, but the user can quit at that point and we can (in a separate client PR) decide how e want to handle such a situation. 

## References

Progress on: #706 
Related to https://github.com/code-corps/code-corps-ember/pull/1183
