### PR TITLE
Fixes log printing in non-hosted environments

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule CodeCorps.Mixfile do
   def application do
     [
       mod: {CodeCorps, []},
-      extra_applications: [:timber, :timex, :tzdata]
+      extra_applications: [:timex, :tzdata]
     ]
   end
 


### PR DESCRIPTION
@JoshSmith asked me to fix this issue where Timber metadata was appearing in development runtime logs.

This changes the way in which the Logger is configured to integrate with the Timber package. It inverts the prior determination of whether to use the "machine-friendly" version of the Timber output.

"Environment" here refers to the Mix build environment which CodeCorps also uses for runtime environment.

In the existing implmentation, the "machine-friendly" output is used for every environment except `:test`. It should really only be used for hosted environments. At the moment, those environments are `:prod` and `:staging`.

The logging configuration will now use the "developer-friendly" version of Timber output by default. If the environment is `:prod` or `:staging` it will switch to the "machine-friendly" version of Timber output.

I also removed `:timber` from the `:extra_applications` field in the Mix configuration. Elixir will automatically include `:timber` in the compiled applications list based on the dependencies.