### PR TITLE
Add controllers and blueprints

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -484,6 +484,48 @@ Keep in mind that an installation could be used across multiple projects. And be
 
     + Attributes (Forbidden Response)
 
+# Group Github Repos
+
+This endpoint is used for retrieving information about a Github Repo for display only.
+
+Note that a Github Repo relates 1:1 to a Github App Installation, since only a single installation of the Code Corps GitHub App will happen on a GitHub account. A Github Repo will never be duplicated and does not need to have a many-to-many relationship.
+
+## Github Repos [/github-repos]
+
+### Filter by id [GET /github-repos{?filter[id]}]
+
++ Request
+
+    + Attributes
+
+        + `filter[id]`: `1,2,3` (string, required) - Comma separated string of `ids` to filter by.
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
++ Response 200 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Github Repos Response)
+
+## Github Repo [/github-repos/{id}]
+
++ Parameters
+
+    + id (number, required)
+
+### Retrieve a Github repo [GET]
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
++ Response 200 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Github Repo Response)
+
 # Group Organizations
 
 This endpoint retrieves Organizations on Code Corps. Organizations usually have one or more Projects.
@@ -724,6 +766,94 @@ This resource identifies a relationship between a Project and a Category. For ex
     + Attributes (Record Not Found Response)
 
 ### Delete a project category [DELETE]
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+            Authorization: Bearer {token}
+
++ Response 204 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (No Content Response)
+
++ Response 401 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (JSON Web Token Invalid Response)
+
++ Response 403 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Forbidden Response)
+
+# Group Project Github Repos
+
+This resource identifies a relationship between a Project and a GitHub repository. This relationship indicates whether the project is connected to a particular repository on GitHub and listening for events on that repository (like an issue being created). This is essential for the operation of the GitHub integration for syncing new issues and comments from GitHub to Code Corps.
+
+For example, the project "Code Corps" may have the GitHub repositories of "code-corps-api" and "code-corps-ember" syncing with the project's tasks _on Code Corps itself_.
+
+The organization owner can update their projects by connecting or disconnecting GitHub repositories that are available under their GitHub App installation. This will create or delete the Project Github Repo records, respectively.
+
+## Project Github Repos [/project-github-repos]
+
+### Create a project GitHub repo [POST]
+
++ Request
+
+    + Attributes (Project Github Repo Create Request)
+
+    + Headers
+
+            Accept: application/vnd.api+json
+            Authorization: Bearer {token}
+
++ Response 201 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Project Github Repo Response)
+
++ Response 401 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (JSON Web Token Invalid Response)
+
++ Response 422 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Unprocessable Entity Response)
+
+### List all project GitHub repos [GET]
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
++ Response 200 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Project Github Repos Response)
+
+## Project Github Repo [/project-github-repos/{id}]
+
++ Parameters
+
+    + id (number, required)
+
+### Retrieve a project GitHub repo [GET]
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
++ Response 200 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Project Github Repo Response)
+
++ Response 404 (application/vnd.api+json; charset=utf-8)
+
+    + Attributes (Record Not Found Response)
+
+### Delete a project GitHub repo [DELETE]
 
 + Request
 
@@ -2740,8 +2870,40 @@ The platform stores Stripe customers and cards so they can be reused across diff
 + include JSON API Version
 
 ## Github App Installation Update Request (object)
-+ include Project User Resource Identifier
-+ attributes(Project User Attributes)
++ include Github App Installation Resource Identifier
++ attributes(Github App Installation Attributes)
+
+## Github Repo Attributes (object)
++ `github-account-avatar-url`: `https://avatars3.githubusercontent.com/u/12991115?v=3` (string) - The GitHub URL for the avatar of the account that owns the GitHub repository
++ `github-account-id`: 12991115 (number) - The account id on GitHub that owns the GitHub repository
++ `github-account-login`: `code-corps` (string) - The account for the GitHub repository
++ `github-account-type`: `Organization` (enum[string]) - The type of GitHub account that owns the GitHub repository
+  + Members
+      + `Organization`
+      + `User`
++ `github-id`: 63497734 (number) - The id of the repository on GitHub
++ `inserted-at`: `2016-07-08T03:03:51.967Z` (string)
++ name: `code-corps-api` (string) - The name of the GitHub repo.
++ `updated-at`: `2016-07-08T03:03:51.967Z` (string)
+
+## Github Repo Resource (object)
++ include Github Repo Resource Identifier
++ attributes(Github Repo Attributes)
++ relationships
+  + github-app-installation
+      + data(Github App Installation Resource Identifier)
+
+## Github Repo Resource Identifier (object)
++ id: `1` (string, required)
++ type: `github-repo` (string, required)
+
+## Github Repo Response (object)
++ data(Github Repo Resource)
++ include JSON API Version
+
+## Github Repos Response (object)
++ data(array[Github Repo Resource])
++ include JSON API Version
 
 ## No Content Response (object)
 
