### PR TITLE
Fix a number of warnings and change log levels

### DIFF
--- a/lib/code_corps/comment/service.ex
+++ b/lib/code_corps/comment/service.ex
@@ -42,8 +42,8 @@ defmodule CodeCorps.Comment.Service do
   defp marshall_result({:ok, %{github: %Comment{} = comment}}), do: {:ok, comment}
   defp marshall_result({:error, :comment, %Changeset{} = changeset, _steps}), do: {:error, changeset}
   defp marshall_result({:error, :github, result, _steps}) do
-    Logger.warn "An error occurred when creating/updating the comment with the GitHub API"
-    Logger.warn "#{inspect result}"
+    Logger.info "An error occurred when creating/updating the comment with the GitHub API"
+    Logger.info "#{inspect result}"
     {:error, :github}
   end
 

--- a/lib/code_corps/github/comment/comment.ex
+++ b/lib/code_corps/github/comment/comment.ex
@@ -6,14 +6,15 @@ defmodule CodeCorps.GitHub.Comment do
   alias CodeCorps.{Comment, GitHub, GithubAppInstallation, GithubRepo, Task, User}
 
   @spec create(Comment.t) :: GitHub.response
-  def create(%Comment{
-    task: %Task{
-      github_repo: %GithubRepo{
-        github_app_installation: %GithubAppInstallation{} = installation
-      }
-    } = task,
-    user:
-    %User{} = user} = comment) do
+  def create(
+    %Comment{
+      task: %Task{
+        github_repo: %GithubRepo{
+          github_app_installation: %GithubAppInstallation{} = installation
+        }
+      },
+      user: %User{} = user
+    } = comment) do
 
     endpoint = comment |> create_endpoint_for()
     attrs = comment |> GitHub.Adapters.Comment.to_github_comment
@@ -26,14 +27,15 @@ defmodule CodeCorps.GitHub.Comment do
   end
 
   @spec update(Comment.t) :: GitHub.response
-  def update(%Comment{
-    task: %Task{
-      github_repo: %GithubRepo{
-        github_app_installation: %GithubAppInstallation{} = installation
-      }
-    } = task,
-    user: %User{} = user,
-    github_id: id} = comment) do
+  def update(
+    %Comment{
+      task: %Task{
+        github_repo: %GithubRepo{
+          github_app_installation: %GithubAppInstallation{} = installation
+        }
+      },
+      user: %User{} = user
+    } = comment) do
 
     endpoint = comment |> update_endpoint_for()
     attrs = comment |> GitHub.Adapters.Comment.to_github_comment

--- a/lib/code_corps/task/service.ex
+++ b/lib/code_corps/task/service.ex
@@ -33,8 +33,8 @@ defmodule CodeCorps.Task.Service do
   defp marshall_result({:ok, %{github: %Task{} = task}}), do: {:ok, task}
   defp marshall_result({:error, :task, %Changeset{} = changeset, _steps}), do: {:error, changeset}
   defp marshall_result({:error, :github, result, _steps}) do
-    Logger.warn "An error occurred when creating/updating the task with the GitHub API"
-    Logger.warn "#{inspect result}"
+    Logger.info "An error occurred when creating/updating the task with the GitHub API"
+    Logger.info "#{inspect result}"
     {:error, :github}
   end
 

--- a/priv/repo/migrations/20161019090945_add_stripe_customers_cards_tables.exs
+++ b/priv/repo/migrations/20161019090945_add_stripe_customers_cards_tables.exs
@@ -3,7 +3,7 @@ defmodule CodeCorps.Repo.Migrations.AddStripeCustomersCardsTables do
 
   def change do
     create table(:stripe_customers) do
-      add :created, :datetime
+      add :created, :utc_datetime
       add :currency, :string
       add :delinquent, :boolean
       add :email, :string

--- a/priv/repo/migrations/20161021131026_create_stripe_plans_stripe_subscriptions.exs
+++ b/priv/repo/migrations/20161021131026_create_stripe_plans_stripe_subscriptions.exs
@@ -4,7 +4,7 @@ defmodule CodeCorps.Repo.Migrations.CreateStripePlansStripeSubscriptions do
   def change do
     create table(:stripe_plans) do
       add :amount, :integer
-      add :created, :datetime
+      add :created, :utc_datetime
       add :id_from_stripe, :string, null: false
       add :name, :string
 
@@ -17,16 +17,16 @@ defmodule CodeCorps.Repo.Migrations.CreateStripePlansStripeSubscriptions do
 
     create table(:stripe_subscriptions) do
       add :application_fee_percent, :decimal
-      add :cancelled_at, :datetime
+      add :cancelled_at, :utc_datetime
       add :customer_id_from_stripe, :string
