### PR TITLE
Switch OrganizationGithubAppInstallation away from ja_resource and canary

### DIFF
--- a/lib/code_corps/policy/organization_github_app_installation.ex
+++ b/lib/code_corps/policy/organization_github_app_installation.ex
@@ -6,8 +6,9 @@ defmodule CodeCorps.Policy.OrganizationGithubAppInstallation do
 
   alias CodeCorps.{OrganizationGithubAppInstallation, User}
 
-  def create?(%User{} = user, %Ecto.Changeset{} = changeset),
-    do: changeset |> get_organization |> owned_by?(user)
+  def create?(%User{} = user, params) do
+    params |> get_organization |> owned_by?(user)
+  end
 
   def delete?(%User{} = user, %OrganizationGithubAppInstallation{} = github_app_installation),
     do: github_app_installation |> get_organization |> owned_by?(user)

--- a/lib/code_corps/policy/policy.ex
+++ b/lib/code_corps/policy/policy.ex
@@ -38,6 +38,10 @@ defmodule CodeCorps.Policy do
   defp can?(%User{} = current_user, :delete, %UserTask{} = user_task, %{}), do: Policy.UserTask.delete?(current_user, user_task)
   defp can?(%User{} = current_user, :create, %Project{}, %{} = params), do: Policy.Project.create?(current_user, params)
   defp can?(%User{} = current_user, :update, %Project{} = project, %{}), do: Policy.Project.update?(current_user, project)  
+  defp can?(%User{} = user, :delete,
+    %OrganizationGithubAppInstallation{} = organization_github_app_installation, %{}),
+      do: Policy.OrganizationGithubAppInstallation.delete?(user, organization_github_app_installation)
+  defp can?(%User{} = user, :create, %OrganizationGithubAppInstallation{}, %{} = params), do: Policy.OrganizationGithubAppInstallation.create?(user, params)
 
   defimpl Canada.Can, for: User do
     # NOTE: Canary sets an :unauthorized and a :not_found handler on a config level
@@ -59,9 +63,6 @@ defmodule CodeCorps.Policy do
 
     def can?(%User{} = user, :create, OrganizationInvite), do: Policy.OrganizationInvite.create?(user)
     def can?(%User{} = user, :update, %OrganizationInvite{}), do: Policy.OrganizationInvite.update?(user)
-
-    def can?(%User{} = user, :create, %Changeset{data: %OrganizationGithubAppInstallation{}} = changeset), do: Policy.OrganizationGithubAppInstallation.create?(user, changeset)
-    def can?(%User{} = user, :delete, %OrganizationGithubAppInstallation{} = github_app_installation), do: Policy.OrganizationGithubAppInstallation.delete?(user, github_app_installation)
 
     def can?(%User{} = user, :create, %Changeset{data: %Preview{}} = changeset), do: Policy.Preview.create?(user, changeset)
 

--- a/lib/code_corps_web/controllers/organization_github_app_installation_controller.ex
+++ b/lib/code_corps_web/controllers/organization_github_app_installation_controller.ex
@@ -1,30 +1,45 @@
 defmodule CodeCorpsWeb.OrganizationGithubAppInstallationController do
   use CodeCorpsWeb, :controller
-  use JaResource
 
   import CodeCorps.Helpers.Query, only: [id_filter: 2]
 
-  alias CodeCorps.{OrganizationGithubAppInstallation}
+  alias CodeCorps.{OrganizationGithubAppInstallation, User, Helpers.Query}
 
-  @preloads [:github_app_installation, :organization]
+  action_fallback CodeCorpsWeb.FallbackController
+  plug CodeCorpsWeb.Plug.DataToAttributes
 
-  plug :load_resource, model: OrganizationGithubAppInstallation, only: [:show], preload: @preloads
-  plug :load_and_authorize_changeset, model: OrganizationGithubAppInstallation, only: [:create], preload: @preloads
-  plug :load_and_authorize_resource, model: OrganizationGithubAppInstallation, only: [:delete]
-
-  plug JaResource
-
-  @spec model :: module
-  def model, do: CodeCorps.OrganizationGithubAppInstallation
-
-  @spec filter(Plug.Conn.t, Ecto.Query.t, String.t, String.t) :: Ecto.Query.t
-  def filter(_conn, query, "id", id_list) do
-    query |> id_filter(id_list)
+  @spec index(Conn.t, map) :: Conn.t
+  def index(%Conn{} = conn, %{} = params) do
+    with organization_installations <- OrganizationGithubAppInstallation |> Query.id_filter(params) |> Repo.all do
+      conn |> render("index.json-api", data: organization_installations)
+    end
   end
 
