### PR TITLE
Fixes a bug in organization_test.exs where a user who is not an admin…

### DIFF
--- a/test/lib/code_corps/policy/organization_test.exs
+++ b/test/lib/code_corps/policy/organization_test.exs
@@ -23,7 +23,7 @@ defmodule CodeCorps.Policy.OrganizationTest do
     end
 
     test "returns true when user is the organization owner" do
-      user = insert(:user, admin: true)
+      user = insert(:user)
       organization = build(:organization, owner_id: user.id)
       assert update?(user, organization)
     end


### PR DESCRIPTION
Fixes bug #885

# What's in this PR?
Simply removed `admin:true` from the test when user is created.