### PR TITLE
Cleaned up ProjectController, introduced Project.Query

### DIFF
--- a/lib/code_corps/helpers/query.ex
+++ b/lib/code_corps/helpers/query.ex
@@ -12,14 +12,6 @@ defmodule CodeCorps.Helpers.Query do
     query |> where([object], object.id in ^ids)
   end
 
-  # project queries
-
-  def approved_filter(query, approved) do
-    query |> where([object], object.approved == ^approved)
-  end
-
-  # end project queries
-
   # skill queries
 
   def limit_filter(query, %{"limit" => count}), do: query |> add_limit(count |> Integer.parse)

--- a/lib/code_corps/project/query.ex
+++ b/lib/code_corps/project/query.ex
@@ -1,0 +1,49 @@
+defmodule CodeCorps.Project.Query do
+  @moduledoc ~S"""
+  Contains queries for retrieving projects
+  """
+  alias CodeCorps.{
+    Project,
+    SluggedRoute,
+    Repo
+  }
+
+  import Ecto.Query
+
+  @doc ~S"""
+  Returns a list of `Project` records based on the provided filter.
+
+  If the filter contains a `slug` key, returns all projects for the specified
+  `Organization.`
+
+  If the filter does not contain a `slug` key, returns all `approved` projects.
+  """
+  @spec list(map) :: list(Project.t)
+  def list(%{"slug" => slug}) do
+    SluggedRoute
+    |> Repo.get_by(slug: slug |> String.downcase)
+    |> Repo.preload([organization: :projects])
+    |> Map.get(:organization)
+    |> Map.get(:projects)
+  end
+  def list(%{}) do
+    Project
+    |> where(approved: true)
+    |> Repo.all
+  end
+
+  @doc ~S"""
+  Finds and returns a single `Project` record based on a map of parameters.
+
+  If the map contains a `project_slug` key, retrieves record by `slug`.
+
+  If the map contains an `id`, retrieves by id.
+  """
+  @spec find(map) :: Project.t | nil
+  def find(%{"project_slug" => slug}) do
+    Project |> Repo.get_by(slug: slug |> String.downcase)
+  end
+  def find(%{"id" => id}) do
+    Project |> Repo.get(id)
+  end
+end

--- a/lib/code_corps_web/controllers/project_controller.ex
+++ b/lib/code_corps_web/controllers/project_controller.ex
@@ -1,36 +1,21 @@
 defmodule CodeCorpsWeb.ProjectController do
   use CodeCorpsWeb, :controller
 
-  alias CodeCorps.{Helpers.Query, Project, User}
+  alias CodeCorps.{Project, User}
 
   action_fallback CodeCorpsWeb.FallbackController
-  plug CodeCorpsWeb.Plug.DataToAttributes  
+  plug CodeCorpsWeb.Plug.DataToAttributes
 
   @spec index(Conn.t, map) :: Conn.t
-  def index(%Conn{} = conn, _params) do
-    with projects <- Project |> Query.approved_filter(true) |> Repo.all do
-      conn |> render("index.json-api", data: projects)
-    end
-  end
-
-  @spec index(Conn.t, map) :: Conn.t
-  def index(%Conn{} = conn, %{"slug" => slug}) do
-    slugged_route = CodeCorps.SluggedRoute |> Query.slug_finder(slug)
-    with projects <- Project |> Repo.all(organization_id: slugged_route.organization_id) do
+  def index(%Conn{} = conn, %{} = params) do
+    with projects <- Project.Query.list(params) do
       conn |> render("index.json-api", data: projects)
     end
   end
 
   @spec show(Conn.t, map) :: Conn.t
-  def show(%Conn{} = conn, %{"id" => id}) do
-    with %Project{} = project <- Project |> Repo.get(id) do
-      conn |> render("show.json-api", data: project)
-    end
-  end
-
-  @spec show(Conn.t, map) :: Conn.t
-  def show(%Conn{} = conn, %{"project_slug" => project_slug}) do
-    with %Project{} = project <- Project |> Query.slug_finder(project_slug) do
+  def show(%Conn{} = conn, %{} = params) do
+    with %Project{} = project <- Project.Query.find(params) do
       conn |> render("show.json-api", data: project)
     end
   end
@@ -45,8 +30,8 @@ defmodule CodeCorpsWeb.ProjectController do
   end
 
   @spec update(Conn.t, map) :: Conn.t
-  def update(%Conn{} = conn, %{"id" => id} = params) do
-    with %Project{} = project <- Project |> Repo.get(id),
+  def update(%Conn{} = conn, %{} = params) do
+    with %Project{} = project <- Project.Query.find(params),
       %User{} = current_user <- conn |> Guardian.Plug.current_resource,
       {:ok, :authorized} <- current_user |> Policy.authorize(:update, project),
       {:ok, %Project{} = project} <- project |> Project.changeset(params) |> Repo.update do


### PR DESCRIPTION
I approved and merged #933 because the changed seemed perfectly fine (and they were), while the tests were passing.

However, post-merge, I got a couple of compiler warnings and realized the merge introduced a bug due to different ordering of `ProjectController` actions. The test that was supposed to fail was passing due to missing a key assertion.

In order to resolve it in a clean way, I rewrote the test, then proceeded to collapse the multiple function clauses in the controller into one and extracted data loading for the actions into a `Project.Query` module, which follows a similar approach to the one I'm implementing with tasks in #805