### PR TITLE
Code corps api#692/add validation to donation goals: positive numbers only

### DIFF
--- a/test/models/donation_goal_test.exs
+++ b/test/models/donation_goal_test.exs
@@ -26,6 +26,15 @@ defmodule CodeCorps.DonationGoalTest do
       refute changeset.valid?
       changeset |> assert_error_message(:project, "does not exist")
     end
+
+    test "amount must not be negative" do
+      attrs = %{amount: -100, description: "Cashback for donators", project_id: 2}
+      donation_goal = insert(:donation_goal)
+      changeset = DonationGoal.create_changeset(donation_goal, attrs)
+
+      refute changeset.valid?
+      changeset |> assert_error_message(:amount, "must be greater than %{number}")
+    end
   end
 
   describe "&update_changeset/2" do

--- a/web/models/donation_goal.ex
+++ b/web/models/donation_goal.ex
@@ -30,6 +30,7 @@ defmodule CodeCorps.DonationGoal do
     struct
     |> cast(params, [:amount, :description, :project_id])
     |> validate_required([:amount, :description, :project_id])
+    |> validate_number(:amount, greater_than: 0)
     |> assoc_constraint(:project)
   end
 


### PR DESCRIPTION
# What's in this PR?

This adds a validation for the amount attribute of donation goals to be greater than zero. It will validate any requests for the creation of donation goals or for the update of donation goals to the backend and will return an "Amount must be greater than 0" error if the validation fails.

Donation goal creation workflow:
![addvalid1](https://cloud.githubusercontent.com/assets/8811742/26764006/e61e9cb4-495e-11e7-9f89-482d8a4f4529.gif)

Donation goal update workflow:
![addvalid2](https://cloud.githubusercontent.com/assets/8811742/26764008/e9e42d82-495e-11e7-8d7c-b08fef11e246.gif)

## References
Fixes #692 
