### PR TITLE
Correct bad moduledoc in CodeCorps.Plug.DataToAttributes

### DIFF
--- a/lib/code_corps_web/plugs/data_to_attributes.ex
+++ b/lib/code_corps_web/plugs/data_to_attributes.ex
@@ -1,6 +1,9 @@
 defmodule CodeCorpsWeb.Plug.DataToAttributes do
-  @moduledoc """
-  Puts authenticated Guardian user into conn.assigns[:current_user]
+  @moduledoc ~S"""
+  Converts params in the JSON api "data" format into flat params convient for
+  changeset casting.
+
+  This is done using `JaSerializer.Params.to_attributes/1`
   """
 
   alias Plug.Conn


### PR DESCRIPTION
Addendum to #867. Corrects bad module dock which wasn't noticed in the initial reviews.