### PR TITLE
Remove duplicate :metadata key in test

### DIFF
--- a/test/lib/code_corps/stripe_service/adapters/stripe_platform_card_test.exs
+++ b/test/lib/code_corps/stripe_service/adapters/stripe_platform_card_test.exs
@@ -5,7 +5,6 @@ defmodule CodeCorps.StripeService.Adapters.StripePlatformCardTest do
 
   @stripe_platform_card %Stripe.Card{
     id: "card_123",
-    metadata: %{},
     address_city: nil,
     address_country: nil,
     address_line1: nil,


### PR DESCRIPTION
This commit removes a duplicate key in `StripePlatformCardTest`, which is the last bit of noise left when running the test suite. All green dots now :)

Before:
![image](https://user-images.githubusercontent.com/5278382/31313339-67f0ab22-abae-11e7-8922-97e979627dd3.png)

After:
![image](https://user-images.githubusercontent.com/5278382/31313350-c4cc071a-abae-11e7-8861-a937ac586836.png)