### PR TITLE
Fix bug introduced into StripeConnectAccountController that does not update on Stripe

### DIFF
--- a/lib/code_corps_web/controllers/fallback_controller.ex
+++ b/lib/code_corps_web/controllers/fallback_controller.ex
@@ -3,6 +3,8 @@ defmodule CodeCorpsWeb.FallbackController do
 
   alias Ecto.Changeset
 
+  require Logger
+
   @type supported_fallbacks :: {:error, Changeset.t} |
                                {:error, :not_authorized} |
                                {:error, :github} |
@@ -32,5 +34,11 @@ defmodule CodeCorpsWeb.FallbackController do
     conn
     |> put_status(500)
     |> render(CodeCorpsWeb.ErrorView, "500.json", message: "An unknown error occurred with GitHub's API.")
+  end
+  def call(%Conn{} = conn, {:error, %Stripe.APIErrorResponse{message: message}}) do
+    Logger.info message
+    conn
+    |> put_status(500)
+    |> render(CodeCorpsWeb.ErrorView, "500.json", message: "An unknown error occurred with Stripe's API.")
   end
 end

--- a/lib/code_corps_web/controllers/stripe_connect_account_controller.ex
+++ b/lib/code_corps_web/controllers/stripe_connect_account_controller.ex
@@ -27,9 +27,9 @@ defmodule CodeCorpsWeb.StripeConnectAccountController do
   def create(%Conn{} = conn, params) do
     params =
       params
+      |> Map.put("managed", true)
       |> Map.put("tos_acceptance_ip", conn |> ConnUtils.extract_ip)
       |> Map.put("tos_acceptance_user_agent", conn |> ConnUtils.extract_user_agent)
-      |> Map.put("managed", true)
     with %User{} = current_user <- conn |> Guardian.Plug.current_resource,
          {:ok, :authorized} <- current_user |> Policy.authorize(:create, %StripeConnectAccount{}, params),
          {:ok, %StripeConnectAccount{} = account} <- StripeConnectAccountService.create(params) do
@@ -42,8 +42,8 @@ defmodule CodeCorpsWeb.StripeConnectAccountController do
     with %StripeConnectAccount{} = account <- StripeConnectAccount |> Repo.get(id),
          %User{} = current_user <- conn |> Guardian.Plug.current_resource,
          {:ok, :authorized} <- current_user |> Policy.authorize(:update, account, params),
-         {:ok, %StripeConnectAccount{} = account} <- account |> StripeConnectAccount.webhook_update_changeset(params) |> Repo.update do
-      conn |> render("show.json-api", data: account)
+         {:ok, %StripeConnectAccount{} = updated_account} <- account |> StripeConnectAccountService.update(params) do
+      conn |> render("show.json-api", data: updated_account)
     end
   end
 end


### PR DESCRIPTION
# What's in this PR?

A PR accidentally introduced a bug that ensures our Stripe Connect accounts don't get updated on Stripe itself.

The following PR fixes this.