### PR TITLE
Loosen markdown restrictions on Comment and Task

### DIFF
--- a/lib/code_corps/model/comment.ex
+++ b/lib/code_corps/model/comment.ex
@@ -22,7 +22,6 @@ defmodule CodeCorps.Comment do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:markdown])
-    |> validate_required([:markdown])
     |> MarkdownRendererService.render_markdown_to_html(:markdown, :body)
   end
 

--- a/lib/code_corps/model/task.ex
+++ b/lib/code_corps/model/task.ex
@@ -34,7 +34,7 @@ defmodule CodeCorps.Task do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:title, :markdown, :task_list_id, :position])
-    |> validate_required([:title, :markdown, :task_list_id])
+    |> validate_required([:title, :task_list_id])
     |> assoc_constraint(:task_list)
     |> apply_position()
     |> set_order(:position, :order, :task_list_id)

--- a/priv/repo/migrations/20170921014405_loosen_markdown_restrictions.exs
+++ b/priv/repo/migrations/20170921014405_loosen_markdown_restrictions.exs
@@ -1,0 +1,15 @@
+defmodule CodeCorps.Repo.Migrations.LoosenMarkdownRestrictions do
+  use Ecto.Migration
+
+  def up do
+    alter table(:comments) do
+      modify :markdown, :text, null: true
+    end
+  end
+
+  def down do
+    alter table(:comments) do
+      modify :markdown, :text, null: false
+    end
+  end
+end

--- a/test/lib/code_corps/model/comment_test.exs
+++ b/test/lib/code_corps/model/comment_test.exs
@@ -11,11 +11,6 @@ defmodule CodeCorps.CommentTest do
     assert changeset.valid?
   end
 
-  test "changeset with invalid attributes" do
-    changeset = Comment.changeset(%Comment{}, @invalid_attrs)
-    refute changeset.valid?
-  end
-
   test "create changeset with valid attributes" do
     attrs =
       @valid_attrs

--- a/test/lib/code_corps_web/controllers/comment_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/comment_controller_test.exs
@@ -98,14 +98,6 @@ defmodule CodeCorpsWeb.CommentControllerTest do
       assert_received {:track, ^user_id, "Edited Comment", ^tracking_properties}
     end
 
-    @tag :authenticated
-    test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, current_user: current_user} do
-      comment = insert(:comment, user: current_user)
-      attrs = @invalid_attrs |> Map.merge(%{user: current_user})
-      json = conn |> request_update(comment, attrs) |> json_response(422)
-      assert json["errors"] != %{}
-    end
-
     test "does not update resource and renders 401 when not authenticated", %{conn: conn} do
       assert conn |> request_update(@valid_attrs) |> json_response(401)
     end


### PR DESCRIPTION
`NOT NULL` constraint from the comments table. Requirement validations for `markdown` on the `Task` and `Comment` models have been moved. Tests that were based on those requirements were removed.

## References
Fixes #962 

Progress on: #940 