@@ -2940,6 +3102,8 @@ The platform stores Stripe customers and cards so they can be reused across diff
         + data(Organization Resource Identifier)
     + `project-categories`
         + data(array[Project Category Resource Identifier])
+    + `project-github-repos`
+        + data(array[Project Github Repo Resource Identifier])
     + `project-skills`
         + data(array[Project Skill Resource Identifier])
     + `project-users`
@@ -2993,6 +3157,29 @@ The platform stores Stripe customers and cards so they can be reused across diff
 
 ## Project Categories Response (object)
 + data(array[Project Category Resource])
++ include JSON API Version
+
+## Project Github Repo Resource (object)
++ include Project Github Repo Resource Identifier
++ relationships
+    + github-repo
+        + data(Github Repo Resource Identifier)
+    + project
+        + data(Project Resource Identifier)
+
+## Project Github Repo Resource Identifier (object)
++ id: `1` (string, required)
++ type: `project-github-repo` (string, required)
+
+## Project Github Repo Create Request (object)
++ data(Project Github Repo Resource)
+
+## Project Github Repo Response (object)
++ data(Project Github Repo Resource)
++ include JSON API Version
+
+## Project Github Repos Response (object)
++ data(array[Project Github Repo Resource])
 + include JSON API Version
 
 ## Project Skill Resource (object)

--- a/test/controllers/github_repo_controller_test.exs
+++ b/test/controllers/github_repo_controller_test.exs
@@ -1,0 +1,39 @@
+defmodule CodeCorps.GithubRepoControllerTest do
+  use CodeCorps.ApiCase, resource_name: :github_repo
+
+  describe "index" do
+    test "lists all resources", %{conn: conn} do
+      [record_1, record_2] = insert_pair(:github_repo)
+
+      conn
+      |> request_index
+      |> json_response(200)
+      |> assert_ids_from_response([record_1.id, record_2.id])
+    end
+
+    test "filters resources by record id", %{conn: conn} do
+      [record_1, record_2 | _] = insert_list(3, :github_repo)
+
+      path = "github-repos/?filter[id]=#{record_1.id},#{record_2.id}"
+
+      conn
+      |> get(path)
+      |> json_response(200)
+      |> assert_ids_from_response([record_1.id, record_2.id])
+    end
+  end
+
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      record = insert(:github_repo)
+      conn
+      |> request_show(record)
+      |> json_response(200)
+      |> assert_id_from_response(record.id)
+    end
+
+    test "renders 404 when id is nonexistent", %{conn: conn} do
+      assert conn |> request_show(:not_found) |> json_response(404)
+    end
+  end
+end

