### PR TITLE
Rewrote api helpers to use string ids, which is what our ember client sends

### DIFF
--- a/lib/code_corps_web/controllers/comment_controller.ex
+++ b/lib/code_corps_web/controllers/comment_controller.ex
@@ -5,6 +5,7 @@ defmodule CodeCorpsWeb.CommentController do
 
   action_fallback CodeCorpsWeb.FallbackController
   plug CodeCorpsWeb.Plug.DataToAttributes
+  plug CodeCorpsWeb.Plug.IdsToIntegers
 
   @spec index(Conn.t, map) :: Conn.t
   def index(%Conn{} = conn, %{} = params) do

--- a/lib/code_corps_web/plugs/ids_to_integers.ex
+++ b/lib/code_corps_web/plugs/ids_to_integers.ex
@@ -1,7 +1,11 @@
 defmodule CodeCorpsWeb.Plug.IdsToIntegers do
   @moduledoc ~S"""
-  Converts id values (primary or relationships) in a conn params map into
-  integers, if applicable.
+  Converts `id` values in a `conn` parameters map into integers, if applicable.
+
+  The JSON API specification expects `id` values in resource objects to be
+  strings.
+
+  See http://jsonapi.org/format/#document-resource-object-identification
   """
 
   alias Plug.Conn
@@ -22,7 +26,7 @@ defmodule CodeCorpsWeb.Plug.IdsToIntegers do
 
   @spec convert_key_value(tuple) :: tuple
   defp convert_key_value({key, value}) do
-    case key |> convert?() do
+    case convert?(key) do
       true -> {key, value |> ensure_integer()}
       false -> {key, value}
     end


### PR DESCRIPTION
This PR modifies the test JSON Payload helper to create relationships with keys cast to strings, to match the behavior our Ember client uses.

This change reveals a bug in the comment controller, so the PR also fixes that bug, by adding the `IdsToIntegers` plug into the controller pipeline. It's unfortunate that this needs to be done on a case-by-case basis right now, but once we get away from ja_resource completely, we can move that plug, as well as `DataToAttributes`, into a router pipeline.

Merging this PR will likely reveal bugs in several other open PRs.


