### PR TITLE
GitHub connect user controller action

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -2265,6 +2265,32 @@ This endpoint handles the User resources for Code Corps.
 
     + Attributes (Record Not Found Response)
 
+### Connect user to GitHub [POST /github_connect]
+
+This endpoint allows a user to connect their CodeCorps account to their respective GitHub account.
+
++ Request
+
+    + Attributes
+
+      + code (string) - Client generated code for authenication when sending request to GitHub.
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
++ Response 201 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (User Response)
+
++ Response 401 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (JSON Web Token Invalid Response)
+
++ Response 422 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Unprocessable Entity Response)
+
 ### Check email availability [GET /users/email_available?email={email}]
 
 This endpoint allows you to check whether an email is valid (by checking simply for presence of the `@` symbol) and whether the email is not already registered.

--- a/lib/code_corps/github.ex
+++ b/lib/code_corps/github.ex
@@ -2,6 +2,11 @@ defmodule CodeCorps.Github do
 
   alias CodeCorps.{User, Repo}
 
+  @doc """
+  Temporary function until the actual behavior is implemented.
+  """
+  def connect(user, _code), do: {:ok, user}
+
   def associate(user, params) do
     user
     |> User.github_associate_changeset(params)

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -242,13 +242,34 @@ defmodule CodeCorps.UserControllerTest do
     end
   end
 
+  describe "github_connect" do
+    test "return the user when current user connects successfully", %{conn: conn} do
+      user = insert(:user)
+
+      code = %{"code" => "client generated code"}
+
+      path = user_path(conn, :github_connect, code)
+
+      json = conn |> authenticate(user) |> post(path) |> json_response(200)
+
+      assert json["data"]["id"] |> String.to_integer == user.id
+    end
+
+    test "return unauthenticated error code when no current user", %{conn: conn} do
+      code = %{"code" => "client generated code"}
+
+      path = user_path(conn, :github_connect, code)
+
+      conn |> post(path) |> json_response(401)
+    end
+  end
+
   describe "email_available" do
     test "returns valid and available when email is valid and available", %{conn: conn} do
       resp = get conn, user_path(conn, :email_available, %{email: "available@mail.com"})
       json = json_response(resp, 200)
       assert json["available"]
       assert json["valid"]
-
     end
 
     test "returns valid but inavailable when email is valid but taken", %{conn: conn} do

--- a/web/router.ex
+++ b/web/router.ex
@@ -63,6 +63,7 @@ defmodule CodeCorps.Router do
     resources "/categories", CategoryController, only: [:create, :update]
     resources "/comments", CommentController, only: [:create, :update]
     resources "/donation-goals", DonationGoalController, only: [:create, :update, :delete]
+    post "/github-connect", UserController, :github_connect
     resources "/organizations", OrganizationController, only: [:create, :update]
     post "/password/reset", PasswordResetController, :reset_password
     resources "/previews", PreviewController, only: [:create]


### PR DESCRIPTION
# What's in this PR?

Adds the `/github_connect` endpoint to hit the currently temp `connect` function under the Github lib file

- [x] Add the `POST /github-connect` route
- [x] Add the `UserController.github_connect/2` action. It 
- [x] Add a user controller test for this action.
- [x] Update documentation

## References
Fixes #788 

Progress on: Milestone 11