### PR TITLE
Fixed issue with policies not relying on canary

### DIFF
--- a/lib/code_corps/policy/policy.ex
+++ b/lib/code_corps/policy/policy.ex
@@ -15,17 +15,17 @@ defmodule CodeCorps.Policy do
   The resource can be a record, when performing an action on an existing record,
   or it can be a map of parameters, when creating a new record.
   """
-  @spec authorize(User.t, atom, map | struct) :: {:ok, :authorized} | {:error, :not_authorized}
-  def authorize(%User{} = user, action, resource) do
-    case user |> can?(action, resource) do
+  @spec authorize(User.t, atom, struct, map) :: {:ok, :authorized} | {:error, :not_authorized}
+  def authorize(%User{} = user, action, struct, %{} = params \\ %{}) do
+    case user |> can?(action, struct, params) do
       true -> {:ok, :authorized}
       false -> {:error, :not_authorized}
     end
   end
 
-  @spec can?(User.t, atom, map | struct) :: boolean
-  defp can?(%User{} = user, :update, %Comment{} = comment), do: Policy.Comment.update?(user, comment)
-  defp can?(%User{} = user, :create, %{} = params), do: Policy.Comment.create?(user, params)
+  @spec can?(User.t, atom, struct, map) :: boolean
+  defp can?(%User{} = user, :create, %Comment{}, %{} = params), do: Policy.Comment.create?(user, params)
+  defp can?(%User{} = user, :update, %Comment{} = comment, %{}), do: Policy.Comment.update?(user, comment)
 
   defimpl Canada.Can, for: User do
     # NOTE: Canary sets an :unauthorized and a :not_found handler on a config level

--- a/lib/code_corps_web/controllers/comment_controller.ex
+++ b/lib/code_corps_web/controllers/comment_controller.ex
@@ -23,7 +23,7 @@ defmodule CodeCorpsWeb.CommentController do
   @spec create(Plug.Conn.t, map) :: Conn.t
   def create(%Conn{} = conn, %{} = params) do
     with %User{} = current_user <- conn |> Guardian.Plug.current_resource,
-         {:ok, :authorized} <- current_user |> Policy.authorize(:create, params),
+         {:ok, :authorized} <- current_user |> Policy.authorize(:create, %Comment{}, params),
          {:ok, %Comment{} = comment} <- %Comment{} |> Comment.create_changeset(params) |> Repo.insert do
       conn |> put_status(:created) |> render("show.json-api", data: comment)
     end


### PR DESCRIPTION
A blank struct needs to be passed in for policy to be able to determine which record is being created

This issue did not become apparent until I started switching the task controller away from canary/ja_resource

It's a quick fix and it gives us flexibility in how we approach our authorizations