### PR TITLE
Set GitHub user's avatar

### DIFF
--- a/lib/code_corps/cloudex/cloudex_test.ex
+++ b/lib/code_corps/cloudex/cloudex_test.ex
@@ -13,4 +13,14 @@ defmodule CloudexTest do
       "https://placehold.it/500x500"
     end
   end
+
+  @spec upload(String.t) :: Cloudex.UploadedImage.t
+  def upload(_url) do
+    [ok: %Cloudex.UploadedImage{public_id: fake_cloudinary_id()}]
+  end
+
+  defp fake_cloudinary_id do
+    :crypto.strong_rand_bytes(5)
+    |> Base.encode64
+  end
 end

--- a/lib/code_corps/cloudex/uploader.ex
+++ b/lib/code_corps/cloudex/uploader.ex
@@ -1,0 +1,8 @@
+defmodule CodeCorps.Cloudex.Uploader do
+
+  @cloudex Application.get_env(:code_corps, :cloudex)
+
+  def upload(url) do
+    @cloudex.upload(url)
+  end
+end

--- a/lib/code_corps/github/event/issues/user_linker.ex
+++ b/lib/code_corps/github/event/issues/user_linker.ex
@@ -17,7 +17,7 @@ defmodule CodeCorps.GitHub.Event.Issues.UserLinker do
   }
 
   @typep linking_result :: {:ok, User.t} |
-                           {:error, Ecto.Changeset.t}
+                           {:error, Ecto.Changeset.t} |
                            {:error, :multiple_users}
 
   @doc ~S"""
@@ -47,7 +47,8 @@ defmodule CodeCorps.GitHub.Event.Issues.UserLinker do
   defp match_users(
     %{
       "issue" => %{"number" => github_issue_number},
-      "repository" =>%{"id" => github_repo_id}}) do
+      "repository" =>%{"id" => github_repo_id}
+    }) do
 
     query = from u in User,
       distinct: u.id,

--- a/lib/code_corps/presenters/image_presenter.ex
+++ b/lib/code_corps/presenters/image_presenter.ex
@@ -2,13 +2,13 @@ defmodule CodeCorps.Presenters.ImagePresenter do
   alias CodeCorps.{Project, User}
   alias CodeCorps.Cloudex.CloudinaryUrl
 
-  @logo_options %{crop: "fill", height: 500, width: 500}
+  @large_options %{crop: "fill", height: 500, width: 500}
 
   def large(%Project{} = project), do: do_large(project, "project")
   def large(%User{} = user), do: do_large(user, "user")
 
   defp do_large(%{cloudinary_public_id: cloudinary_id, default_color: color}, type),
-    do: cloudinary_image(cloudinary_id, @logo_options, "large", color, type)
+    do: cloudinary_image(cloudinary_id, @large_options, "large", color, type)
 
   @thumb_options %{crop: "fill", height: 100, width: 100}
 

--- a/test/lib/code_corps/accounts/accounts_test.exs
+++ b/test/lib/code_corps/accounts/accounts_test.exs
@@ -1,6 +1,7 @@
 defmodule CodeCorps.AccountsTest do
   @moduledoc false
 
+  use CodeCorps.BackgroundProcessingCase
   use CodeCorps.DbAccessCase
 
   alias CodeCorps.{Accounts, User, GitHub.TestHelpers}
@@ -12,6 +13,8 @@ defmodule CodeCorps.AccountsTest do
         "user"
         |> TestHelpers.load_endpoint_fixture
         |> Accounts.create_from_github
+
+      wait_for_supervisor()
 
       assert user.id
       assert user.default_color
@@ -29,7 +32,21 @@ defmodule CodeCorps.AccountsTest do
         payload
         |> Accounts.create_from_github
 
+      wait_for_supervisor()
+
       assert changeset.errors[:email] == {"has already been taken", []}
+    end
+
+    test "uploads photo from GitHub avatar" do
+      {:ok, %User{} = user} =
+        "user"
+        |> TestHelpers.load_endpoint_fixture
+        |> Accounts.create_from_github
+
+      wait_for_supervisor()
+
+      user = Repo.get(User, user.id)
+      assert user.cloudinary_public_id
     end
   end
 

--- a/test/lib/code_corps/cloudex/uploader_test.exs
+++ b/test/lib/code_corps/cloudex/uploader_test.exs
@@ -1,0 +1,12 @@
+defmodule CodeCorps.Cloudex.UploaderTest do
+  alias CodeCorps.Cloudex.Uploader
+  use ExUnit.Case, async: true
+
+  test "returns the public_id" do
+    [ok: %Cloudex.UploadedImage{public_id: public_id}] =
+      "https://placehold.it/500x500"
+      |> Uploader.upload
+
+    assert public_id
+  end
+end


### PR DESCRIPTION
# What's in this PR?

In the async process (after a successful creation of the GitHub user):

- Ensures we have the largest (or original) size of the GitHub avatar in the avatar URL (this is the default we get back)
- Uploads to Cloudinary with the GitHub avatar URL `Cloudex.upload("http://example.org/test.jpg")`
- Takes the `public_id` that's returned and sets it to `cloudinary_public_id` for the `User`
- Adapts `CloudexTest` to allow us to use `Cloudex.upload` in tests
- Tests that the `cloudinary_public_id` is correctly set

Also changes `ImagePresenter` `@logo_options` to `@large_options`.

## References
Fixes #949 