### PR TITLE
791 - Associate user with github account

### DIFF
--- a/lib/code_corps/github.ex
+++ b/lib/code_corps/github.ex
@@ -1,0 +1,10 @@
+defmodule CodeCorps.Github do
+
+  alias CodeCorps.{User, Repo}
+
+  def associate(user, params) do
+    user
+    |> User.github_associate_changeset(params)
+    |> Repo.update()
+  end
+end

--- a/priv/repo/migrations/20170424215355_add-github-id-to-user.exs
+++ b/priv/repo/migrations/20170424215355_add-github-id-to-user.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.CodeCorps.Repo.Migrations.Add-github-id-to-user" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :github_id, :string
+    end
+  end
+end

--- a/test/lib/code_corps/github_test.exs
+++ b/test/lib/code_corps/github_test.exs
@@ -1,0 +1,20 @@
+defmodule CodeCorps.GithubTest do
+  use CodeCorps.ModelCase
+  alias CodeCorps.Github
+
+  describe "associate/2" do
+    test "should update the user with the github_id" do
+      user = insert(:user)
+      params = %{github_id: "foobar"}
+      {:ok, result} = Github.associate(user, params)
+      assert result.github_id == "foobar"
+    end
+
+    test "should return the error with a changeset" do
+      user = insert(:user)
+      params = %{}
+      {:error, changeset} = Github.associate(user, params)
+      refute changeset.valid?
+    end
+  end
+end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -140,6 +140,20 @@ defmodule CodeCorps.UserTest do
     end
   end
 
+  describe "github_associate_changeset" do
+    test "should cast github_id" do
+      user = insert(:user)
+      changeset = user |> User.github_associate_changeset(%{github_id: "foobar"})
+      assert changeset.valid?
+      assert changeset.changes.github_id == "foobar"
+    end
+    test "github_id should be required" do
+      user = insert(:user)
+      changeset = user |> User.github_associate_changeset(%{})
+      refute changeset.valid?
+    end
+  end
+
   test "reset_password_changeset with valid passwords" do
     changeset = User.reset_password_changeset(%User{}, %{password: "foobar", password_confirmation: "foobar"})
     assert changeset.valid?

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -30,7 +30,7 @@ defmodule CodeCorps.User do
     field :twitter, :string
     field :username, :string
     field :website, :string
-
+    field :github_id, :string
     field :state, :string, default: "signed_up"
     field :state_transition, :string, virtual: true
 
@@ -93,6 +93,12 @@ defmodule CodeCorps.User do
     |> validate_format(:website, CodeCorps.Helpers.URL.valid_format())
     |> validate_format(:twitter, ~r/\A[a-zA-Z0-9_]{1,15}\z/)
     |> apply_state_transition(struct)
+  end
+
+  def github_associate_changeset(struct, params) do
+    struct
+    |> cast(params, [:github_id])
+    |> validate_required([:github_id])
   end
 
   def reset_password_changeset(struct, params) do


### PR DESCRIPTION
# What's in this PR?
* Adds a new `github_id` field on the user.
* Adds a new GitHub association changeset for the user
* Adds a new GitHub module that performs associations to a user. 

My only concern is the `Github` module. I'm not sure if that's where that file should live or if it should be in the services folder. Would love some feedback @begedin @JoshSmith 

## References
Fixes #791

Progress on: Milestone 11
