### PR TITLE
Set default color for GitHub users

### DIFF
--- a/lib/code_corps/accounts/changesets.ex
+++ b/lib/code_corps/accounts/changesets.ex
@@ -4,6 +4,7 @@ defmodule CodeCorps.Accounts.Changesets do
   """
 
   alias CodeCorps.GitHub.Adapters
+  alias CodeCorps.Helpers.RandomIconColor
   alias Ecto.Changeset
 
   @doc ~S"""
@@ -16,6 +17,7 @@ defmodule CodeCorps.Accounts.Changesets do
     |> Changeset.put_change(:sign_up_context, "github")
     |> Changeset.unique_constraint(:email)
     |> Changeset.validate_inclusion(:type, ["bot", "user"])
+    |> RandomIconColor.generate_icon_color(:default_color)
   end
 
   @doc ~S"""

--- a/test/lib/code_corps/accounts/accounts_test.exs
+++ b/test/lib/code_corps/accounts/accounts_test.exs
@@ -14,6 +14,7 @@ defmodule CodeCorps.AccountsTest do
         |> Accounts.create_from_github
 
       assert user.id
+      assert user.default_color
       assert user.sign_up_context == "github"
       assert user.type == "user"
     end
@@ -27,7 +28,7 @@ defmodule CodeCorps.AccountsTest do
       {:error, %Changeset{} = changeset} =
         payload
         |> Accounts.create_from_github
-        
+
       assert changeset.errors[:email] == {"has already been taken", []}
     end
   end

--- a/test/lib/code_corps/accounts/changesets_test.exs
+++ b/test/lib/code_corps/accounts/changesets_test.exs
@@ -3,17 +3,20 @@ defmodule CodeCorps.Accounts.ChangesetsTest do
 
   use CodeCorps.DbAccessCase
 
-  alias CodeCorps.{Accounts, User}
+  alias CodeCorps.{Accounts.Changesets, User}
 
   describe "create_from_github_changeset/1" do
     test "validates inclusion of type" do
       params = %{"email" => "test@email.com", "type" => "Organization"}
 
-      changeset =
-        %User{}
-        |> Accounts.Changesets.create_from_github_changeset(params)
+      changeset = Changesets.create_from_github_changeset(%User{}, params)
 
       assert changeset.errors[:type] == {"is invalid", [validation: :inclusion]}
+    end
+
+    test "generates the default icon color" do
+      changeset = Changesets.create_from_github_changeset(%User{}, %{})
+      assert changeset.changes.default_color
     end
   end
 
@@ -22,9 +25,7 @@ defmodule CodeCorps.Accounts.ChangesetsTest do
       user = insert(:user, email: "original@email.com")
       params = %{"email" => "new@email.com"}
 
-      changeset =
-        user
-        |> Accounts.Changesets.update_from_github_oauth_changeset(params)
+      changeset = Changesets.update_from_github_oauth_changeset(user, params)
 
       refute changeset.changes[:email]
     end
@@ -33,9 +34,7 @@ defmodule CodeCorps.Accounts.ChangesetsTest do
       user = insert(:user, email: "original@email.com")
       params = %{"email" => nil}
 
-      changeset =
-        user
-        |> Accounts.Changesets.update_from_github_oauth_changeset(params)
+      changeset = Changesets.update_from_github_oauth_changeset(user, params)
 
       refute changeset.changes[:email]
     end
@@ -44,9 +43,7 @@ defmodule CodeCorps.Accounts.ChangesetsTest do
       user = insert(:user, email: nil)
       params = %{"email" => "new@email.com"}
 
-      changeset =
-        user
-        |> Accounts.Changesets.update_from_github_oauth_changeset(params)
+      changeset = Changesets.update_from_github_oauth_changeset(user, params)
 
       assert changeset.changes[:email]
     end
@@ -55,9 +52,7 @@ defmodule CodeCorps.Accounts.ChangesetsTest do
       user = insert(:user)
       params = %{}
 
-      changeset =
-        user
-        |> Accounts.Changesets.update_from_github_oauth_changeset(params)
+      changeset = Changesets.update_from_github_oauth_changeset(user, params)
 
       refute changeset.errors[:email]
     end


### PR DESCRIPTION
# What's in this PR?

Sets the default color for GitHub users upon creation.

## References
Fixes #947 