### PR TITLE
Add tests for StripeConnectSubscriptionController.show/2

### DIFF
--- a/lib/code_corps/model/stripe_connect_subscription.ex
+++ b/lib/code_corps/model/stripe_connect_subscription.ex
@@ -63,6 +63,7 @@ defmodule CodeCorps.StripeConnectSubscription do
     :quantity, :stripe_connect_plan_id, :user_id
   ]
 
+  @spec create_changeset(CodeCorps.StripeConnectPlan.t, map) :: Ecto.Changeset.t
   def create_changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @permitted_params)
@@ -74,6 +75,7 @@ defmodule CodeCorps.StripeConnectSubscription do
 
   @update_params [:cancelled_at, :current_period_end, :current_period_start, :ended_at, :quantity, :start, :status]
 
+  @spec webhook_update_changeset(CodeCorps.StripeConnectPlan.t, map) :: Ecto.Changeset.t
   def webhook_update_changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @update_params)

--- a/test/lib/code_corps_web/controllers/stripe_connect_subscription_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/stripe_connect_subscription_controller_test.exs
@@ -50,4 +50,35 @@ defmodule CodeCorpsWeb.StripeConnectSubscriptionControllerTest do
       assert conn |> request_create |> json_response(403)
     end
   end
+
+  describe "show" do
+    @tag :authenticated
+    test "shows resource when authenticated and authorized", %{conn: conn, current_user: current_user} do
+      stripe_connect_plan = insert(:stripe_connect_plan)
+      stripe_connect_subscription =
+        insert(:stripe_connect_subscription, user: current_user, stripe_connect_plan: stripe_connect_plan)
+
+      conn
+      |> request_show(stripe_connect_subscription)
+      |> json_response(200)
+      |> assert_id_from_response(stripe_connect_subscription.id)
+    end
+
+    test "renders 401 when unauthenticated", %{conn: conn} do
+      stripe_connect_subscription = insert(:stripe_connect_subscription)
+
+      assert conn |> request_show(stripe_connect_subscription) |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders 403 when not authorized", %{conn: conn} do
+      stripe_connect_subscription = insert(:stripe_connect_subscription)
+      assert conn |> request_show(stripe_connect_subscription) |> json_response(403)
+    end
+
+    @tag :authenticated
+    test "renders 404 when record not found", %{conn: conn} do
+      assert conn |> request_show(:not_found) |> json_response(404)
+    end
+  end
 end


### PR DESCRIPTION
Add missing tests for `StripeConnectSubscriptionController.show/2`

Typespecs were also added for the changesets in the StripeConnectSubscription model.

## References
Closes #1050 
