### PR TITLE
Fix 500 error with Postmark and email encoding

### DIFF
--- a/config/staging.exs
+++ b/config/staging.exs
@@ -59,7 +59,7 @@ config :code_corps, CodeCorps.Mailer,
   api_key: System.get_env("POSTMARK_API_KEY")
 
 config :code_corps,
-postmark_forgot_password_template: "1989481",
+  postmark_forgot_password_template: "1989481",
   postmark_project_acceptance_template: "1447022",
   postmark_receipt_template: "1252361"
 

--- a/lib/code_corps/emails/forgot_password_email.ex
+++ b/lib/code_corps/emails/forgot_password_email.ex
@@ -7,7 +7,7 @@ defmodule CodeCorps.Emails.ForgotPasswordEmail do
   def create(user, token) do
     BaseEmail.create
     |> to(user.email)
-    |> template(template_id(), [link: link(token)])
+    |> template(template_id(), %{link: link(token)})
   end
 
   defp template_id, do: Application.get_env(:code_corps, :postmark_forgot_password_template)


### PR DESCRIPTION
# What's in this PR?

There was an encoding error happening due to the way the model was being generated. This should fix it on staging.