### PR TITLE
Refactor event handlers to take only the payload

### DIFF
--- a/lib/code_corps/github/event/handler.ex
+++ b/lib/code_corps/github/event/handler.ex
@@ -3,14 +3,12 @@ defmodule CodeCorps.GitHub.Event.Handler do
   Default behavior for all GitHub webhook event handlers.
   """
 
-  alias CodeCorps.GithubEvent
-
   @doc ~S"""
   The only entry point a GitHub webhook event handler function should contain.
 
-  Receives a `CodeCorps.GithubEvent` record and a payload, returns an `:ok`
-  tuple if the process was successful, or an `:error` tuple, where the second
-  element is an atom, if it failed.
+  Receives the GitHub payload, returns an `:ok` tuple if the process was
+  successful, or an `:error` tuple, where the second element is an atom, if it
+  failed.
   """
-  @callback handle(GithubEvent.t, map) :: {:ok, any} | {:error, atom}
+  @callback handle(map) :: {:ok, any} | {:error, atom}
 end

--- a/lib/code_corps/github/event/installation.ex
+++ b/lib/code_corps/github/event/installation.ex
@@ -8,7 +8,6 @@ defmodule CodeCorps.GitHub.Event.Installation do
 
   alias CodeCorps.{
     GithubAppInstallation,
-    GithubEvent,
     GitHub.Event.Installation,
     Repo,
     User
@@ -48,8 +47,8 @@ defmodule CodeCorps.GitHub.Event.Installation do
   If a step in the process failes, an `:error` tuple will be returned, where the
   second element is an atom indicating which step of the process failed.
   """
-  @spec handle(GithubEvent.t, map) :: outcome
-  def handle(%GithubEvent{}, payload) do
+  @spec handle(map) :: outcome
+  def handle(payload) do
     Multi.new
     |> Multi.run(:payload, fn _ -> payload |> validate_payload() end)
     |> Multi.run(:action, fn _ -> payload |> validate_action() end)

