### PR TITLE
Add task to inbox task list when created from GitHub

### DIFF
--- a/lib/code_corps/github/event/issues/changeset_builder.ex
+++ b/lib/code_corps/github/event/issues/changeset_builder.ex
@@ -5,29 +5,57 @@ defmodule CodeCorps.GitHub.Event.Issues.ChangesetBuilder do
   """
 
   alias CodeCorps.{
-    Services.MarkdownRendererService,
     ProjectGithubRepo,
+    Repo,
+    Services.MarkdownRendererService,
     Task,
+    TaskList,
     User
   }
   alias CodeCorps.GitHub.Adapters.Task, as: TaskAdapter
   alias Ecto.Changeset
+
+  import Ecto.Query, only: [where: 3]
 
   @doc ~S"""
   Constructs a changeset for syncing a task when processing an Issues webhook
   """
   @spec build_changeset(Task.t, map, ProjectGithubRepo.t, User.t) :: Changeset.t
   def build_changeset(
-    %Task{} = task,
+    %Task{id: task_id} = task,
     %{"issue" => issue_attrs},
     %ProjectGithubRepo{project_id: project_id},
     %User{id: user_id}) do
+
+    case is_nil(task_id) do
+      true -> create_changeset(task, issue_attrs, project_id, user_id)
+      false -> update_changeset(task, issue_attrs)
+    end
+  end
+
+  defp create_changeset(%Task{} = task, issue_attrs, project_id, user_id) do
+    %TaskList{id: task_list_id} =
+      TaskList
+      |> where([l], l.project_id == ^project_id)
+      |> where([l], l.inbox == true)
+      |> Repo.one
 
     task
     |> Changeset.change(issue_attrs |> TaskAdapter.from_issue())
     |> MarkdownRendererService.render_markdown_to_html(:markdown, :body)
     |> Changeset.put_change(:project_id, project_id)
+    |> Changeset.put_change(:task_list_id, task_list_id)
     |> Changeset.put_change(:user_id, user_id)
+    |> Changeset.validate_required([:project_id, :task_list_id, :user_id, :markdown, :body, :title])
+    |> Changeset.assoc_constraint(:project)
+    |> Changeset.assoc_constraint(:task_list)
+    |> Changeset.assoc_constraint(:user)
+  end
+
+  defp update_changeset(%Task{} = task, issue_attrs) do
+    task
+    |> Changeset.change(issue_attrs |> TaskAdapter.from_issue())
+    |> MarkdownRendererService.render_markdown_to_html(:markdown, :body)
     |> Changeset.validate_required([:project_id, :user_id, :markdown, :body, :title])
     |> Changeset.assoc_constraint(:project)
     |> Changeset.assoc_constraint(:user)

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.1
--- Dumped by pg_dump version 9.5.1
+-- Dumped from database version 9.5.4
+-- Dumped by pg_dump version 9.5.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/test/lib/code_corps/github/event/issue_comment_test.exs
+++ b/test/lib/code_corps/github/event/issue_comment_test.exs
@@ -8,6 +8,7 @@ defmodule CodeCorps.GitHub.Event.IssueCommentTest do
   alias CodeCorps.{
     Comment,
     GitHub.Event.IssueComment,
+    Project,
     Task,
     Repo,
     User
@@ -55,6 +56,11 @@ defmodule CodeCorps.GitHub.Event.IssueCommentTest do
         project_ids =
           insert_list(3, :project_github_repo, github_repo: github_repo)
           |> Enum.map(&Map.get(&1, :project_id))
+
+        project_ids |> Enum.each(fn project_id ->
+          project = Project |> Repo.get_by(id: project_id)
+          insert(:task_list, project: project, inbox: true)
+        end)
 
         {:ok, comments} = IssueComment.handle(@event, @payload)
 
@@ -123,6 +129,11 @@ defmodule CodeCorps.GitHub.Event.IssueCommentTest do
           project_github_repos = insert_list(3, :project_github_repo, github_repo: github_repo)
 
         project_ids = project_github_repos |> Enum.map(&Map.get(&1, :project_id))
+
+        project_ids |> Enum.each(fn project_id ->
+          project = Project |> Repo.get_by(id: project_id)
+          insert(:task_list, project: project, inbox: true)
+        end)
 
         # there's a task for project 1
         task_1 = insert(:task, project: project_1, user: issue_user, github_id: issue_github_id)
@@ -201,6 +212,11 @@ defmodule CodeCorps.GitHub.Event.IssueCommentTest do
 
         project_ids = project_github_repos |> Enum.map(&Map.get(&1, :project_id))
 
+        project_ids |> Enum.each(fn project_id ->
+          project = Project |> Repo.get_by(id: project_id)
+          insert(:task_list, project: project, inbox: true)
+        end)
+
         {:ok, comments} = IssueComment.handle(@event, @payload)
 
         assert Enum.count(comments) == 3
@@ -270,6 +286,11 @@ defmodule CodeCorps.GitHub.Event.IssueCommentTest do
           project_github_repos = insert_list(3, :project_github_repo, github_repo: github_repo)
 
         project_ids = project_github_repos |> Enum.map(&Map.get(&1, :project_id))
+
+        project_ids |> Enum.each(fn project_id ->
+          project = Project |> Repo.get_by(id: project_id)
+          insert(:task_list, project: project, inbox: true)
+        end)
 
         # there's a task and comment for project 1
         task_1 = insert(:task, project: project_1, user: issue_user, github_id: issue_github_id)

--- a/test/lib/code_corps/github/event/issues/changeset_builder_test.exs
+++ b/test/lib/code_corps/github/event/issues/changeset_builder_test.exs
@@ -15,8 +15,10 @@ defmodule CodeCorps.GitHub.Event.Issues.ChangesetBuilderTest do
     test "assigns proper changes to the task" do
       payload = load_event_fixture("issues_opened")
       task = %Task{}
-      project_github_repo = insert(:project_github_repo)
+      project = insert(:project)
+      project_github_repo = insert(:project_github_repo, project: project)
       user = insert(:user)
+      task_list = insert(:task_list, project: project, inbox: true)
 
       changeset = ChangesetBuilder.build_changeset(
         task, payload, project_github_repo, user
@@ -34,6 +36,7 @@ defmodule CodeCorps.GitHub.Event.Issues.ChangesetBuilderTest do
 
       # relationships are proper
       assert get_change(changeset, :project_id) == project_github_repo.project_id
+      assert get_change(changeset, :task_list_id) == task_list.id
       assert get_change(changeset, :user_id) == user.id
 
       assert changeset.valid?

--- a/test/lib/code_corps/github/event/issues/task_syncer_test.exs
+++ b/test/lib/code_corps/github/event/issues/task_syncer_test.exs
@@ -7,6 +7,7 @@ defmodule CodeCorps.GitHub.Event.Issues.TaskSyncerTest do
 
   alias CodeCorps.{
     GitHub.Event.Issues.TaskSyncer,
+    Project,
     Repo,
     Task
   }
@@ -24,6 +25,12 @@ defmodule CodeCorps.GitHub.Event.Issues.TaskSyncerTest do
 
       task_1 = insert(:task, project: project_1, user: user, github_id: issue_github_id)
 
+      project_ids = project_github_repos |> Enum.map(&Map.get(&1, :project_id))
+
+      project_ids |> Enum.each(fn project_id ->
+        project = Project |> Repo.get_by(id: project_id)
+        insert(:task_list, project: project, inbox: true)
+      end)
 
       {:ok, tasks} = %{github_repo | project_github_repos: project_github_repos}
       |> TaskSyncer.sync_all(user, @payload)

--- a/test/lib/code_corps/github/event/issues_test.exs
+++ b/test/lib/code_corps/github/event/issues_test.exs
@@ -7,6 +7,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
 
   alias CodeCorps.{
     GitHub.Event.Issues,
+    Project,
     Repo,
     Task,
     User
@@ -51,6 +52,11 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         project_github_repos
         |> Enum.map(&Map.get(&1, :project))
         |> Enum.map(&Map.get(&1, :id))
+
+      project_ids |> Enum.each(fn project_id ->
+        project = Project |> Repo.get_by(id: project_id)
+        insert(:task_list, project: project, inbox: true)
+      end)
 
       {:ok, tasks} = Issues.handle(@event, @payload)
 
@@ -100,6 +106,11 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         project_github_repos
         |> Enum.map(&Map.get(&1, :project))
         |> Enum.map(&Map.get(&1, :id))
+
+      project_ids |> Enum.each(fn project_id ->
+        project = Project |> Repo.get_by(id: project_id)
+        insert(:task_list, project: project, inbox: true)
+      end)
 
       %{id: existing_task_id} = insert(:task, project: project, user: user, github_id: github_id)
 
@@ -170,6 +181,11 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         |> Enum.map(&Map.get(&1, :project))
         |> Enum.map(&Map.get(&1, :id))
 
+      project_ids |> Enum.each(fn project_id ->
+        project = Project |> Repo.get_by(id: project_id)
+        insert(:task_list, project: project, inbox: true)
+      end)
+
       {:ok, tasks} = Issues.handle(@event, @payload)
 
       assert Enum.count(tasks) == 3
@@ -218,6 +234,11 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         project_github_repos
         |> Enum.map(&Map.get(&1, :project))
         |> Enum.map(&Map.get(&1, :id))
+
+      project_ids |> Enum.each(fn project_id ->
+        project = Project |> Repo.get_by(id: project_id)
+        insert(:task_list, project: project, inbox: true)
+      end)
 
       %{id: existing_task_id} = insert(:task, project: project, user: user, github_id: github_id)
 
@@ -288,6 +309,11 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         |> Enum.map(&Map.get(&1, :project))
         |> Enum.map(&Map.get(&1, :id))
 
+      project_ids |> Enum.each(fn project_id ->
+        project = Project |> Repo.get_by(id: project_id)
+        insert(:task_list, project: project, inbox: true)
+      end)
+
       {:ok, tasks} = Issues.handle(@event, @payload)
 
       assert Enum.count(tasks) == 3
@@ -336,6 +362,11 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         project_github_repos
         |> Enum.map(&Map.get(&1, :project))
         |> Enum.map(&Map.get(&1, :id))
+
+      project_ids |> Enum.each(fn project_id ->
+        project = Project |> Repo.get_by(id: project_id)
+        insert(:task_list, project: project, inbox: true)
+      end)
 
       %{id: existing_task_id} = insert(:task, project: project, user: user, github_id: github_id)
 
@@ -406,6 +437,11 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         |> Enum.map(&Map.get(&1, :project))
         |> Enum.map(&Map.get(&1, :id))
 
+      project_ids |> Enum.each(fn project_id ->
+        project = Project |> Repo.get_by(id: project_id)
+        insert(:task_list, project: project, inbox: true)
+      end)
+
       {:ok, tasks} = Issues.handle(@event, @payload)
 
       assert Enum.count(tasks) == 3
@@ -454,6 +490,11 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         project_github_repos
         |> Enum.map(&Map.get(&1, :project))
         |> Enum.map(&Map.get(&1, :id))
+
+      project_ids |> Enum.each(fn project_id ->
+        project = Project |> Repo.get_by(id: project_id)
+        insert(:task_list, project: project, inbox: true)
+      end)
 
       %{id: existing_task_id} = insert(:task, project: project, user: user, github_id: github_id)
 


### PR DESCRIPTION
# What's in this PR?

This change makes it so a task created on GitHub is synced to the `inbox` `TaskList` for the given `Project`.

Open to thoughts on how to improve the logic or the tests.

## References
Fixes #872 