### PR TITLE
Code and comment cleanups for IssueComment

### DIFF
--- a/lib/code_corps/github/event/issue_comment/comment_syncer.ex
+++ b/lib/code_corps/github/event/issue_comment/comment_syncer.ex
@@ -1,4 +1,12 @@
 defmodule CodeCorps.GitHub.Event.IssueComment.CommentSyncer do
+  @moduledoc ~S"""
+  In charge of syncing `CodeCorps.Comment` records with a GitHub comment
+  payload.
+
+  A single GitHub comment always matches a single `CodeCorps.GithubComment`, but
+  it can match multiple `CodeCorps.Comment` records. This module handles
+  creating or updating all those records.
+  """
 
   import Ecto.Query
 
@@ -17,10 +25,15 @@ defmodule CodeCorps.GitHub.Event.IssueComment.CommentSyncer do
   @type outcome :: {:ok, list(Comment.t)} |
                    {:error, {list(Comment.t), list(Changeset.t)}}
 
-  @doc """
-  When provided a list of `Task`s, a `User` and a GitHub API payload, for each
-  `Comment` associated to those `Task`s it creates or updates a `Comment`
-  associated to the specified `User`.
+  @doc ~S"""
+  Creates or updates `CodeCorps.Comment` records for the speciifed list of
+  `CodeCorps.Task` records.
+
+  When provided a list of `CodeCorps.Task` records, a `CodeCorps.GithubComment`,
+  a `CodeCorps.User`, and a GitHub API payload , for each `CodeCorps.Task`
+  record, it creates or updates a `CodeCorps.Comment` record, using the provided
+  GitHub API payload, associated to the specified `CodeCorps.GithubComment` and
+  `CodeCorps.User`
   """
   @spec sync_all(list(Task.t), GithubComment.t, User.t, map) :: outcome
   def sync_all(tasks, %GithubComment{} = github_comment, %User{} = user, %{} = payload) do

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.9
+-- Dumped from database version 10.0
 -- Dumped by pg_dump version 10.0
 
 SET statement_timeout = 0;


### PR DESCRIPTION
# What's in this PR?

This was done as part of looking into #1077. 

While searching for spots where the desired behavior (comment is always created_or_updated), I found some comment/code mistakes (not really bugs) which I corrected