### PR TITLE
Reinstate the markdown restrictions on comments

### DIFF
--- a/lib/code_corps/model/comment.ex
+++ b/lib/code_corps/model/comment.ex
@@ -26,6 +26,7 @@ defmodule CodeCorps.Comment do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:markdown])
+    |> validate_required([:markdown])
     |> MarkdownRendererService.render_markdown_to_html(:markdown, :body)
   end
 

--- a/test/lib/code_corps_web/controllers/comment_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/comment_controller_test.exs
@@ -98,6 +98,14 @@ defmodule CodeCorpsWeb.CommentControllerTest do
       assert_received {:track, ^user_id, "Edited Comment", ^tracking_properties}
     end
 
+    @tag :authenticated
+    test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, current_user: current_user} do
+      comment = insert(:comment, user: current_user)
+      attrs = @invalid_attrs |> Map.merge(%{user: current_user})
+      json = conn |> request_update(comment, attrs) |> json_response(422)
+      assert json["errors"] != %{}
+    end
+
     test "does not update resource and renders 401 when not authenticated", %{conn: conn} do
       assert conn |> request_update(@valid_attrs) |> json_response(401)
     end


### PR DESCRIPTION
# What's in this PR?

This reinstates markdown validations on comments because it turns out that GitHub also requires something to be in the `body` of a comment for it to be posted.