### PR TITLE
Modify Task to accommodate Github sync timestamps

### DIFF
--- a/lib/code_corps/model/task.ex
+++ b/lib/code_corps/model/task.ex
@@ -15,6 +15,8 @@ defmodule CodeCorps.Task do
     field :status, :string, default: "open"
     field :title, :string
     field :github_issue_number, :integer
+    field :task_created_at, :naive_datetime
+    field :task_updated_at, :naive_datetime
 
     field :position, :integer, virtual: true
 
@@ -50,6 +52,7 @@ defmodule CodeCorps.Task do
     |> assoc_constraint(:project)
     |> assoc_constraint(:user)
     |> assoc_constraint(:github_repo)
+    |> set_datetime(:task_created_at)
     |> put_change(:status, "open")
   end
 
@@ -57,6 +60,7 @@ defmodule CodeCorps.Task do
     struct
     |> changeset(params)
     |> cast(params, [:status])
+    |> set_datetime(:task_updated_at)
     |> validate_inclusion(:status, statuses())
   end
 
@@ -66,6 +70,10 @@ defmodule CodeCorps.Task do
         put_change(changeset, :position, 0)
       _ -> changeset
     end
+  end
+
+  defp set_datetime(changeset, field) do
+    put_change(changeset, field, NaiveDateTime.utc_now)
   end
 
   defp statuses do

--- a/priv/repo/migrations/20170920131458_add_github_friendly_task_timestamps.exs
+++ b/priv/repo/migrations/20170920131458_add_github_friendly_task_timestamps.exs
@@ -1,0 +1,10 @@
+defmodule CodeCorps.Repo.Migrations.AddGithubFriendlyTaskTimestamps do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tasks) do
+      add :task_created_at, :timestamp
+      add :task_updated_at, :timestamp
+    end
+  end
+end

--- a/test/lib/code_corps/model/task_test.exs
+++ b/test/lib/code_corps/model/task_test.exs
@@ -37,5 +37,10 @@ defmodule CodeCorps.TaskTest do
       changeset = Task.update_changeset(%Task{}, changes)
       refute changeset.valid?
     end
+
+    test "sets task_updated_at" do
+      changeset = Task.update_changeset(%Task{}, @valid_attrs)
+      assert changeset |> get_change(:task_updated_at)
+    end
   end
 end


### PR DESCRIPTION
# What's in this PR?
Timestamps (`task_created_at` and `task_updated_at`) have been _added_ to Task. When `Task.update_changeset/2` is called, `task_updated_at` is updated. Likewise, when `Task.create_changeset/2` is called, `task_created_at` is updated.

#888 specified adding the new timestamp fields, which I understood to mean in addition to the default fields. If the defaults should be renamed, please let me know. Likewise, there was some inconsistency with a name. In one instance one of the new fields was referred to as `task_created_at`, while in another place it was referred to as `task_inserted_at`. I opted for the former, but I can do either one.

## References
Fixes #888 (first portion)

Progress on: #888, #878 