--- a/test/controllers/project_github_repo_controller_test.exs
+++ b/test/controllers/project_github_repo_controller_test.exs
@@ -1,0 +1,96 @@
+defmodule CodeCorps.ProjectGithubRepoControllerTest do
+  use CodeCorps.ApiCase, resource_name: :project_github_repo
+
+  describe "index" do
+    test "lists all entries on index", %{conn: conn} do
+      [project_github_repo_1, project_github_repo_2] = insert_pair(:project_github_repo)
+
+      conn
+      |> request_index
+      |> json_response(200)
+      |> assert_ids_from_response([project_github_repo_1.id, project_github_repo_2.id])
+    end
+
+    test "filters resources on index", %{conn: conn} do
+      [project_github_repo_1, project_github_repo_2 | _] = insert_list(3, :project_github_repo)
+
+      path = "project-github-repos/?filter[id]=#{project_github_repo_1.id},#{project_github_repo_2.id}"
+
+      conn
+      |> get(path)
+      |> json_response(200)
+      |> assert_ids_from_response([project_github_repo_1.id, project_github_repo_2.id])
+    end
+  end
+
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      github_repo = insert(:github_repo)
+      project = insert(:project)
+      project_github_repo = insert(:project_github_repo, project: project, github_repo: github_repo)
+
+      conn
+      |> request_show(project_github_repo)
+      |> json_response(200)
+      |> assert_id_from_response(project_github_repo.id)
+    end
+
+    test "renders 404 error when id is nonexistent", %{conn: conn} do
+      assert conn |> request_show(:not_found) |> json_response(404)
+    end
+  end
+
+  describe "create" do
+    @tag :authenticated
+    test "creates and renders resource when data is valid", %{conn: conn, current_user: current_user} do
+      project = insert(:project)
+      insert(:project_user, project: project, user: current_user, role: "owner")
+      github_repo = insert(:github_repo)
+
+      attrs = %{project: project, github_repo: github_repo}
+      assert conn |> request_create(attrs) |> json_response(201)
+    end
+
+    @tag :authenticated
+    test "renders 422 error when data is invalid", %{conn: conn, current_user: current_user} do
+      project = insert(:project)
+      insert(:project_user, project: project, user: current_user, role: "owner")
+
+      invalid_attrs = %{project: project}
+      assert conn |> request_create(invalid_attrs) |> json_response(422)
+    end
+
+    test "renders 401 when unauthenticated", %{conn: conn} do
+      assert conn |> request_create |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_create |> json_response(403)
+    end
+  end
+
+  describe "delete" do
+    @tag :authenticated
+    test "deletes chosen resource", %{conn: conn, current_user: current_user} do
+      project = insert(:project)
+      insert(:project_user, project: project, user: current_user, role: "owner")
+      project_github_repo = insert(:project_github_repo, project: project)
+      assert conn |> request_delete(project_github_repo) |> response(204)
+    end
+
+    test "renders 401 when unauthenticated", %{conn: conn} do
+      assert conn |> request_delete |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders 403 when not authorized", %{conn: conn} do
+      assert conn |> request_delete |> json_response(403)
+    end
+
+    @tag :authenticated
+    test "renders 404 when id is nonexistent on delete", %{conn: conn} do
+      assert conn |> request_delete(:not_found) |> json_response(404)
+    end
+  end
+end

--- a/test/models/project_github_repo_test.exs
+++ b/test/models/project_github_repo_test.exs
@@ -1,0 +1,57 @@
+defmodule CodeCorps.ProjectGithubRepoTest do
+  use CodeCorps.ModelCase
+
+  alias CodeCorps.ProjectGithubRepo
+
+  test "changeset with valid attributes" do
+    project_id = insert(:project).id
+    github_repo_id = insert(:github_repo).id
+
+    changeset = ProjectGithubRepo.create_changeset(%ProjectGithubRepo{}, %{project_id: project_id, github_repo_id: github_repo_id})
+    assert changeset.valid?
+  end
+
+  test "changeset requires project_id" do
+    github_repo_id = insert(:github_repo).id
+
+    changeset = ProjectGithubRepo.create_changeset(%ProjectGithubRepo{}, %{github_repo_id: github_repo_id})
+
+    refute changeset.valid?
+    assert_error_message(changeset, :project_id, "can't be blank")
+  end
+
+  test "changeset requires github_repo_id" do
+    project_id = insert(:project).id
+
+    changeset = ProjectGithubRepo.create_changeset(%ProjectGithubRepo{}, %{project_id: project_id})
+
+    refute changeset.valid?
+    assert_error_message(changeset, :github_repo_id, "can't be blank")
+  end
+
+  test "changeset requires id of actual project" do
+    project_id = -1
+    github_repo_id = insert(:github_repo).id
+
+    {result, changeset} =
+      ProjectGithubRepo.create_changeset(%ProjectGithubRepo{}, %{project_id: project_id, github_repo_id: github_repo_id})
+      |> Repo.insert
+
+    assert result == :error
+    refute changeset.valid?
+    assert_error_message(changeset, :project, "does not exist")
+  end
+
+  test "changeset requires id of actual github_repo" do
+    project_id = insert(:project).id
+    github_repo_id = -1
+
+    {result, changeset} =
+      ProjectGithubRepo.create_changeset(%ProjectGithubRepo{}, %{project_id: project_id, github_repo_id: github_repo_id})
+      |> Repo.insert
+
+    assert result == :error
+    refute changeset.valid?
+    assert_error_message(changeset, :github_repo, "does not exist")
+  end
+end

