### PR TITLE
Added tracking of "Connected to GitHub" event to segment

### DIFF
--- a/lib/code_corps/analytics/segment_tracker.ex
+++ b/lib/code_corps/analytics/segment_tracker.ex
@@ -21,9 +21,13 @@ defmodule CodeCorps.Analytics.SegmentTracker do
   @doc """
   Calls `track` in the configured API module.
   """
-  @spec track(String.t, atom, struct) :: any
-  def track(user_id, action, data) do
+  @spec track(integer, atom | String.t, struct) :: any
+  def track(user_id, action, data) when is_atom(action) do
     event = SegmentEventNameBuilder.build(action, data)
+    traits = SegmentTraitsBuilder.build(data)
+    @api.track(user_id, event, traits)
+  end
+  def track(user_id, event, data) when is_binary(event) do
     traits = SegmentTraitsBuilder.build(data)
     @api.track(user_id, event, traits)
   end

--- a/lib/code_corps/analytics/segment_traits_builder.ex
+++ b/lib/code_corps/analytics/segment_traits_builder.ex
@@ -13,10 +13,15 @@ defmodule CodeCorps.Analytics.SegmentTraitsBuilder do
       created_at: user.inserted_at,
       email: user.email,
       first_name: user.first_name,
+      github_id: user.github_id,
+      github_username: user.github_username,
       last_name: user.last_name,
+      sign_up_context: user.sign_up_context,
       state: user.state,
       twitter: user.twitter,
-      username: user.username
+      type: user.type,
+      username: user.username,
+      website: user.website
     }
   end
 

--- a/lib/code_corps/model/user.ex
+++ b/lib/code_corps/model/user.ex
@@ -32,12 +32,12 @@ defmodule CodeCorps.User do
     field :password, :string, virtual: true
     field :password_confirmation, :string, virtual: true
     field :sign_up_context, :string, default: "default"
+    field :state, :string, default: "signed_up"
+    field :state_transition, :string, virtual: true
     field :twitter, :string
     field :type, :string, default: "user"
     field :username, :string
     field :website, :string
-    field :state, :string, default: "signed_up"
-    field :state_transition, :string, virtual: true
 
     has_one :slugged_route, SluggedRoute
 

--- a/lib/code_corps_web/controllers/user_controller.ex
+++ b/lib/code_corps_web/controllers/user_controller.ex
@@ -1,8 +1,13 @@
 defmodule CodeCorpsWeb.UserController do
   use CodeCorpsWeb, :controller
 
-  alias CodeCorps.{Helpers.Query, Services.UserService, User}
-  alias CodeCorps.GitHub
+  alias CodeCorps.{
+    Analytics,
+    GitHub,
+    Helpers.Query,
+    Services.UserService,
+    User
+  }
 
   action_fallback CodeCorpsWeb.FallbackController
   plug CodeCorpsWeb.Plug.DataToAttributes
@@ -48,6 +53,7 @@ defmodule CodeCorpsWeb.UserController do
     current_user = Guardian.Plug.current_resource(conn)
     with {:ok, user} <- GitHub.User.connect(current_user, code, state)
     do
+      Analytics.SegmentTracker.track(user.id, "Connected to GitHub", user)
       conn |> render("show.json-api", data: user)
     end
   end


### PR DESCRIPTION
# What's in this PR?

Adds tracking of "Connected to GitHub" event with Segment.

Considering the existence of #927, I did not rely on our tracker "plug" to implement tracking here and instead made it explicit by calling the `track/3` function from the controller.

Progress on: #1038