-      add :created, :datetime
-      add :current_period_end, :datetime
-      add :current_period_start, :datetime
-      add :ended_at, :datetime
+      add :created, :utc_datetime
+      add :current_period_end, :utc_datetime
+      add :current_period_start, :utc_datetime
+      add :ended_at, :utc_datetime
       add :id_from_stripe, :string, null: false
       add :plan_id_from_stripe, :string, null: false
       add :quantity, :integer
-      add :start, :datetime
+      add :start, :utc_datetime
       add :status, :string
 
       add :stripe_plan_id, references(:stripe_plans), null: false

--- a/priv/repo/migrations/20161212005641_create_stripe_file_upload.exs
+++ b/priv/repo/migrations/20161212005641_create_stripe_file_upload.exs
@@ -3,7 +3,7 @@ defmodule CodeCorps.Repo.Migrations.CreateStripeFileUpload do
 
   def change do
     create table(:stripe_file_upload) do
-      add :created, :datetime
+      add :created, :utc_datetime
       add :id_from_stripe, :string, null: false
       add :purpose, :string
       add :size, :integer

--- a/priv/repo/migrations/20161218005913_add_verification_fields_to_stripe_connect_account.exs
+++ b/priv/repo/migrations/20161218005913_add_verification_fields_to_stripe_connect_account.exs
@@ -4,7 +4,7 @@ defmodule CodeCorps.Repo.Migrations.AddVerificationFieldsToStripeConnectAccount 
   def change do
     alter table(:stripe_connect_accounts) do
       add :verification_disabled_reason, :string
-      add :verification_due_by, :datetime
+      add :verification_due_by, :utc_datetime
       add :verification_fields_needed, {:array, :string}
     end
   end

--- a/priv/repo/migrations/20170102130055_add_tos_acceptance_fields_to_stripe_connect_accounts.exs
+++ b/priv/repo/migrations/20170102130055_add_tos_acceptance_fields_to_stripe_connect_accounts.exs
@@ -3,7 +3,7 @@ defmodule CodeCorps.Repo.Migrations.AddTosAcceptanceFieldsToStripeConnectAccount
 
   def change do
     alter table(:stripe_connect_accounts) do
-      add :tos_acceptance_date, :datetime
+      add :tos_acceptance_date, :utc_datetime
       add :tos_acceptance_ip, :string
       add :tos_acceptance_user_agent, :string
     end

--- a/priv/repo/migrations/20170102181053_convert_stripe_time_stamps_to_integers.exs
+++ b/priv/repo/migrations/20170102181053_convert_stripe_time_stamps_to_integers.exs
@@ -48,18 +48,18 @@ defmodule CodeCorps.Repo.Migrations.ConvertStripeTimeStampsToIntegers do
       remove :tos_acceptance_date
       remove :verification_due_by
 
-      add :tos_acceptance_date, :datetime
-      add :verification_due_by, :datetime
+      add :tos_acceptance_date, :utc_datetime
+      add :verification_due_by, :utc_datetime
     end
 
     alter table(:stripe_platform_customers) do
       remove :created
-      add :created, :datetime
+      add :created, :utc_datetime
     end
 
     alter table(:stripe_connect_plans) do
       remove :created
-      add :created, :datetime
+      add :created, :utc_datetime
     end
 
     alter table(:stripe_connect_subscriptions) do
@@ -70,18 +70,18 @@ defmodule CodeCorps.Repo.Migrations.ConvertStripeTimeStampsToIntegers do
       remove :ended_at
       remove :start
 
-      add :cancelled_at, :datetime
-      add :created, :datetime
-      add :current_period_end, :datetime
-      add :current_period_start, :datetime
-      add :ended_at, :datetime
-      add :start, :datetime
+      add :cancelled_at, :utc_datetime
+      add :created, :utc_datetime
+      add :current_period_end, :utc_datetime
+      add :current_period_start, :utc_datetime
+      add :ended_at, :utc_datetime
+      add :start, :utc_datetime
     end
 
     alter table(:stripe_file_upload) do
       remove :created
 
-      add :created, :datetime
+      add :created, :utc_datetime
     end
   end
 end

--- a/priv/repo/migrations/20170106013143_add_editable_to_task_lists.exs
+++ b/priv/repo/migrations/20170106013143_add_editable_to_task_lists.exs
@@ -1,8 +1,4 @@
 defmodule CodeCorps.Repo.Migrations.AddEditableToTaskLists do
-  alias CodeCorps.{Repo, TaskList}
-
-  import Ecto.Query
-
   use Ecto.Migration
 
   def up do


### PR DESCRIPTION
# What's in this PR?

- Fixes warnings about migrations relying on `:datetime`. I saw no harm in changing them to `:utc_datetime` instead.
- Changes `Logger.warn` to `Logger.info` in a few places
- Removes a few compiler warnings and does some quick reformatting where needed