### PR TITLE
Remove JaResource/Canary from RoleSkillController

### DIFF
--- a/lib/code_corps/model/role_skill.ex
+++ b/lib/code_corps/model/role_skill.ex
@@ -15,25 +15,30 @@ defmodule CodeCorps.RoleSkill do
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
-  @spec changeset(CodeCorps.RoleSkill.t, map) :: Ecto.Changeset.t
-  def changeset(struct, params \\ %{}) do
-    struct
-    |> cast(params, [:role_id, :skill_id])
-    |> validate_required([:role_id, :skill_id])
-    |> assoc_constraint(:role)
-    |> assoc_constraint(:skill)
-    |> unique_constraint(:role_id, name: :index_projects_on_role_id_skill_id)
+  @spec create_changeset(CodeCorps.RoleSkill.t, map) :: Ecto.Changeset.t
+  def create_changeset(struct, params \\ %{}) do
+    changeset(struct, params)
   end
 
   @doc """
   Builds a changeset for importing a category.
   """
   @spec import_changeset(CodeCorps.RoleSkill.t, map) :: Ecto.Changeset.t
-  def import_changeset(struct, params) do
+  def import_changeset(struct, params \\ %{}) do
     struct
     |> changeset(params)
     |> cast(params, [:cat])
     |> validate_inclusion(:cat, cats())
+  end
+
+  @spec changeset(CodeCorps.RoleSkill.t, map) :: Ecto.Changeset.t
+  defp changeset(struct, params) do
+    struct
+    |> cast(params, [:role_id, :skill_id])
+    |> validate_required([:role_id, :skill_id])
+    |> assoc_constraint(:role)
+    |> assoc_constraint(:skill)
+    |> unique_constraint(:role_id, name: :index_projects_on_role_id_skill_id)
   end
 
   defp cats do

--- a/lib/code_corps/policy/policy.ex
+++ b/lib/code_corps/policy/policy.ex
@@ -47,6 +47,8 @@ defmodule CodeCorps.Policy do
     %OrganizationGithubAppInstallation{} = organization_github_app_installation, %{}),
       do: Policy.OrganizationGithubAppInstallation.delete?(user, organization_github_app_installation)
   defp can?(%User{} = user, :create, %OrganizationGithubAppInstallation{}, %{} = params), do: Policy.OrganizationGithubAppInstallation.create?(user, params)
+  defp can?(%User{} = current_user, :create, %RoleSkill{}, %{}), do: Policy.RoleSkill.create?(current_user)
+  defp can?(%User{} = current_user, :delete, %RoleSkill{}, %{}), do: Policy.RoleSkill.delete?(current_user)
   defp can?(%User{} = current_user, :create, %TaskSkill{}, %{} = params), do: Policy.TaskSkill.create?(current_user, params)
   defp can?(%User{} = current_user, :delete, %TaskSkill{} = task_skill, %{}), do: Policy.TaskSkill.delete?(current_user, task_skill)
   defp can?(%User{} = current_user, :create, %UserCategory{} = user_category, %{}), do: Policy.UserCategory.create?(current_user, user_category)
@@ -89,9 +91,6 @@ defmodule CodeCorps.Policy do
     def can?(%User{} = user, :delete, %ProjectGithubRepo{} = project_github_repo), do: Policy.ProjectGithubRepo.delete?(user, project_github_repo)
 
     def can?(%User{} = user, :create, Role), do: Policy.Role.create?(user)
-
-    def can?(%User{} = user, :create, RoleSkill), do: Policy.RoleSkill.create?(user)
-    def can?(%User{} = user, :delete, %RoleSkill{}), do: Policy.RoleSkill.delete?(user)
 
     def can?(%User{} = user, :create, Skill), do: Policy.Skill.create?(user)
 

--- a/lib/code_corps/policy/role_skill.ex
+++ b/lib/code_corps/policy/role_skill.ex
@@ -1,9 +1,11 @@
 defmodule CodeCorps.Policy.RoleSkill do
   alias CodeCorps.User
 
+  @spec create?(User.t) :: boolean
   def create?(%User{admin: true}), do: true
   def create?(%User{admin: false}), do: false
 
+  @spec delete?(User.t) :: boolean
   def delete?(%User{admin: true}), do: true
   def delete?(%User{admin: false}), do: false
 end

--- a/lib/code_corps_web/controllers/role_skill_controller.ex
+++ b/lib/code_corps_web/controllers/role_skill_controller.ex
@@ -1,18 +1,44 @@
 defmodule CodeCorpsWeb.RoleSkillController do
   use CodeCorpsWeb, :controller
-  use JaResource
 
-  import CodeCorps.Helpers.Query, only: [id_filter: 2]
+  alias CodeCorps.{RoleSkill, User, Helpers.Query}
 
-  alias CodeCorps.RoleSkill
+  action_fallback CodeCorpsWeb.FallbackController
+  plug CodeCorpsWeb.Plug.DataToAttributes
+  plug CodeCorpsWeb.Plug.IdsToIntegers
 
