### PR TITLE
Set order on tasks from issues/PRs coming from GitHub

### DIFF
--- a/lib/code_corps/github/event/issues/changeset_builder.ex
+++ b/lib/code_corps/github/event/issues/changeset_builder.ex
@@ -65,6 +65,7 @@ defmodule CodeCorps.GitHub.Event.Issues.ChangesetBuilder do
     |> Changeset.assoc_constraint(:project)
     |> Changeset.assoc_constraint(:task_list)
     |> Changeset.assoc_constraint(:user)
+    |> Task.order_task()
   end
 
   @update_attrs ~w(markdown modified_at status title)a
@@ -79,5 +80,6 @@ defmodule CodeCorps.GitHub.Event.Issues.ChangesetBuilder do
     |> Changeset.assoc_constraint(:github_repo)
     |> Changeset.assoc_constraint(:project)
     |> Changeset.assoc_constraint(:user)
+    |> Task.order_task()
   end
 end

--- a/lib/code_corps/github/event/pull_request/changeset_builder.ex
+++ b/lib/code_corps/github/event/pull_request/changeset_builder.ex
@@ -65,6 +65,7 @@ defmodule CodeCorps.GitHub.Event.PullRequest.ChangesetBuilder do
     |> Changeset.assoc_constraint(:project)
     |> Changeset.assoc_constraint(:task_list)
     |> Changeset.assoc_constraint(:user)
+    |> Task.order_task()
   end
 
   @update_attrs ~w(markdown modified_at status title)a
@@ -79,5 +80,6 @@ defmodule CodeCorps.GitHub.Event.PullRequest.ChangesetBuilder do
     |> Changeset.assoc_constraint(:github_repo)
     |> Changeset.assoc_constraint(:project)
     |> Changeset.assoc_constraint(:user)
+    |> Task.order_task()
   end
 end

--- a/lib/code_corps/model/task.ex
+++ b/lib/code_corps/model/task.ex
@@ -44,9 +44,14 @@ defmodule CodeCorps.Task do
     |> cast(params, [:title, :markdown, :task_list_id, :position])
     |> validate_required([:title, :task_list_id])
     |> assoc_constraint(:task_list)
+    |> order_task()
+    |> MarkdownRendererService.render_markdown_to_html(:markdown, :body)
+  end
+
+  def order_task(changeset) do
+    changeset
     |> apply_position()
     |> set_order(:position, :order, :task_list_id)
-    |> MarkdownRendererService.render_markdown_to_html(:markdown, :body)
   end
 
   @spec create_changeset(struct, map) :: Ecto.Changeset.t

--- a/test/lib/code_corps/github/event/issues/changeset_builder_test.exs
+++ b/test/lib/code_corps/github/event/issues/changeset_builder_test.exs
@@ -52,6 +52,7 @@ defmodule CodeCorps.GitHub.Event.Issues.ChangesetBuilderTest do
       assert get_change(changeset, :user_id) == user.id
 
       assert changeset.valid?
+      assert changeset.changes[:position]
     end
 
     test "validates that modified_at has not already happened" do

--- a/test/lib/code_corps/github/event/issues_test.exs
+++ b/test/lib/code_corps/github/event/issues_test.exs
@@ -65,6 +65,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "open"
+        assert task.order
       end)
     end
 
@@ -113,6 +114,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "open"
+        assert task.order
       end)
 
       assert existing_task_id in (tasks |> Enum.map(&Map.get(&1, :id)))
@@ -182,6 +184,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "closed"
+        assert task.order
       end)
     end
 
@@ -230,6 +233,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "closed"
+        assert task.order
       end)
 
       assert existing_task_id in (tasks |> Enum.map(&Map.get(&1, :id)))
@@ -299,6 +303,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "open"
+        assert task.order
       end)
     end
 
@@ -347,6 +352,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "open"
+        assert task.order
       end)
 
       assert existing_task_id in (tasks |> Enum.map(&Map.get(&1, :id)))
@@ -416,6 +422,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "open"
+        assert task.order
       end)
     end
 
@@ -464,6 +471,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "open"
+        assert task.order
       end)
 
       assert existing_task_id in (tasks |> Enum.map(&Map.get(&1, :id)))

--- a/test/lib/code_corps/github/event/pull_request/changeset_builder_test.exs
+++ b/test/lib/code_corps/github/event/pull_request/changeset_builder_test.exs
@@ -52,6 +52,7 @@ defmodule CodeCorps.GitHub.Event.PullRequest.ChangesetBuilderTest do
       assert get_change(changeset, :user_id) == user.id
 
       assert changeset.valid?
+      assert changeset.changes[:position]
     end
 
     test "validates that modified_at has not already happened" do

--- a/test/lib/code_corps/github/event/pull_request_test.exs
+++ b/test/lib/code_corps/github/event/pull_request_test.exs
@@ -113,6 +113,7 @@ defmodule CodeCorps.GitHub.Event.PullRequestTest do
         assert task.title == title
         assert task.github_pull_request.number == number
         assert task.status == "open"
+        assert task.order
       end)
 
       assert existing_task_id in (tasks |> Enum.map(&Map.get(&1, :id)))
@@ -182,6 +183,7 @@ defmodule CodeCorps.GitHub.Event.PullRequestTest do
         assert task.title == title
         assert task.github_pull_request.number == number
         assert task.status == "closed"
+        assert task.order
       end)
     end
 
@@ -230,6 +232,7 @@ defmodule CodeCorps.GitHub.Event.PullRequestTest do
         assert task.title == title
         assert task.github_pull_request.number == number
         assert task.status == "closed"
+        assert task.order
       end)
 
       assert existing_task_id in (tasks |> Enum.map(&Map.get(&1, :id)))
@@ -299,6 +302,7 @@ defmodule CodeCorps.GitHub.Event.PullRequestTest do
         assert task.title == title
         assert task.github_pull_request.number == number
         assert task.status == "open"
+        assert task.order
       end)
     end
 
@@ -347,6 +351,7 @@ defmodule CodeCorps.GitHub.Event.PullRequestTest do
         assert task.title == title
         assert task.github_pull_request.number == number
         assert task.status == "open"
+        assert task.order
       end)
 
       assert existing_task_id in (tasks |> Enum.map(&Map.get(&1, :id)))
@@ -416,6 +421,7 @@ defmodule CodeCorps.GitHub.Event.PullRequestTest do
         assert task.title == title
         assert task.github_pull_request.number == number
         assert task.status == "open"
+        assert task.order
       end)
     end
 
@@ -464,6 +470,7 @@ defmodule CodeCorps.GitHub.Event.PullRequestTest do
         assert task.title == title
         assert task.github_pull_request.number == number
         assert task.status == "open"
+        assert task.order
       end)
 
       assert existing_task_id in (tasks |> Enum.map(&Map.get(&1, :id)))


### PR DESCRIPTION
# What's in this PR?

This fixes the task ordering when an issue/PR comes from GitHub.

## References
Fixes #1078 