### PR TITLE
779 Scheme is missing when images are placed into email dynamically f…

### DIFF
--- a/lib/code_corps/cloudex/cloudinary_url.ex
+++ b/lib/code_corps/cloudex/cloudinary_url.ex
@@ -7,5 +7,15 @@ defmodule CodeCorps.Cloudex.CloudinaryUrl do
   end
   def for(public_id, options, _version, _default_color, _type) do
     @cloudex.Url.for(public_id, options)
+    |> add_uri_scheme
   end
+
+  defp add_uri_scheme(generated_url) do
+    base_url =  String.split(generated_url, "//")
+    add_https(base_url)
+  end
+
+  defp add_https(base_url) when is_list(base_url) and length(base_url) > 0, do: "https://" <> List.last(base_url)
+  defp add_https(url), do: url
+
 end

--- a/test/lib/code_corps/cloudex/cloudinary_url_test.exs
+++ b/test/lib/code_corps/cloudex/cloudinary_url_test.exs
@@ -8,6 +8,12 @@ defmodule CodeCorps.Cloudex.CloudinaryUrlTest do
     assert expected_url == url
   end
 
+  test "call Cloudex.Url.for insert https://" do
+    expected_url = "https://placehold.it/100x100"
+    url = CloudinaryUrl.for("//placehold.it/100x100", %{height: 100, width: 100}, nil, nil, nil)
+    assert expected_url == url
+  end
+
   test "returns correct url if called without public_id" do
     expected_url = "#{Application.get_env(:code_corps, :asset_host)}/icons/type1_default_version1_color1.png"
     url = CloudinaryUrl.for(nil, %{}, "version1", "color1", "type1")


### PR DESCRIPTION
779 Scheme is missing when images are placed into email dynamically from Cloudinary

# What's in this PR?

Added a function to prepend cloudinary url's with https://

## References
Fixes #

Progress on: #
