### PR TITLE
Fix github-app-installations relationship to be available on user view

### DIFF
--- a/lib/code_corps_web/views/user_view.ex
+++ b/lib/code_corps_web/views/user_view.ex
@@ -3,9 +3,10 @@ defmodule CodeCorpsWeb.UserView do
 
   use CodeCorpsWeb.PreloadHelpers,
       default_preloads: [
-        :project_users, :slugged_route, :stripe_connect_subscriptions,
-        :stripe_platform_card, :stripe_platform_customer,
-        :user_categories, :user_roles, :user_skills
+        :github_app_installations, :project_users, :slugged_route,
+        :stripe_connect_subscriptions, :stripe_platform_card,
+        :stripe_platform_customer, :user_categories, :user_roles,
+        :user_skills
       ]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
@@ -22,6 +23,7 @@ defmodule CodeCorpsWeb.UserView do
   has_one :stripe_platform_card, serializer: CodeCorpsWeb.StripePlatformCardView
   has_one :stripe_platform_customer, serializer: CodeCorpsWeb.StripePlatformCustomerView
 
+  has_many :github_app_installations, serializer: CodeCorpsWeb.GithubAppInstallationView, identifiers: :always
   has_many :project_users, serializer: CodeCorpsWeb.ProjectUserView, identifiers: :always
   has_many :stripe_connect_subscriptions, serializer: CodeCorpsWeb.StripeConnectSubscriptionView, identifiers: :always
   has_many :user_categories, serializer: CodeCorpsWeb.UserCategoryView, identifiers: :always

--- a/test/lib/code_corps_web/views/user_view_test.exs
+++ b/test/lib/code_corps_web/views/user_view_test.exs
@@ -6,6 +6,7 @@ defmodule CodeCorpsWeb.UserViewTest do
 
   test "renders all attributes and relationships properly" do
     user = insert(:user, first_name: "First", github_avatar_url: "foo", github_id: 123, github_username: "githubuser", last_name: "Last", default_color: "blue")
+    github_app_installation = insert(:github_app_installation, user: user)
     slugged_route = insert(:slugged_route, user: user)
     stripe_connect_subscription = insert(:stripe_connect_subscription, user: user)
     stripe_platform_card = insert(:stripe_platform_card, user: user)
@@ -45,6 +46,11 @@ defmodule CodeCorpsWeb.UserViewTest do
           "website" => user.website
         },
         "relationships" => %{
+          "github-app-installations" => %{
+            "data" => [
+              %{"id" => github_app_installation.id |> Integer.to_string, "type" => "github-app-installation"}
+            ]
+          },
           "project-users" => %{
             "data" => [
               %{"id" => project_user.id |> Integer.to_string, "type" => "project-user"}


### PR DESCRIPTION
# What's in this PR?

This fixes the `UserView` to have `github-app-installations` relationships available on it, otherwise the Ember app does not have any unconnected installations to display for the user.

Also adds a test for this behavior.