### PR TITLE
Added "github" context to users created during github sync

### DIFF
--- a/lib/code_corps/accounts/accounts.ex
+++ b/lib/code_corps/accounts/accounts.ex
@@ -1,0 +1,26 @@
+defmodule CodeCorps.Accounts do
+  @moduledoc ~S"""
+  Main entry-point for managing accounts.
+
+  All actions to acounts should go through here.
+  """
+
+  alias CodeCorps.{
+    GitHub.Adapters,
+    User,
+    Repo
+  }
+  alias Ecto.Changeset
+
+  @doc ~S"""
+  Creates a user record using attributes from a GitHub payload.
+  """
+  @spec create_from_github(map) :: {:ok, User.t} | {:error, Changeset.t}
+  def create_from_github(%{} = attrs) do
+    %User{}
+    |> Changeset.change(attrs |> Adapters.User.from_github_user())
+    |> Changeset.put_change(:context, "github")
+    |> Changeset.unique_constraint(:email)
+    |> Repo.insert
+  end
+end

--- a/lib/code_corps/github/event/issue_comment/user_linker.ex
+++ b/lib/code_corps/github/event/issue_comment/user_linker.ex
@@ -5,11 +5,10 @@ defmodule CodeCorps.GitHub.Event.IssueComment.UserLinker do
   """
 
   alias CodeCorps.{
+    Accounts,
     Repo,
     User
   }
-  alias CodeCorps.GitHub.Adapters.User, as: UserAdapter
-  alias Ecto.Changeset
 
   @doc ~S"""
   Finds or creates a user using information contained in an Issues webhook
@@ -18,7 +17,7 @@ defmodule CodeCorps.GitHub.Event.IssueComment.UserLinker do
   @spec find_or_create_user(map) :: {:ok, User.t}
   def find_or_create_user(%{"comment" => %{"user" => user_attrs}}) do
     case user_attrs |> find_user() do
-      nil -> user_attrs |> create_user()
+      nil -> user_attrs |> Accounts.create_from_github
       %User{} = user -> {:ok, user}
     end
   end
@@ -26,12 +25,5 @@ defmodule CodeCorps.GitHub.Event.IssueComment.UserLinker do
   @spec find_user(map) :: User.t | nil
   defp find_user(%{"id" => github_id}) do
     User |> Repo.get_by(github_id: github_id)
-  end
-
-  @spec create_user(map) :: {:ok, User.t}
-  defp create_user(%{} = user_attrs) do
-    %User{}
-    |> Changeset.change(user_attrs |> UserAdapter.from_github_user())
-    |> Repo.insert
   end
 end

--- a/lib/code_corps/github/event/issues/user_linker.ex
+++ b/lib/code_corps/github/event/issues/user_linker.ex
@@ -5,11 +5,10 @@ defmodule CodeCorps.GitHub.Event.Issues.UserLinker do
   """
 
   alias CodeCorps.{
+    Accounts,
     Repo,
     User
   }
-  alias CodeCorps.GitHub.Adapters.User, as: UserAdapter
-  alias Ecto.Changeset
 
   @doc ~S"""
   Finds or creates a user using information contained in an Issues webhook
@@ -18,7 +17,7 @@ defmodule CodeCorps.GitHub.Event.Issues.UserLinker do
   @spec find_or_create_user(map) :: {:ok, User.t}
   def find_or_create_user(%{"issue" => %{"user" => user_attrs}}) do
     case user_attrs |> find_user() do
-      nil -> user_attrs |> create_user()
+      nil -> user_attrs |> Accounts.create_from_github
       %User{} = user -> {:ok, user}
     end
   end
@@ -26,12 +25,5 @@ defmodule CodeCorps.GitHub.Event.Issues.UserLinker do
   @spec find_user(map) :: User.t | nil
   defp find_user(%{"id" => github_id}) do
     User |> Repo.get_by(github_id: github_id)
-  end
-
-  @spec create_user(map) :: {:ok, User.t}
-  defp create_user(%{} = user_attrs) do
-    %User{}
-    |> Changeset.change(user_attrs |> UserAdapter.from_github_user())
-    |> Repo.insert
   end
 end

--- a/test/lib/code_corps/accounts/accounts_test.exs
+++ b/test/lib/code_corps/accounts/accounts_test.exs
@@ -1,0 +1,30 @@
+defmodule CodeCorps.AccountsTest do
+  @moduledoc false
+
+  use CodeCorps.DbAccessCase
+
+  alias CodeCorps.{Accounts, User, GitHub.TestHelpers}
+  alias Ecto.Changeset
+
+  describe "create_from_github/1" do
+    test "creates proper user from provided payload" do
+      {:ok, %User{} = user} =
+        "user"
+        |> TestHelpers.load_endpoint_fixture
+        |> Accounts.create_from_github
+
+      assert user.id
+      assert user.context == "github"
+    end
+
+    test "returns changeset if there was a validation error" do
+      %{"email" => email} = payload = TestHelpers.load_endpoint_fixture("user")
+      # email must be unique, so if a user with email already exists, this
+      # triggers a validation error
+      insert(:user, email: email)
+
+      {:error, %Changeset{} = changeset} = payload |> Accounts.create_from_github
+      assert changeset.errors[:email] == {"has already been taken", []}
+    end
+  end
+end


### PR DESCRIPTION
Closes #948 

`Issues.UserLinker` and `IssueComment.UserLinker` ended up needing the exact same change and are quite similar to begin with. Instead of trying to force this into a `Github.Event.Common` module, I figured this is a good opportunity to start a `CodeCorps.Account` bounded context, with its first function, `Account.create_from_github/1`

- added `Account` bounded context
- added `Account.create_from_github/1`
- added `AccountTest`
- added `fixtures/github/endpoint/user.json`

The context is simply `"github"` since the whole idea is that the user being created originates from github.
