### PR TITLE
Misc GitHub flow fixes

### DIFF
--- a/lib/code_corps/github/installation.ex
+++ b/lib/code_corps/github/installation.ex
@@ -19,12 +19,17 @@ defmodule CodeCorps.GitHub.Installation do
   """
   @spec repositories(GithubAppInstallation.t) :: {:ok, list(map)} | {:error, GitHub.api_error_struct}
   def repositories(%GithubAppInstallation{} = installation) do
-    endpoint = "installation/repositories"
-    {:ok, access_token} = installation |> get_access_token()
-    case Request.retrieve(endpoint, [access_token: access_token]) do
+    with {:ok, access_token} <- installation |> get_access_token(),
+         {:ok, %{"repositories" => repositories}} <- fetch_repositories(access_token) do
+
+      {:ok, repositories}
+    else
       {:error, error} -> {:error, error}
-      {:ok, %{"total_count" => _, "repositories" => repositories}} -> {:ok, repositories}
     end
+  end
+
+  defp fetch_repositories(access_token) do
+    Request.retrieve("installation/repositories", [access_token: access_token])
   end
 
   @doc """

--- a/lib/code_corps/github/jwt.ex
+++ b/lib/code_corps/github/jwt.ex
@@ -4,8 +4,6 @@ defmodule CodeCorps.Github.JWT do
   it.
   """
 
-  @app_id Application.get_env(:code_corps, :github_app_id)
-
   @doc """
   Generates a JWT from the GitHub App's generated RSA private key using the
   RS256 algo, where the issuer is the GitHub App's ID.
@@ -21,7 +19,7 @@ defmodule CodeCorps.Github.JWT do
     %{}
     |> Joken.token
     |> Joken.with_exp(Timex.now |> Timex.shift(minutes: 5) |> Timex.to_unix)
-    |> Joken.with_iss(@app_id |> String.to_integer())
+    |> Joken.with_iss(app_id())
     |> Joken.with_iat(Timex.now |> Timex.to_unix)
     |> Joken.with_signer(signer)
     |> Joken.sign
@@ -32,4 +30,6 @@ defmodule CodeCorps.Github.JWT do
     Application.get_env(:code_corps, :github_app_pem)
     |> JOSE.JWK.from_pem()
   end
+
+  defp app_id(), do: Application.get_env(:code_corps, :github_app_id)
 end


### PR DESCRIPTION
# What's in this PR?

This PR fixes several minor issues in the GitHub integration code

- With a missing `GITHUB_APP_ID`, the `JWT.generate/0` related code was failing, because we've been converting the id to integer to set it as the token `iss` field. It does not need to be an integer, so I removed that conversion.

- We did not handle a case of `get_access_token` failing when fetching installation repositories, causing the `GithubAppInstallation` to enter errored state when processing repositories.