--- a/test/policies/project_github_repo_policy_test.exs
+++ b/test/policies/project_github_repo_policy_test.exs
@@ -1,0 +1,84 @@
+defmodule CodeCorps.ProjectGithubRepoPolicyTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.ProjectGithubRepoPolicy, only: [create?: 2, delete?: 2]
+  import CodeCorps.ProjectGithubRepo, only: [create_changeset: 2]
+
+  alias CodeCorps.ProjectGithubRepo
+
+  describe "create?" do
+    test "returns false when user is not a project member" do
+      user = insert(:user)
+      project = insert(:project)
+
+      changeset = %ProjectGithubRepo{} |> create_changeset(%{project_id: project.id})
+      refute create?(user, changeset)
+    end
+
+    test "returns false when user is a pending project member" do
+      %{project: project, user: user} = insert(:project_user, role: "pending")
+
+      changeset = %ProjectGithubRepo{} |> create_changeset(%{project_id: project.id})
+      refute create?(user, changeset)
+    end
+
+    test "returns false when user is a project contributor" do
+      %{project: project, user: user} = insert(:project_user, role: "contributor")
+
+      changeset = %ProjectGithubRepo{} |> create_changeset(%{project_id: project.id})
+      refute create?(user, changeset)
+    end
+
+    test "returns true when user is a project admin" do
+      %{project: project, user: user} = insert(:project_user, role: "admin")
+
+      changeset = %ProjectGithubRepo{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset)
+    end
+
+    test "returns true when user is project owner" do
+      %{project: project, user: user} = insert(:project_user, role: "owner")
+
+      changeset = %ProjectGithubRepo{} |> create_changeset(%{project_id: project.id})
+      assert create?(user, changeset)
+    end
+  end
+
+  describe "delete?" do
+    test "returns false when user is not a project member" do
+      user = insert(:user)
+      project = insert(:project)
+
+      record = insert(:project_github_repo, project: project)
+      refute delete?(user, record)
+    end
+
+    test "returns false when user is a pending project member" do
+      %{project: project, user: user} = insert(:project_user, role: "pending")
+
+      record = insert(:project_github_repo, project: project)
+      refute delete?(user, record)
+    end
+
+    test "returns false when user is a project contributor" do
+      %{project: project, user: user} = insert(:project_user, role: "contributor")
+
+      record = insert(:project_github_repo, project: project)
+      refute delete?(user, record)
+    end
+
+    test "returns true when user is a project admin" do
+      %{project: project, user: user} = insert(:project_user, role: "admin")
+
+      record = insert(:project_github_repo, project: project)
+      assert delete?(user, record)
+    end
+
+    test "returns true when user is project owner" do
+      %{project: project, user: user} = insert(:project_user, role: "owner")
+
+      record = insert(:project_github_repo, project: project)
+      assert delete?(user, record)
+    end
+  end
+end

--- a/web/controllers/github_repo_controller.ex
+++ b/web/controllers/github_repo_controller.ex
@@ -1,0 +1,19 @@
+defmodule CodeCorps.GithubRepoController do
+  use CodeCorps.Web, :controller
+  use JaResource
+
+  import CodeCorps.Helpers.Query, only: [id_filter: 2]
+
+  alias CodeCorps.{GithubRepo}
+
+  @preloads [:github_app_installation]
+
+  plug :load_resource, model: GithubRepo, only: [:show], preload: @preloads
+
+  plug JaResource
+
+  @spec filter(Plug.Conn.t, Ecto.Query.t, String.t, String.t) :: Ecto.Query.t
+  def filter(_conn, query, "id", id_list) do
+    query |> id_filter(id_list)
+  end
+end

