### PR TITLE
Switches category controller away from ja_resource 

### DIFF
--- a/lib/code_corps/policy/category.ex
+++ b/lib/code_corps/policy/category.ex
@@ -1,5 +1,5 @@
 defmodule CodeCorps.Policy.Category do
-  alias CodeCorps.{ User }
+  alias CodeCorps.User
 
   @spec create?(User.t) :: boolean
   def create?(%User{admin: true}), do: true

--- a/lib/code_corps/policy/category.ex
+++ b/lib/code_corps/policy/category.ex
@@ -1,9 +1,11 @@
 defmodule CodeCorps.Policy.Category do
-  alias CodeCorps.User
+  alias CodeCorps.{ User }
 
+  @spec create?(User.t) :: boolean
   def create?(%User{admin: true}), do: true
-  def create?(%User{admin: false}), do: false
+  def create?(%User{}), do: false
 
+  @spec update?(User.t) :: boolean
   def update?(%User{admin: true}), do: true
-  def update?(%User{admin: false}), do: false
+  def update?(%User{}), do: false
 end

--- a/lib/code_corps/policy/policy.ex
+++ b/lib/code_corps/policy/policy.ex
@@ -24,6 +24,8 @@ defmodule CodeCorps.Policy do
   end
 
   @spec can?(User.t, atom, struct, map) :: boolean
+  defp can?(%User{} = user, :create, %Category{}, %{}), do: Policy.Category.create?(user)
+  defp can?(%User{} = user, :update, %Category{}, %{}), do: Policy.Category.update?(user)
   defp can?(%User{} = user, :create, %Comment{}, %{} = params), do: Policy.Comment.create?(user, params)
   defp can?(%User{} = user, :update, %Comment{} = comment, %{}), do: Policy.Comment.update?(user, comment)
 
@@ -38,9 +40,6 @@ defmodule CodeCorps.Policy do
     def can?(%User{}, _action, nil), do: true
 
     def can?(%User{} = current_user, :update, %User{} = user), do: Policy.User.update?(user, current_user)
-
-    def can?(%User{} = user, :create, Category), do: Policy.Category.create?(user)
-    def can?(%User{} = user, :update, %Category{}), do: Policy.Category.update?(user)
 
     def can?(%User{} = user, :create, %Changeset{data: %DonationGoal{}} = changeset), do: Policy.DonationGoal.create?(user, changeset)
     def can?(%User{} = user, :update, %DonationGoal{} = comment), do: Policy.DonationGoal.update?(user, comment)

--- a/lib/code_corps_web/controllers/category_controller.ex
+++ b/lib/code_corps_web/controllers/category_controller.ex
@@ -1,17 +1,43 @@
 defmodule CodeCorpsWeb.CategoryController do
   use CodeCorpsWeb, :controller
-  use JaResource
 
-  alias CodeCorps.Category
+  alias CodeCorps.{ Category, User, Helpers.Query}
 
-  plug :load_resource, model: Category, only: [:show]
-  plug :load_and_authorize_resource, model: Category, only: [:create, :update]
-  plug JaResource
+  action_fallback CodeCorpsWeb.FallbackController
+  plug CodeCorpsWeb.Plug.DataToAttributes
 
-  @spec model :: module
-  def model, do: CodeCorps.Category
+  @spec index(Conn.t, map) :: Conn.t
+  def index(%Conn{} = conn, %{} = params) do
+    with categories <- Category |> Query.id_filter(params) |> Repo.all do
+      conn |> render("index.json-api", data: categories)
+    end
+  end
 
-  def handle_create(_conn, attributes) do
-    Category.create_changeset(%Category{}, attributes)
+  @spec show(Conn.t, map) :: Conn.t
+  def show(%Conn{} = conn, %{"id" => id}) do
+    with %Category{} = category <- Category |> Repo.get(id) do
+      conn |> render("show.json-api", data: category)
+    end
+  end
+
+  @spec create(Plug.Conn.t, map) :: Conn.t
+  def create(%Conn{} = conn, %{} = params) do
+    with %User{} = current_user <- conn |> Guardian.Plug.current_resource,
+      {:ok, :authorized} <- current_user |> Policy.authorize(:create, %Category{}, params),
+      {:ok, %Category{} = category} <- %Category{} |> Category.create_changeset(params) |> Repo.insert
+    do
+      conn |> put_status(:created) |> render("show.json-api", data: category)
+    end
+  end
+
+  @spec update(Plug.Conn.t, map) :: Conn.t
+  def update(%Conn{} = conn, %{"id" => id} = params) do
+    with %Category{} = category <- Category |> Repo.get(id),
+      %User{} = current_user <- conn |> Guardian.Plug.current_resource,
+      {:ok, :authorized} <- current_user |> Policy.authorize(:update, category),
+      {:ok, %Category{} = category} <- category |> Category.changeset(params) |> Repo.update
+    do
+      conn |> render("show.json-api", data: category)
+    end
   end
 end

--- a/lib/code_corps_web/controllers/category_controller.ex
+++ b/lib/code_corps_web/controllers/category_controller.ex
@@ -1,7 +1,7 @@
 defmodule CodeCorpsWeb.CategoryController do
   use CodeCorpsWeb, :controller
 
-  alias CodeCorps.{ Category, User, Helpers.Query}
+  alias CodeCorps.{Category, User, Helpers.Query}
 
   action_fallback CodeCorpsWeb.FallbackController
   plug CodeCorpsWeb.Plug.DataToAttributes
@@ -20,7 +20,7 @@ defmodule CodeCorpsWeb.CategoryController do
     end
   end
 
-  @spec create(Plug.Conn.t, map) :: Conn.t
+  @spec create(Conn.t, map) :: Conn.t
   def create(%Conn{} = conn, %{} = params) do
     with %User{} = current_user <- conn |> Guardian.Plug.current_resource,
       {:ok, :authorized} <- current_user |> Policy.authorize(:create, %Category{}, params),
@@ -30,7 +30,7 @@ defmodule CodeCorpsWeb.CategoryController do
     end
   end
 
-  @spec update(Plug.Conn.t, map) :: Conn.t
+  @spec update(Conn.t, map) :: Conn.t
   def update(%Conn{} = conn, %{"id" => id} = params) do
     with %Category{} = category <- Category |> Repo.get(id),
       %User{} = current_user <- conn |> Guardian.Plug.current_resource,


### PR DESCRIPTION
# What's in this PR?

- [x] Updates `Category` policy methods
      - can (`policy.ex`)
      - update (`category/policy.ex`)
      - create (`category/policy.ex`)

- [x] Updates `Category` controller methods
       - index
       - show
       - update
       - create
 
Progress on: #864 