-  @spec handle_create(Plug.Conn.t, map) :: Ecto.Changeset.t
-  def handle_create(_conn, attributes) do
-    %OrganizationGithubAppInstallation{}
-    |> OrganizationGithubAppInstallation.create_changeset(attributes)
+  @spec show(Conn.t, map) :: Conn.t
+  def show(%Conn{} = conn, %{"id" => id}) do
+    with %OrganizationGithubAppInstallation{} = organization_installation <- OrganizationGithubAppInstallation |> Repo.get(id) do
+      conn |> render("show.json-api", data: organization_installation)
+    end
+  end
+
+  @spec create(Plug.Conn.t, map) :: Conn.t
+  def create(%Conn{} = conn, %{} = params) do
+    with %User{} = current_user <- conn |> Guardian.Plug.current_resource,
+         {:ok, :authorized} <- current_user |> Policy.authorize(:create, %OrganizationGithubAppInstallation{}, params),
+         {:ok, %OrganizationGithubAppInstallation{} = organization_installation} <- %OrganizationGithubAppInstallation{} |> OrganizationGithubAppInstallation.create_changeset(params) |> Repo.insert do
+      conn |> put_status(:created) |> render("show.json-api", data: organization_installation)
+    end
+  end
+
+  @spec delete(Plug.Conn.t, map) :: Conn.t
+  def delete(%Conn{} = conn, %{"id" => id} = params) do
+    with %OrganizationGithubAppInstallation{} = organization_github_installation <- OrganizationGithubAppInstallation |> Repo.get(id),
+         %User{} = current_user <- conn |> Guardian.Plug.current_resource,
+         {:ok, :authorized} <- current_user |> Policy.authorize(:delete, organization_github_installation, params),
+         {:ok, _organization_github_installation} <-
+           organization_github_installation
+           |> Repo.delete do
+      conn |> send_resp(:no_content, "")
+    end
   end
 end

--- a/test/lib/code_corps/policy/organization_github_app_installation_test.exs
+++ b/test/lib/code_corps/policy/organization_github_app_installation_test.exs
@@ -11,22 +11,16 @@ defmodule CodeCorps.Policy.OrganizationGithubAppInstallationTest do
       user = insert(:user)
       organization = insert(:organization, owner: user)
       github_app_installation = insert(:github_app_installation)
-      changeset =
-        %OrganizationGithubAppInstallation{}
-        |> create_changeset(%{github_app_installation_id: github_app_installation.id, organization_id: organization.id})
 
-      assert create?(user, changeset)
+      assert create?(user, %{github_app_installation_id: github_app_installation.id, organization_id: organization.id})
     end
 
     test "returns false for normal user" do
       user = insert(:user)
       organization = insert(:organization)
-      github_app_installation = insert(:github_app_installation)
-      changeset =
-        %OrganizationGithubAppInstallation{}
-        |> create_changeset(%{github_app_installation_id: github_app_installation.id, organization_id: organization.id})
 
-      refute create?(user, changeset)
+      github_app_installation = insert(:github_app_installation)
+      refute create?(user, %{github_app_installation_id: github_app_installation.id, organization_id: organization.id})
     end
   end
 

--- a/test/lib/code_corps_web/controllers/organization_github_app_installation_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/organization_github_app_installation_controller_test.exs
@@ -75,7 +75,6 @@ defmodule CodeCorpsWeb.OrganizationGithubAppInstallationControllerTest do
     test "deletes resource", %{conn: conn, current_user: user} do
       organization = insert(:organization, owner: user)
       record = insert(:organization_github_app_installation, organization: organization)
-
       assert conn |> request_delete(record) |> response(204)
     end
 


### PR DESCRIPTION
Switch OrganizationGithubAppInstallationController away from ja_resource and canary

Closes #893

# What's in this PR?

Switch OrganizationGithubAppInstallationController away from ja_resource and canary

Make sure any changes to code include changes to documentation.

## References
Fixes # 893

Progress on: # 864