-  plug :load_and_authorize_resource, model: RoleSkill, only: [:create, :delete]
-  plug JaResource
+  @spec index(Conn.t, map) :: Conn.t
+  def index(%Conn{} = conn, %{} = params) do
+    with role_skills <- RoleSkill |> Query.id_filter(params) |> Repo.all do
+      conn |> render("index.json-api", data: role_skills)
+    end
+  end
 
-  @spec model :: module
-  def model, do: CodeCorps.RoleSkill
+  @spec show(Conn.t, map) :: Conn.t
+  def show(%Conn{} = conn, %{"id" => id}) do
+    with %RoleSkill{} = role_skill <- RoleSkill |> Repo.get(id) do
+      conn |> render("show.json-api", data: role_skill)
+    end
+  end
 
-  def filter(_conn, query, "id", id_list) do
-    query |> id_filter(id_list)
+  @spec create(Conn.t, map) :: Conn.t
+  def create(%Conn{} = conn, %{} = params) do
+    with %User{} = current_user <- conn |> Guardian.Plug.current_resource,
+      {:ok, :authorized} <- current_user |> Policy.authorize(:create, %RoleSkill{}, params),
+      {:ok, %RoleSkill{} = role_skill} <- %RoleSkill{} |> RoleSkill.create_changeset(params) |> Repo.insert
+    do
+      conn |> put_status(:created) |> render("show.json-api", data: role_skill)
+    end
+  end
+
+  @spec delete(Conn.t, map) :: Conn.t
+  def delete(%Conn{} = conn, %{"id" => id} = _params) do
+    with %RoleSkill{} = role_skill <- RoleSkill |> Repo.get(id),
+      %User{} = current_user <- conn |> Guardian.Plug.current_resource,
+      {:ok, :authorized} <- current_user |> Policy.authorize(:delete, role_skill),
+      {:ok, %RoleSkill{} = _role_skill} <- role_skill |> Repo.delete
+    do
+      conn |> Conn.assign(:role_skill, role_skill) |> send_resp(:no_content, "")
+    end
   end
 end

--- a/test/lib/code_corps/model/role_skill_test.exs
+++ b/test/lib/code_corps/model/role_skill_test.exs
@@ -3,38 +3,38 @@ defmodule CodeCorps.RoleSkillTest do
 
   alias CodeCorps.RoleSkill
 
-  test "changeset with valid attributes" do
+  test "create_changeset with valid attributes" do
     role_id = insert(:role).id
     skill_id = insert(:skill).id
 
-    changeset = RoleSkill.changeset(%RoleSkill{}, %{role_id: role_id, skill_id: skill_id})
+    changeset = RoleSkill.create_changeset(%RoleSkill{}, %{role_id: role_id, skill_id: skill_id})
     assert changeset.valid?
   end
 
-  test "changeset requires role_id" do
+  test "create_changeset requires role_id" do
     skill_id = insert(:skill).id
 
-    changeset = RoleSkill.changeset(%RoleSkill{}, %{skill_id: skill_id})
+    changeset = RoleSkill.create_changeset(%RoleSkill{}, %{skill_id: skill_id})
 
     refute changeset.valid?
     assert_error_message(changeset, :role_id, "can't be blank")
   end
 
-  test "changeset requires skill_id" do
+  test "create_changeset requires skill_id" do
     role_id = insert(:role).id
 
-    changeset = RoleSkill.changeset(%RoleSkill{}, %{role_id: role_id})
+    changeset = RoleSkill.create_changeset(%RoleSkill{}, %{role_id: role_id})
 
     refute changeset.valid?
     assert_error_message(changeset, :skill_id, "can't be blank")
   end
 
-  test "changeset requires id of actual role" do
+  test "create_changeset requires id of actual role" do
     role_id = -1
     skill_id = insert(:skill).id
 
     {result, changeset} =
-      RoleSkill.changeset(%RoleSkill{}, %{role_id: role_id, skill_id: skill_id})
+      RoleSkill.create_changeset(%RoleSkill{}, %{role_id: role_id, skill_id: skill_id})
       |> Repo.insert
 
     assert result == :error
@@ -42,12 +42,12 @@ defmodule CodeCorps.RoleSkillTest do
     assert_error_message(changeset, :role, "does not exist")
   end
 
-  test "changeset requires id of actual skill" do
+  test "create_changeset requires id of actual skill" do
     role_id = insert(:role).id
     skill_id = -1
 
     {result, changeset} =
-      RoleSkill.changeset(%RoleSkill{}, %{role_id: role_id, skill_id: skill_id})
+      RoleSkill.create_changeset(%RoleSkill{}, %{role_id: role_id, skill_id: skill_id})
       |> Repo.insert
 
     assert result == :error


### PR DESCRIPTION
Remove JaResource/Canary from RoleSkillController

`RoleSkill.changeset/2` was made private and is now called by a new function `RoleSkill.create_changeset/2`. This semantic change was made after observing some dialog in #966 

## References
Closes #902

Progress on: #864 
