### PR TITLE
Remove ProjectSkillController reliance on ja_resources/canary

### DIFF
--- a/lib/code_corps/policy/helpers.ex
+++ b/lib/code_corps/policy/helpers.ex
@@ -60,6 +60,7 @@ defmodule CodeCorps.Policy.Helpers do
   Returns `CodeCorps.Project`
   """
   @spec get_project(struct | Changeset.t | any) :: Project.t
+  def get_project(%{"project_id" =>  id}), do: Project |> Repo.get(id)
   def get_project(%{project_id: id}), do: Project |> Repo.get(id)
   def get_project(%Changeset{changes: %{project_id: id}}), do: Project |> Repo.get(id)
   def get_project(_), do: nil

--- a/lib/code_corps/policy/policy.ex
+++ b/lib/code_corps/policy/policy.ex
@@ -38,9 +38,11 @@ defmodule CodeCorps.Policy do
   defp can?(%User{} = current_user, :delete, %UserTask{} = user_task, %{}), do: Policy.UserTask.delete?(current_user, user_task)
   defp can?(%User{} = current_user, :create, %Project{}, %{} = params), do: Policy.Project.create?(current_user, params)
   defp can?(%User{} = current_user, :update, %Project{} = project, %{}), do: Policy.Project.update?(current_user, project)
+  defp can?(%User{} = current_user, :create, %ProjectSkill{}, %{} = params), do: Policy.ProjectSkill.create?(current_user, params)
+  defp can?(%User{} = current_user, :delete, %ProjectSkill{} = project_skill, %{}), do: Policy.ProjectSkill.delete?(current_user, project_skill)
   defp can?(%User{} = current_user, :create, %ProjectUser{}, %{} = params), do: Policy.ProjectUser.create?(current_user, params)
   defp can?(%User{} = current_user, :update, %ProjectUser{} = project_user, %{} = params), do: Policy.ProjectUser.update?(current_user, project_user, params)
-  defp can?(%User{} = current_user, :delete, %ProjectUser{} = project_user, %{}), do: Policy.ProjectUser.delete?(current_user, project_user)  
+  defp can?(%User{} = current_user, :delete, %ProjectUser{} = project_user, %{}), do: Policy.ProjectUser.delete?(current_user, project_user)
   defp can?(%User{} = user, :delete,
     %OrganizationGithubAppInstallation{} = organization_github_app_installation, %{}),
       do: Policy.OrganizationGithubAppInstallation.delete?(user, organization_github_app_installation)
@@ -82,9 +84,6 @@ defmodule CodeCorps.Policy do
 
     def can?(%User{} = user, :create, %Changeset{data: %ProjectGithubRepo{}} = changeset), do: Policy.ProjectGithubRepo.create?(user, changeset)
     def can?(%User{} = user, :delete, %ProjectGithubRepo{} = project_github_repo), do: Policy.ProjectGithubRepo.delete?(user, project_github_repo)
-
-    def can?(%User{} = user, :create, %Changeset{data: %ProjectSkill{}} = changeset), do: Policy.ProjectSkill.create?(user, changeset)
-    def can?(%User{} = user, :delete, %ProjectSkill{} = project_skill), do: Policy.ProjectSkill.delete?(user, project_skill)
 
     def can?(%User{} = user, :create, Role), do: Policy.Role.create?(user)
 

--- a/lib/code_corps/policy/project_skill.ex
+++ b/lib/code_corps/policy/project_skill.ex
@@ -2,12 +2,13 @@ defmodule CodeCorps.Policy.ProjectSkill do
   import CodeCorps.Policy.Helpers, only: [get_project: 1, administered_by?: 2]
 
   alias CodeCorps.{ProjectSkill, User}
-  alias Ecto.Changeset
 
-  def create?(%User{} = user, %Changeset{} = changeset) do
-    changeset |> get_project |> administered_by?(user)
+  @spec create?(User.t, map) :: boolean
+  def create?(%User{} = user, %{} = params) do
+    params |> get_project |> administered_by?(user)
   end
 
+  @spec delete?(User.t, ProjectSkill.t) :: boolean
   def delete?(%User{} = user, %ProjectSkill{} = project_skill) do
     project_skill |> get_project |> administered_by?(user)
   end

--- a/lib/code_corps_web/controllers/project_skill_controller.ex
+++ b/lib/code_corps_web/controllers/project_skill_controller.ex
@@ -1,24 +1,43 @@
 defmodule CodeCorpsWeb.ProjectSkillController do
   use CodeCorpsWeb, :controller
-  use JaResource
 
-  import CodeCorps.Helpers.Query, only: [id_filter: 2]
+  alias CodeCorps.{ProjectSkill, User, Helpers.Query}
 
-  alias CodeCorps.ProjectSkill
+  action_fallback CodeCorpsWeb.FallbackController
+  plug CodeCorpsWeb.Plug.DataToAttributes
+  plug CodeCorpsWeb.Plug.IdsToIntegers
 
-  plug :load_resource, model: ProjectSkill, only: [:show], preload: [:project, :skill]
-  plug :load_and_authorize_changeset, model: ProjectSkill, only: [:create]
-  plug :load_and_authorize_resource, model: ProjectSkill, only: [:delete]
-  plug JaResource
-
-  @spec model :: module
-  def model, do: CodeCorps.ProjectSkill
-
-  def filter(_conn, query, "id", id_list) do
-    query |> id_filter(id_list)
+  @spec index(Conn.t, map) :: Conn.t
+  def index(%Conn{} = conn, %{} = params) do
+    with project_skills <- ProjectSkill |> Query.id_filter(params) |> Repo.all do
+      conn |> render("index.json-api", data: project_skills)
+    end
   end
 
-  def handle_create(_conn, attributes) do
-    %ProjectSkill{} |> ProjectSkill.create_changeset(attributes)
+  @spec show(Conn.t, map) :: Conn.t
+  def show(%Conn{} = conn, %{"id" => id}) do
+    with %ProjectSkill{} = project_skill <- ProjectSkill |> Repo.get(id) do
+      conn |> render("show.json-api", data: project_skill)
+    end
+  end
+
+  @spec create(Plug.Conn.t, map) :: Conn.t
+  def create(%Conn{} = conn, %{} = params) do
+    with %User{} = current_user <- conn |> Guardian.Plug.current_resource,
+         {:ok, :authorized} <- current_user |> Policy.authorize(:create, %ProjectSkill{}, params),
+         {:ok, %ProjectSkill{} = project_skill} <- %ProjectSkill{} |> ProjectSkill.create_changeset(params) |> Repo.insert do
+      conn |> put_status(:created) |> render("show.json-api", data: project_skill)
+    end
+  end
+
+  @spec delete(Conn.t, map) :: Conn.t
+  def delete(%Conn{} = conn, %{"id" => id} = _params) do
+    with %ProjectSkill{} = project_skill <- ProjectSkill |> Repo.get(id),
+      %User{} = current_user <- conn |> Guardian.Plug.current_resource,
+      {:ok, :authorized} <- current_user |> Policy.authorize(:delete, project_skill),
+      {:ok, %ProjectSkill{} = _project_skill} <- project_skill |> Repo.delete
+    do
+      conn |> Conn.assign(:project_skill, project_skill) |> send_resp(:no_content, "")
+    end
   end
 end

--- a/test/lib/code_corps/policy/project_skill_test.exs
+++ b/test/lib/code_corps/policy/project_skill_test.exs
@@ -2,45 +2,42 @@ defmodule CodeCorps.Policy.ProjectSkillTest do
   use CodeCorps.PolicyCase
 
   import CodeCorps.Policy.ProjectSkill, only: [create?: 2, delete?: 2]
-  import CodeCorps.ProjectSkill, only: [create_changeset: 2]
-
-  alias CodeCorps.ProjectSkill
 
   describe "create?" do
     test "returns false when user is not a project member" do
       user = insert(:user)
       project = insert(:project)
 
-      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      refute create?(user, changeset)
+      params = %{project_id: project.id}
+      refute create?(user, params)
     end
 
     test "returns false when user is a pending project member" do
       %{project: project, user: user} = insert(:project_user, role: "pending")
 
-      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      refute create?(user, changeset)
+      params = %{project_id: project.id}
+      refute create?(user, params)
     end
 
     test "returns false when user is a project contributor" do
       %{project: project, user: user} = insert(:project_user, role: "contributor")
 
-      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      refute create?(user, changeset)
+      params = %{project_id: project.id}
+      refute create?(user, params)
     end
 
     test "returns true when user is a project admin" do
       %{project: project, user: user} = insert(:project_user, role: "admin")
 
-      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset)
+      params = %{project_id: project.id}
+      assert create?(user, params)
     end
 
     test "returns true when user is project owner" do
       %{project: project, user: user} = insert(:project_user, role: "owner")
 
-      changeset = %ProjectSkill{} |> create_changeset(%{project_id: project.id})
-      assert create?(user, changeset)
+      params = %{project_id: project.id}
+      assert create?(user, params)
     end
   end
 


### PR DESCRIPTION
Remove `ProjectSkillController` reliance on `ja_resources`/`canary`.

## References
Closes #899 

Progress on: #864 