--- a/web/controllers/project_github_repo_controller.ex
+++ b/web/controllers/project_github_repo_controller.ex
@@ -1,0 +1,21 @@
+defmodule CodeCorps.ProjectGithubRepoController do
+  use CodeCorps.Web, :controller
+  use JaResource
+
+  import CodeCorps.Helpers.Query, only: [id_filter: 2]
+
+  alias CodeCorps.ProjectGithubRepo
+
+  plug :load_resource, model: ProjectGithubRepo, only: [:show], preload: [:github_repo, :project]
+  plug :load_and_authorize_changeset, model: ProjectGithubRepo, only: [:create]
+  plug :load_and_authorize_resource, model: ProjectGithubRepo, only: [:delete]
+  plug JaResource
+
+  def filter(_conn, query, "id", id_list) do
+    query |> id_filter(id_list)
+  end
+
+  def handle_create(_conn, attributes) do
+    %ProjectGithubRepo{} |> ProjectGithubRepo.create_changeset(attributes)
+  end
+end

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -1,7 +1,7 @@
 defmodule Canary.Abilities do
-  alias CodeCorps.{Category, Comment, DonationGoal, GithubAppInstallation, Organization, OrganizationGithubAppInstallation, Preview, Project, ProjectCategory, ProjectSkill, ProjectUser, Role, RoleSkill, Skill, StripeConnectAccount, StripeConnectPlan, StripeConnectSubscription, StripePlatformCard, StripePlatformCustomer, Task, TaskSkill, User, UserCategory, UserRole, UserSkill, UserTask}
+  alias CodeCorps.{Category, Comment, DonationGoal, GithubAppInstallation, Organization, OrganizationGithubAppInstallation, Preview, Project, ProjectCategory, ProjectGithubRepo, ProjectSkill, ProjectUser, Role, RoleSkill, Skill, StripeConnectAccount, StripeConnectPlan, StripeConnectSubscription, StripePlatformCard, StripePlatformCustomer, Task, TaskSkill, User, UserCategory, UserRole, UserSkill, UserTask}
 
-  alias CodeCorps.{CategoryPolicy, CommentPolicy, DonationGoalPolicy, GithubAppInstallationPolicy, OrganizationPolicy, OrganizationGithubAppInstallationPolicy, PreviewPolicy, ProjectPolicy, ProjectCategoryPolicy, ProjectSkillPolicy, ProjectUserPolicy, RolePolicy, RoleSkillPolicy, SkillPolicy, StripeConnectAccountPolicy, StripeConnectPlanPolicy, StripeConnectSubscriptionPolicy, StripePlatformCardPolicy, StripePlatformCustomerPolicy, TaskPolicy, TaskSkillPolicy, UserPolicy, UserCategoryPolicy, UserRolePolicy, UserSkillPolicy, UserTaskPolicy}
+  alias CodeCorps.{CategoryPolicy, CommentPolicy, DonationGoalPolicy, GithubAppInstallationPolicy, OrganizationPolicy, OrganizationGithubAppInstallationPolicy, PreviewPolicy, ProjectPolicy, ProjectCategoryPolicy, ProjectGithubRepoPolicy, ProjectSkillPolicy, ProjectUserPolicy, RolePolicy, RoleSkillPolicy, SkillPolicy, StripeConnectAccountPolicy, StripeConnectPlanPolicy, StripeConnectSubscriptionPolicy, StripePlatformCardPolicy, StripePlatformCustomerPolicy, TaskPolicy, TaskSkillPolicy, UserPolicy, UserCategoryPolicy, UserRolePolicy, UserSkillPolicy, UserTaskPolicy}
 
   alias Ecto.Changeset
 
@@ -43,6 +43,9 @@ defmodule Canary.Abilities do
 
     def can?(%User{} = user, :create, %Changeset{data: %ProjectCategory{}} = changeset), do: ProjectCategoryPolicy.create?(user, changeset)
     def can?(%User{} = user, :delete, %ProjectCategory{} = project_category), do: ProjectCategoryPolicy.delete?(user, project_category)
