### PR TITLE
Fix issue with undead async tasks

### DIFF
--- a/test/lib/code_corps/github/user_test.exs
+++ b/test/lib/code_corps/github/user_test.exs
@@ -1,6 +1,7 @@
 defmodule CodeCorps.GitHub.UserTest do
   @moduledoc false
 
+  use CodeCorps.BackgroundProcessingCase
   use CodeCorps.DbAccessCase
   import CodeCorps.GitHub.TestHelpers
 

--- a/test/lib/code_corps_web/controllers/stripe_connect_events_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/stripe_connect_events_controller_test.exs
@@ -1,4 +1,5 @@
 defmodule CodeCorpsWeb.StripeConnectEventsControllerTest do
+  use CodeCorps.BackgroundProcessingCase
   use CodeCorpsWeb.ConnCase
 
   alias CodeCorps.StripeEvent
@@ -10,20 +11,6 @@ defmodule CodeCorpsWeb.StripeConnectEventsControllerTest do
       |> put_req_header("content-type", "application/json")
 
     {:ok, conn: conn}
-  end
-
-  defp wait_for_supervisor(), do: wait_for_children(:background_processor)
-
-  # used to have the test wait for or the children of a supervisor to exit
-
-  defp wait_for_children(supervisor_ref) do
-    supervisor_ref |> Task.Supervisor.children |> Enum.each(&wait_for_child/1)
-  end
-
-  defp wait_for_child(pid) do
-    # Wait until the pid is dead
-    ref = Process.monitor(pid)
-    assert_receive {:DOWN, ^ref, _, _, _}
   end
 
   test "responds with 200 when the event will be processed", %{conn: conn} do

--- a/test/lib/code_corps_web/controllers/stripe_platform_events_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/stripe_platform_events_controller_test.exs
@@ -1,4 +1,5 @@
 defmodule CodeCorpsWeb.StripePlatformEventsControllerTest do
+  use CodeCorps.BackgroundProcessingCase
   use CodeCorpsWeb.ConnCase
 
   alias CodeCorps.StripeEvent
@@ -10,21 +11,6 @@ defmodule CodeCorpsWeb.StripePlatformEventsControllerTest do
       |> put_req_header("content-type", "application/json")
 
     {:ok, conn: conn}
-  end
-
-  defp wait_for_supervisor(), do: wait_for_children(:background_processor)
-
-  # used to have the test wait for or the children of a supervisor to exit
-
-  defp wait_for_children(supervisor_ref) do
-    Task.Supervisor.children(supervisor_ref)
-    |> Enum.each(&wait_for_child/1)
-  end
-
-  defp wait_for_child(pid) do
-    # Wait until the pid is dead
-    ref = Process.monitor(pid)
-    assert_receive {:DOWN, ^ref, _, _, _}
   end
 
   test "responds with 200 when the event will be processed", %{conn: conn} do

--- a/test/support/background_processing_case.ex
+++ b/test/support/background_processing_case.ex
@@ -27,4 +27,15 @@ defmodule CodeCorps.BackgroundProcessingCase do
       end
     end
   end
+
+  setup do
+    on_exit fn ->
+      Task.Supervisor.children(:background_processor)
+      |> Enum.map(&terminate_child/1)
+    end
+  end
+
+  defp terminate_child(child) do
+    Task.Supervisor.terminate_child(:background_processor, child)
+  end
 end


### PR DESCRIPTION
# What's in this PR?

This is a quick fix for the issue presented in #1027.

I know that simply killing the processes without explicitly calling `wait_for_supervisor` is a bit hacky, and it requires some explicit knowledge of implicit async event processing happening, but for now it's the best quick fix I could identify to move forward.

## References
Fixes #1027