### PR TITLE
Handle closed_at with respect to github sync

### DIFF
--- a/lib/code_corps/github/adapters/issue.ex
+++ b/lib/code_corps/github/adapters/issue.ex
@@ -42,7 +42,8 @@ defmodule CodeCorps.GitHub.Adapters.Issue do
     {:markdown, ["body"]},
     {:modified_at, ["updated_at"]},
     {:status, ["state"]},
-    {:title, ["title"]}
+    {:title, ["title"]},
+    {:closed_at, ["closed_at"]}
   ]
 
   @doc ~S"""

--- a/lib/code_corps/github/event/issues/changeset_builder.ex
+++ b/lib/code_corps/github/event/issues/changeset_builder.ex
@@ -37,7 +37,7 @@ defmodule CodeCorps.GitHub.Event.Issues.ChangesetBuilder do
     end
   end
 
-  @create_attrs ~w(created_at markdown modified_at status title)a
+  @create_attrs ~w(created_at markdown modified_at status title closed_at)a
   @spec create_changeset(Task.t, map, GithubIssue.t, ProjectGithubRepo.t, User.t) :: Changeset.t
   defp create_changeset(
     %Task{} = task,
@@ -68,7 +68,7 @@ defmodule CodeCorps.GitHub.Event.Issues.ChangesetBuilder do
     |> Task.order_task()
   end
 
-  @update_attrs ~w(markdown modified_at status title)a
+  @update_attrs ~w(markdown modified_at status title closed_at)a
   @spec update_changeset(Task.t, map) :: Changeset.t
   defp update_changeset(%Task{} = task, %{} = issue_attrs) do
     task

--- a/test/fixtures/github/events/issues_closed.json
+++ b/test/fixtures/github/events/issues_closed.json
@@ -44,7 +44,7 @@
     "comments": 0,
     "created_at": "2075-05-05T23:40:28Z",
     "updated_at": "2075-05-05T23:40:28Z",
-    "closed_at": null,
+    "closed_at": "2076-05-05T23:40:28Z",
     "body": "It looks like you accidently spelled 'commit' with two 't's."
   },
   "repository": {

--- a/test/lib/code_corps/github/adapters/issue_test.exs
+++ b/test/lib/code_corps/github/adapters/issue_test.exs
@@ -39,7 +39,19 @@ defmodule CodeCorps.GitHub.Adapters.IssueTest do
         markdown: payload["body"],
         modified_at: payload["updated_at"],
         status: payload["state"],
-        title: payload["title"]
+        title: payload["title"],
+        closed_at: payload["closed_at"]
+      }
+
+      %{"issue" => closed_payload} = load_event_fixture("issues_closed")
+
+      assert Adapters.Issue.to_task(closed_payload) == %{
+        created_at: closed_payload["created_at"],
+        markdown: closed_payload["body"],
+        modified_at: closed_payload["updated_at"],
+        status: closed_payload["state"],
+        title: closed_payload["title"],
+        closed_at: closed_payload["closed_at"]
       }
     end
   end

--- a/test/lib/code_corps/github/event/issues_test.exs
+++ b/test/lib/code_corps/github/event/issues_test.exs
@@ -66,6 +66,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.github_issue.number == number
         assert task.status == "open"
         assert task.order
+        refute task.closed_at
       end)
     end
 
@@ -115,6 +116,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.github_issue.number == number
         assert task.status == "open"
         assert task.order
+        refute task.closed_at
       end)
 
       assert existing_task_id in (tasks |> Enum.map(&Map.get(&1, :id)))
@@ -184,6 +186,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "closed"
+        assert task.closed_at ==  Timex.parse!(@payload["issue"]["closed_at"], "{ISO:Extended:Z}")
         assert task.order
       end)
     end
@@ -233,6 +236,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "closed"
+        assert task.closed_at ==  Timex.parse!(@payload["issue"]["closed_at"], "{ISO:Extended:Z}")
         assert task.order
       end)
 
@@ -422,6 +426,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "open"
+        refute task.closed_at
         assert task.order
       end)
     end
@@ -471,6 +476,7 @@ defmodule CodeCorps.GitHub.Event.IssuesTest do
         assert task.title == title
         assert task.github_issue.number == number
         assert task.status == "open"
+        refute task.closed_at
         assert task.order
       end)
 


### PR DESCRIPTION
# What's in this PR?
Handle `closed_at` field in `Tasks` with respect to Github sync

Fixes #992 