+
+    def can?(%User{} = user, :create, %Changeset{data: %ProjectGithubRepo{}} = changeset), do: ProjectGithubRepoPolicy.create?(user, changeset)
+    def can?(%User{} = user, :delete, %ProjectGithubRepo{} = project_github_repo), do: ProjectGithubRepoPolicy.delete?(user, project_github_repo)
 
     def can?(%User{} = user, :create, %Changeset{data: %ProjectSkill{}} = changeset), do: ProjectSkillPolicy.create?(user, changeset)
     def can?(%User{} = user, :delete, %ProjectSkill{} = project_skill), do: ProjectSkillPolicy.delete?(user, project_skill)

--- a/web/models/project_github_repo.ex
+++ b/web/models/project_github_repo.ex
@@ -8,9 +8,20 @@ defmodule CodeCorps.ProjectGithubRepo do
   @type t :: %__MODULE__{}
 
   schema "project_github_repos" do
-    belongs_to :project, CodeCorps.Project
     belongs_to :github_repo, CodeCorps.GithubRepo
+    belongs_to :project, CodeCorps.Project
 
     timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def create_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:github_repo_id, :project_id])
+    |> validate_required([:github_repo_id, :project_id])
+    |> assoc_constraint(:github_repo)
+    |> assoc_constraint(:project)
   end
 end

--- a/web/policies/project_github_repo_policy.ex
+++ b/web/policies/project_github_repo_policy.ex
@@ -1,0 +1,14 @@
+defmodule CodeCorps.ProjectGithubRepoPolicy do
+  import CodeCorps.Helpers.Policy, only: [get_project: 1, administered_by?: 2]
+
+  alias CodeCorps.{ProjectGithubRepo, User}
+  alias Ecto.Changeset
+
+  def create?(%User{} = user, %Changeset{} = changeset) do
+    changeset |> get_project |> administered_by?(user)
+  end
+
+  def delete?(%User{} = user, %ProjectGithubRepo{} = project_github_repo) do
+    project_github_repo |> get_project |> administered_by?(user)
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -79,6 +79,7 @@ defmodule CodeCorps.Router do
     resources "/organizations", OrganizationController, only: [:create, :update]
     resources "/previews", PreviewController, only: [:create]
     resources "/project-categories", ProjectCategoryController, only: [:create, :delete]
+    resources "/project-github-repos", ProjectGithubRepoController, only: [:create, :delete]
     resources "/project-skills", ProjectSkillController, only: [:create, :delete]
     resources "/project-users", ProjectUserController, only: [:create, :update, :delete]
     resources "/projects", ProjectController, only: [:create, :update]
@@ -110,10 +111,12 @@ defmodule CodeCorps.Router do
     resources "/comments", CommentController, only: [:index, :show]
     resources "/donation-goals", DonationGoalController, only: [:index, :show]
     resources "/github-app-installations", GithubAppInstallationController, only: [:index, :show]
+    resources "/github-repos", GithubRepoController, only: [:index, :show]
     resources "/organization-github-app-installations", OrganizationGithubAppInstallationController, only: [:index, :show]
     resources "/organizations", OrganizationController, only: [:index, :show]
     post "/password/forgot", PasswordController, :forgot_password
     resources "/project-categories", ProjectCategoryController, only: [:index, :show]
+    resources "/project-github-repos", ProjectGithubRepoController, only: [:index, :show]
     resources "/project-skills", ProjectSkillController, only: [:index, :show]
     resources "/project-users", ProjectUserController, only: [:index, :show]
     resources "/projects", ProjectController, only: [:index, :show] do

--- a/web/views/project_github_repo_view.ex
+++ b/web/views/project_github_repo_view.ex
@@ -3,6 +3,6 @@ defmodule CodeCorps.ProjectGithubRepoView do
   use CodeCorps.Web, :view
   use JaSerializer.PhoenixView
 
-  has_one :project, serializer: CodeCorps.ProjectView
   has_one :github_repo, serializer: CodeCorps.GithubRepoView
+  has_one :project, serializer: CodeCorps.ProjectView
 end


### PR DESCRIPTION
# What's in this PR?

Should be rebased off #846 once that's merged into `develop`.

This simply adds missing API blueprints and controllers/tests for `GithubRepo` and `ProjectGithubRepo` models.