### PR TITLE
Loosen required elixir version to 1.4 or greater

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule CodeCorps.Mixfile do
   def project do
     [app: :code_corps,
      version: "0.0.1",
-     elixir: "1.4.1",
+     elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      dialyzer: [plt_add_deps: :transitive],


### PR DESCRIPTION
The mix.exs file has the version of elixir pegged to 1.4.1.  This increases the difficulty of onboarding new contributors and may no longer be necessary.

From the git history, it appears it was pegged to a specific version back when trying to get the project to work with both docker and heroku; the commits were squashed together, so it's hard to tell which.  Since that time, the docker configurations were removed and the elixir version is now defined in elixir_buildpack.config for both heroku and circle ci.

I'm hoping that this PR will trigger circle ci verification which should hopefully verify both cases still work?