### PR TITLE
Removed test_watch as a dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,6 @@ defmodule CodeCorps.Mixfile do
       {:ja_resource, "~> 0.2"},
       {:ja_serializer, "~> 0.12"}, # JSON API
       {:joken, "~> 1.5"}, # JWT encoding
-      {:mix_test_watch, "~> 0.4", only: :dev}, # Test watcher
       {:money, "~> 1.2.1"},
       {:poison, "~> 3.0", override: true},
       {:scrivener_ecto, "~> 1.2"}, # DB query pagination


### PR DESCRIPTION
Discovered in #925 

Tests run each time we change something in the code while `mix phx.server` is running. This is not really our work flow and hasn't been like this since docker times, so this PR simply removes the `mix_test_watch` dependency.

To explain why this suddenly started happening.

We had it as a dependency, but in the move to Phoenix 1.3, I also performed a migration to Elixir 1.4

One of the new features of 1.4 is that we no longer need to explicitly specify an `applications: []` list parameter, to specify which applications need to run alongside the main application. Instead, this is inferred from the dependency list.

Prior to the move, we did specify a list explicitly, and `mix_test_watch` wasn't in it, so it didn't run. Basically, we had an external dependency which we weren't using.

In the migration PR, I removed this list, so now it's being inferred, so now `mix_test_watch` runs. Since this was an unused dependency before the move, the "fix" is to explicitly remove it.