--- a/lib/code_corps/github/event/installation_repositories.ex
+++ b/lib/code_corps/github/event/installation_repositories.ex
@@ -10,7 +10,6 @@ defmodule CodeCorps.GitHub.Event.InstallationRepositories do
 
   alias CodeCorps.{
     GithubAppInstallation,
-    GithubEvent,
     GithubRepo,
     GitHub.Event.Common.ResultAggregator,
     GitHub.Event.InstallationRepositories,
@@ -43,8 +42,8 @@ defmodule CodeCorps.GitHub.Event.InstallationRepositories do
         `CodeCorps.ProjectGithubRepo` records, they are deleted automatically,
         due to `on_delete: :delete_all` set at the database level.
   """
-  @spec handle(GithubEvent.t, map) :: outcome
-  def handle(%GithubEvent{}, payload) do
+  @spec handle(map) :: outcome
+  def handle(payload) do
     Multi.new
     |> Multi.run(:payload, fn _ -> payload |> validate_payload() end)
     |> Multi.run(:action, fn _ -> payload |> validate_action() end)

--- a/lib/code_corps/github/event/issue_comment.ex
+++ b/lib/code_corps/github/event/issue_comment.ex
@@ -8,7 +8,6 @@ defmodule CodeCorps.GitHub.Event.IssueComment do
 
   alias CodeCorps.{
     Comment,
-    GithubEvent,
     GitHub.Event.Common.RepoFinder,
     GitHub.Event.Issues,
     GitHub.Event.Issues.TaskSyncer,
@@ -50,8 +49,8 @@ defmodule CodeCorps.GitHub.Event.IssueComment do
   If it fails, it will instead return an `:error` tuple, where the second
   element is the atom indicating a reason.
   """
-  @spec handle(GithubEvent.t, map) :: outcome
-  def handle(%GithubEvent{}, payload) do
+  @spec handle(map) :: outcome
+  def handle(payload) do
     Multi.new
     |> Multi.run(:payload, fn _ -> payload |> validate_payload() end)
     |> Multi.run(:action, fn _ -> payload |> validate_action() end)

--- a/lib/code_corps/github/event/issues.ex
+++ b/lib/code_corps/github/event/issues.ex
@@ -8,7 +8,6 @@ defmodule CodeCorps.GitHub.Event.Issues do
   @behaviour CodeCorps.GitHub.Event.Handler
 
   alias CodeCorps.{
-    GithubEvent,
     GitHub.Event.Common.RepoFinder,
     GitHub.Event.Issues.TaskSyncer,
     GitHub.Event.Issues.UserLinker,
@@ -45,8 +44,8 @@ defmodule CodeCorps.GitHub.Event.Issues do
   If it fails, it will instead return an `:error` tuple, where the second
   element is the atom indicating a reason.
   """
-  @spec handle(GithubEvent.t, map) :: outcome
-  def handle(%GithubEvent{}, %{} = payload) do
+  @spec handle(map) :: outcome
+  def handle(payload) do
     Multi.new
     |> Multi.run(:payload, fn _ -> payload |> validate_payload() end)
     |> Multi.run(:action, fn _ -> payload |> validate_action() end)

--- a/lib/code_corps/github/webhook/handler.ex
+++ b/lib/code_corps/github/webhook/handler.ex
@@ -20,9 +20,9 @@ defmodule CodeCorps.GitHub.Webhook.Handler do
   def handle(type, id, payload) do
     with %{} = params <- build_params(type, id, payload),
          {:ok, %GithubEvent{} = event} <- params |> create_event(),
-         {:ok, %GithubEvent{status: "processing"} = processing_event} <- event |> Event.start_processing
+         {:ok, %GithubEvent{status: "processing"} = event} <- event |> Event.start_processing
     do
-      processing_event |> do_handle(payload) |> Event.stop_processing(event)
+      payload |> do_handle(type) |> Event.stop_processing(event)
     end
   end
 
@@ -47,8 +47,8 @@ defmodule CodeCorps.GitHub.Webhook.Handler do
     end
   end
 
-  defp do_handle(%GithubEvent{type: "installation"} = event, payload), do: Installation.handle(event, payload)
-  defp do_handle(%GithubEvent{type: "installation_repositories"} = event, payload), do: InstallationRepositories.handle(event, payload)
-  defp do_handle(%GithubEvent{type: "issue_comment"} = event, payload), do: IssueComment.handle(event, payload)
-  defp do_handle(%GithubEvent{type: "issues"} = event, payload), do: Issues.handle(event, payload)
+  defp do_handle(payload, "installation"), do: Installation.handle(payload)
+  defp do_handle(payload, "installation_repositories"), do: InstallationRepositories.handle(payload)
+  defp do_handle(payload, "issue_comment"), do: IssueComment.handle(payload)
+  defp do_handle(payload, "issues"), do: Issues.handle(payload)
 end

--- a/test/lib/code_corps/github/event/installation_repositories_test.exs
+++ b/test/lib/code_corps/github/event/installation_repositories_test.exs
@@ -12,24 +12,22 @@ defmodule CodeCorps.GitHub.Event.InstallationRepositoriesTest do
     Repo
   }
 
-  describe "handle/2" do
+  describe "handle/1" do
     @payload load_event_fixture("installation_repositories_added")
 
     test "marks event as errored if invalid action" do
       payload = @payload |> Map.put("action", "foo")
-      event = build(:github_event, action: "foo", type: "installation_repositories")
-      assert {:error, :unexpected_action} == InstallationRepositories.handle(event, payload)
+      assert {:error, :unexpected_action} == InstallationRepositories.handle(payload)
     end
 
     test "marks event as errored if invalid payload" do
-      event = build(:github_event, action: "added", type: "installation_repositories")
       payload = @payload |> Map.delete("action")
       assert {:error, :unexpected_payload} ==
-        InstallationRepositories.handle(event, payload)
+        InstallationRepositories.handle(payload)
     end
   end
 
-  describe "handle/2 for InstallationRepositories::added" do
+  describe "handle/1 for InstallationRepositories::added" do
     @payload load_event_fixture("installation_repositories_added")
 
     test "creates repos" do
@@ -40,8 +38,7 @@ defmodule CodeCorps.GitHub.Event.InstallationRepositoriesTest do
 
       %{id: installation_id} = insert(:github_app_installation, github_id: installation_github_id)
 
-      event = build(:github_event, action: "added", type: "installation_repositories")
-      {:ok, [%GithubRepo{}, %GithubRepo{}]} = InstallationRepositories.handle(event, @payload)
+      {:ok, [%GithubRepo{}, %GithubRepo{}]} = InstallationRepositories.handle(@payload)
 
       github_repo_1 = Repo.get_by(GithubRepo, github_id: repo_1_payload["id"])
       assert github_repo_1
@@ -63,8 +60,7 @@ defmodule CodeCorps.GitHub.Event.InstallationRepositoriesTest do
       installation = insert(:github_app_installation, github_id: installation_github_id)
       preinserted_repo = insert(:github_repo, github_app_installation: installation, github_id: repo_1_payload["id"])
 
-      event = build(:github_event, action: "added", type: "installation_repositories")
-      {:ok, [%GithubRepo{}, %GithubRepo{}]} = InstallationRepositories.handle(event, @payload)
+      {:ok, [%GithubRepo{}, %GithubRepo{}]} = InstallationRepositories.handle(@payload)
 
       github_repo_1 = Repo.get_by(GithubRepo, github_id: repo_1_payload["id"])
       assert github_repo_1.id == preinserted_repo.id
@@ -78,23 +74,20 @@ defmodule CodeCorps.GitHub.Event.InstallationRepositoriesTest do
     end
 
     test "marks event as errored if invalid instalation payload" do
-      event = insert(:github_event, action: "added", type: "installation_repositories")
-      assert {:error, :unexpected_payload} == InstallationRepositories.handle(event, @payload |> Map.put("installation", "foo"))
+      assert {:error, :unexpected_payload} == InstallationRepositories.handle(@payload |> Map.put("installation", "foo"))
     end
 
     test "marks event as errored if invalid repo payload" do
-      event = insert(:github_event, action: "added", type: "installation_repositories")
       insert(:github_app_installation, github_id: @payload["installation"]["id"])
-      assert {:error, :unexpected_payload} == InstallationRepositories.handle(event, @payload |> Map.put("repositories_added", ["foo"]))
+      assert {:error, :unexpected_payload} == InstallationRepositories.handle(@payload |> Map.put("repositories_added", ["foo"]))
     end
 
     test "marks event as errored if no installation" do
-      event = insert(:github_event, action: "added", type: "installation_repositories")
-      assert {:error, :unmatched_installation} == InstallationRepositories.handle(event, @payload)
+      assert {:error, :unmatched_installation} == InstallationRepositories.handle(@payload)
     end
   end
 
-  describe "handle/2 for InstallationRepositories::removed" do
+  describe "handle/1 for InstallationRepositories::removed" do
     @payload load_event_fixture("installation_repositories_removed")
 
     test "deletes github repos and associated project github repos" do
@@ -108,8 +101,7 @@ defmodule CodeCorps.GitHub.Event.InstallationRepositoriesTest do
       insert(:project_github_repo, project: project, github_repo: github_repo_1)
       insert(:github_repo, github_app_installation: installation, github_id: repo_2_payload["id"])
 
-      event = build(:github_event, action: "removed", type: "installation_repositories")
-      {:ok, [%GithubRepo{}, %GithubRepo{}]} = InstallationRepositories.handle(event, @payload)
+      {:ok, [%GithubRepo{}, %GithubRepo{}]} = InstallationRepositories.handle(@payload)
 
       assert Repo.aggregate(GithubRepo, :count, :id) == 0
       assert Repo.aggregate(ProjectGithubRepo, :count, :id) == 0
@@ -125,31 +117,27 @@ defmodule CodeCorps.GitHub.Event.InstallationRepositoriesTest do
       github_repo_1 = insert(:github_repo, github_app_installation: installation, github_id: repo_1_payload["id"])
       insert(:project_github_repo, project: project, github_repo: github_repo_1)
 
-      event = build(:github_event, action: "removed", type: "installation_repositories")
-      {:ok, [%GithubRepo{}]} = InstallationRepositories.handle(event, @payload)
+      {:ok, [%GithubRepo{}]} = InstallationRepositories.handle(@payload)
 
       assert Repo.aggregate(GithubRepo, :count, :id) == 0
       assert Repo.aggregate(ProjectGithubRepo, :count, :id) == 0
     end
 
     test "marks event as errored if invalid instalation payload" do
-      event = build(:github_event, action: "removed", type: "installation_repositories")
       payload = @payload |> Map.put("installation", "foo")
       assert {:error, :unexpected_payload} ==
-        InstallationRepositories.handle(event, payload)
+        InstallationRepositories.handle(payload)
     end
 
     test "marks event as errored if invalid repo payload" do
-      event = build(:github_event, action: "removed", type: "installation_repositories")
       insert(:github_app_installation, github_id: @payload["installation"]["id"])
       payload = @payload |> Map.put("repositories_removed", ["foo"])
       assert {:error, :unexpected_payload} ==
-        InstallationRepositories.handle(event, payload)
+        InstallationRepositories.handle(payload)
     end
 
     test "marks event as errored if no installation" do
-      event = build(:github_event, action: "added", type: "installation_repositories")
-      assert {:error, :unmatched_installation} == InstallationRepositories.handle(event, @payload)
+      assert {:error, :unmatched_installation} == InstallationRepositories.handle(@payload)
     end
   end
 end

--- a/test/lib/code_corps/github/event/issues_test.exs
+++ b/test/lib/code_corps/github/event/issues_test.exs
@@ -17,14 +17,12 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
     @payload load_event_fixture("issues_opened") |> Map.put("action", "foo")
 
     test "returns error if action of the event is wrong" do
-      event = build(:github_event, action: "foo", type: "issues")
-      assert {:error, :unexpected_action} == Issues.handle(event, @payload)
+      assert {:error, :unexpected_action} == Issues.handle(@payload)
     end
   end
 
   describe "handle/2 for Issues::opened" do
     @payload load_event_fixture("issues_opened")
-    @event build(:github_event, action: "opened", type: "issues")
 
     test "with unmatched user, passes with no changes made if no matching projects" do
       %{
@@ -35,7 +33,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       } = @payload
 
       insert(:github_repo, github_id: repo_github_id)
-      assert Issues.handle(@event, @payload) == {:ok, []}
+      assert Issues.handle(@payload) == {:ok, []}
       assert Repo.aggregate(Task, :count, :id) == 0
       refute Repo.get_by(User, github_id: user_github_id)
     end
@@ -63,7 +61,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         insert(:task_list, project: project, inbox: true)
       end)
 
-      {:ok, tasks} = Issues.handle(@event, @payload)
+      {:ok, tasks} = Issues.handle(@payload)
 
       assert Enum.count(tasks) == 3
       assert Repo.aggregate(Task, :count, :id) == 3
@@ -83,7 +81,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
     end
 
     test "with unmatched user, returns error if unmatched repository" do
-      assert Issues.handle(@event, @payload) == {:error, :repository_not_found}
+      assert Issues.handle(@payload) == {:error, :repository_not_found}
       refute Repo.one(User)
     end
 
@@ -92,7 +90,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       insert(:user, github_id: user_github_id)
 
       insert(:github_repo, github_id: repo_github_id)
-      assert Issues.handle(@event, @payload) == {:ok, []}
+      assert Issues.handle(@payload) == {:ok, []}
       assert Repo.aggregate(Task, :count, :id) == 0
     end
 
@@ -121,7 +119,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       %{id: existing_task_id} =
         insert(:task, project: project, user: user, github_repo: github_repo, github_issue_number: number)
 
-      {:ok, tasks} = Issues.handle(@event, @payload)
+      {:ok, tasks} = Issues.handle(@payload)
 
       assert Enum.count(tasks) == 3
       assert Repo.aggregate(Task, :count, :id) == 3
@@ -142,25 +140,24 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       %{"issue" => %{"user" => %{"id" => user_github_id}}} = @payload
       insert(:user, github_id: user_github_id)
 
-      assert Issues.handle(@event, @payload) == {:error, :repository_not_found}
+      assert Issues.handle(@payload) == {:error, :repository_not_found}
     end
 
     test "returns error if payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, %{})
+      assert {:error, :unexpected_payload} == Issues.handle(%{})
     end
 
     test "returns error if repo payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, @payload |> Map.put("repository", "foo"))
+      assert {:error, :unexpected_payload} == Issues.handle(@payload |> Map.put("repository", "foo"))
     end
 
     test "returns error if issue payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, @payload |> Map.put("issue", "foo"))
+      assert {:error, :unexpected_payload} == Issues.handle(@payload |> Map.put("issue", "foo"))
     end
   end
 
   describe "handle/2 for Issues::closed" do
     @payload load_event_fixture("issues_closed")
-    @event build(:github_event, action: "closed", type: "issues")
 
     test "with unmatched user, passes with no changes made if no matching projects" do
       %{
@@ -169,7 +166,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       } = @payload
 
       insert(:github_repo, github_id: repo_github_id)
-      assert Issues.handle(@event, @payload) == {:ok, []}
+      assert Issues.handle(@payload) == {:ok, []}
       assert Repo.aggregate(Task, :count, :id) == 0
       refute Repo.get_by(User, github_id: user_github_id)
     end
@@ -197,7 +194,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         insert(:task_list, project: project, inbox: true)
       end)
 
-      {:ok, tasks} = Issues.handle(@event, @payload)
+      {:ok, tasks} = Issues.handle(@payload)
 
       assert Enum.count(tasks) == 3
       assert Repo.aggregate(Task, :count, :id) == 3
@@ -217,7 +214,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
     end
 
     test "with unmatched user, returns error if unmatched repository" do
-      assert Issues.handle(@event, @payload) == {:error, :repository_not_found}
+      assert Issues.handle(@payload) == {:error, :repository_not_found}
       refute Repo.one(User)
     end
 
@@ -226,7 +223,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       insert(:user, github_id: user_github_id)
 
       insert(:github_repo, github_id: repo_github_id)
-      assert Issues.handle(@event, @payload) == {:ok, []}
+      assert Issues.handle(@payload) == {:ok, []}
       assert Repo.aggregate(Task, :count, :id) == 0
     end
 
@@ -255,7 +252,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       %{id: existing_task_id} =
         insert(:task, project: project, user: user, github_repo: github_repo, github_issue_number: number)
 
-      {:ok, tasks} = Issues.handle(@event, @payload)
+      {:ok, tasks} = Issues.handle(@payload)
 
       assert Enum.count(tasks) == 3
       assert Repo.aggregate(Task, :count, :id) == 3
@@ -276,25 +273,24 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       %{"issue" => %{"user" => %{"id" => user_github_id}}} = @payload
       insert(:user, github_id: user_github_id)
 
-      assert Issues.handle(@event, @payload) == {:error, :repository_not_found}
+      assert Issues.handle(@payload) == {:error, :repository_not_found}
     end
 
     test "returns error if payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, %{})
+      assert {:error, :unexpected_payload} == Issues.handle(%{})
     end
 
     test "returns error if repo payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, @payload |> Map.put("repository", "foo"))
+      assert {:error, :unexpected_payload} == Issues.handle(@payload |> Map.put("repository", "foo"))
     end
 
     test "returns error if issue payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, @payload |> Map.put("issue", "foo"))
+      assert {:error, :unexpected_payload} == Issues.handle(@payload |> Map.put("issue", "foo"))
     end
   end
 
   describe "handle/2 for Issues::edited" do
     @payload load_event_fixture("issues_edited")
-    @event build(:github_event, action: "edited", type: "issues")
 
     test "with unmatched user, passes with no changes made if no matching projects" do
       %{
@@ -303,7 +299,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       } = @payload
 
       insert(:github_repo, github_id: repo_github_id)
-      assert Issues.handle(@event, @payload) == {:ok, []}
+      assert Issues.handle(@payload) == {:ok, []}
       assert Repo.aggregate(Task, :count, :id) == 0
       refute Repo.get_by(User, github_id: user_github_id)
     end
@@ -331,7 +327,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         insert(:task_list, project: project, inbox: true)
       end)
 
-      {:ok, tasks} = Issues.handle(@event, @payload)
+      {:ok, tasks} = Issues.handle(@payload)
 
       assert Enum.count(tasks) == 3
       assert Repo.aggregate(Task, :count, :id) == 3
@@ -351,7 +347,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
     end
 
     test "with unmatched user, returns error if unmatched repository" do
-      assert Issues.handle(@event, @payload) == {:error, :repository_not_found}
+      assert Issues.handle(@payload) == {:error, :repository_not_found}
       refute Repo.one(User)
     end
 
@@ -360,7 +356,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       insert(:user, github_id: user_github_id)
 
       insert(:github_repo, github_id: repo_github_id)
-      assert Issues.handle(@event, @payload) == {:ok, []}
+      assert Issues.handle(@payload) == {:ok, []}
       assert Repo.aggregate(Task, :count, :id) == 0
     end
 
@@ -389,7 +385,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       %{id: existing_task_id} =
         insert(:task, project: project, user: user, github_repo: github_repo, github_issue_number: number)
 
-      {:ok, tasks} = Issues.handle(@event, @payload)
+      {:ok, tasks} = Issues.handle(@payload)
 
       assert Enum.count(tasks) == 3
       assert Repo.aggregate(Task, :count, :id) == 3
@@ -410,25 +406,24 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       %{"issue" => %{"user" => %{"id" => user_github_id}}} = @payload
       insert(:user, github_id: user_github_id)
 
-      assert Issues.handle(@event, @payload) == {:error, :repository_not_found}
+      assert Issues.handle(@payload) == {:error, :repository_not_found}
     end
 
     test "returns error if payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, %{})
+      assert {:error, :unexpected_payload} == Issues.handle(%{})
     end
 
     test "returns error if repo payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, @payload |> Map.put("repository", "foo"))
+      assert {:error, :unexpected_payload} == Issues.handle(@payload |> Map.put("repository", "foo"))
     end
 
     test "returns error if issue payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, @payload |> Map.put("issue", "foo"))
+      assert {:error, :unexpected_payload} == Issues.handle(@payload |> Map.put("issue", "foo"))
     end
   end
 
   describe "handle/2 for Issues::reopened" do
     @payload load_event_fixture("issues_reopened")
-    @event build(:github_event, action: "reopened", type: "issues")
 
     test "with unmatched user, passes with no changes made if no matching projects" do
       %{
@@ -437,7 +432,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       } = @payload
 
       insert(:github_repo, github_id: repo_github_id)
-      assert Issues.handle(@event, @payload) == {:ok, []}
+      assert Issues.handle(@payload) == {:ok, []}
       assert Repo.aggregate(Task, :count, :id) == 0
       refute Repo.get_by(User, github_id: user_github_id)
     end
@@ -465,7 +460,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         insert(:task_list, project: project, inbox: true)
       end)
 
-      {:ok, tasks} = Issues.handle(@event, @payload)
+      {:ok, tasks} = Issues.handle(@payload)
 
       assert Enum.count(tasks) == 3
       assert Repo.aggregate(Task, :count, :id) == 3
@@ -485,7 +480,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
     end
 
     test "with unmatched user, returns error if unmatched repository" do
-      assert Issues.handle(@event, @payload) == {:error, :repository_not_found}
+      assert Issues.handle(@payload) == {:error, :repository_not_found}
       refute Repo.one(User)
     end
 
@@ -494,7 +489,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       insert(:user, github_id: user_github_id)
 
       insert(:github_repo, github_id: repo_github_id)
-      assert Issues.handle(@event, @payload) == {:ok, []}
+      assert Issues.handle(@payload) == {:ok, []}
       assert Repo.aggregate(Task, :count, :id) == 0
     end
 
@@ -523,7 +518,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       %{id: existing_task_id} =
         insert(:task, project: project, user: user, github_repo: github_repo, github_issue_number: number)
 
-      {:ok, tasks} = Issues.handle(@event, @payload)
+      {:ok, tasks} = Issues.handle(@payload)
 
       assert Enum.count(tasks) == 3
       assert Repo.aggregate(Task, :count, :id) == 3
@@ -544,19 +539,19 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
       %{"issue" => %{"user" => %{"id" => user_github_id}}} = @payload
       insert(:user, github_id: user_github_id)
 
-      assert Issues.handle(@event, @payload) == {:error, :repository_not_found}
+      assert Issues.handle(@payload) == {:error, :repository_not_found}
     end
 
     test "returns error if payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, %{})
+      assert {:error, :unexpected_payload} == Issues.handle(%{})
     end
 
     test "returns error if repo payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, @payload |> Map.put("repository", "foo"))
+      assert {:error, :unexpected_payload} == Issues.handle(@payload |> Map.put("repository", "foo"))
     end
 
     test "returns error if issue payload is wrong" do
-      assert {:error, :unexpected_payload} == Issues.handle(@event, @payload |> Map.put("issue", "foo"))
+      assert {:error, :unexpected_payload} == Issues.handle(@payload |> Map.put("issue", "foo"))
     end
   end
 
@@ -573,10 +568,8 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         "repository" => %{"id" => 2}
       }
 
-      @event build(:github_event, action: action, type: "issues")
-
       test "is not implemented" do
-        assert Issues.handle(@event, @payload) == {:error, :not_fully_implemented}
+        assert Issues.handle(@payload) == {:error, :not_fully_implemented}
       end
     end
   end)


### PR DESCRIPTION
# What's in this PR?

Refactors the event handlers to remove reliance on `GithubEvent` and instead just takes the payload.

## References
Fixes #983 