### PR TITLE
Fix identifiers in views to not preload for belongs_to IDs

### DIFF
--- a/lib/code_corps_web/views/comment_view.ex
+++ b/lib/code_corps_web/views/comment_view.ex
@@ -1,6 +1,5 @@
 defmodule CodeCorpsWeb.CommentView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:user, :task]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
@@ -9,6 +8,6 @@ defmodule CodeCorpsWeb.CommentView do
     :modified_from, :updated_at
   ]
 
-  has_one :user, serializer: CodeCorpsWeb.UserView
-  has_one :task, serializer: CodeCorpsWeb.TaskView
+  has_one :task, type: "task", field: :task_id
+  has_one :user, type: "user", field: :user_id
 end

--- a/lib/code_corps_web/views/donation_goal_view.ex
+++ b/lib/code_corps_web/views/donation_goal_view.ex
@@ -1,12 +1,12 @@
 defmodule CodeCorpsWeb.DonationGoalView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:project]
+  use CodeCorpsWeb.PreloadHelpers, default_preloads: ~w(project)a
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:achieved, :amount, :current, :description]
 
-  has_one :project, serializer: CodeCorpsWeb.ProjectView
+  has_one :project, type: "project", field: :project_id
 
   @doc """
   Determines whether the goal has been met by checking the amount against

--- a/lib/code_corps_web/views/github_app_installation_view.ex
+++ b/lib/code_corps_web/views/github_app_installation_view.ex
@@ -1,13 +1,13 @@
 defmodule CodeCorpsWeb.GithubAppInstallationView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: ~w(github_repos organization_github_app_installations project user)a
+  use CodeCorpsWeb.PreloadHelpers, default_preloads: ~w(github_repos organization_github_app_installations)a
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes ~w(github_id github_account_id github_account_avatar_url github_account_login github_account_type inserted_at installed state updated_at)a
 
-  has_one :project, serializer: CodeCorpsWeb.ProjectView
-  has_one :user, serializer: CodeCorpsWeb.UserView
+  has_one :project, type: "project", field: :project_id
+  has_one :user, type: "user", field: :user_id
 
   has_many :github_repos, serializer: CodeCorpsWeb.GithubRepoView, identifiers: :always
   has_many :organization_github_app_installations, serializer: CodeCorpsWeb.OrganizationGithubAppInstallationView, identifiers: :always

--- a/lib/code_corps_web/views/github_issue_view.ex
+++ b/lib/code_corps_web/views/github_issue_view.ex
@@ -1,7 +1,5 @@
 defmodule CodeCorpsWeb.GithubIssueView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers,
-      default_preloads: ~w(github_repo)a
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
@@ -11,5 +9,6 @@ defmodule CodeCorpsWeb.GithubIssueView do
     :state, :title, :url
   ]
 
-  has_one :github_repo, serializer: CodeCorpsWeb.GithubRepoView
+  has_one :github_pull_request, type: "github-pull-request", field: :github_pull_request_id
+  has_one :github_repo, type: "github-repo", field: :github_repo_id
 end

--- a/lib/code_corps_web/views/github_pull_request_view.ex
+++ b/lib/code_corps_web/views/github_pull_request_view.ex
@@ -1,10 +1,9 @@
 defmodule CodeCorpsWeb.GithubPullRequestView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:github_repo]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:github_created_at, :github_updated_at, :html_url, :merged, :number, :state]
 
-  has_one :github_repo, serializer: CodeCorpsWeb.GithubRepoView
+  has_one :github_repo, type: "github-repo", field: :github_repo_id
 end

--- a/lib/code_corps_web/views/github_repo_view.ex
+++ b/lib/code_corps_web/views/github_repo_view.ex
@@ -1,6 +1,5 @@
 defmodule CodeCorpsWeb.GithubRepoView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:github_app_installation]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
@@ -8,5 +7,5 @@ defmodule CodeCorpsWeb.GithubRepoView do
   :github_account_login, :github_account_type, :github_id, :inserted_at,
   :name, :updated_at]
 
-  has_one :github_app_installation, serializer: CodeCorpsWeb.GithubAppInstallationView
+  has_one :github_app_installation, type: "github-app-installation", field: :github_app_installation_id
 end

--- a/lib/code_corps_web/views/organization_github_app_installation_view.ex
+++ b/lib/code_corps_web/views/organization_github_app_installation_view.ex
@@ -1,11 +1,10 @@
 defmodule CodeCorpsWeb.OrganizationGithubAppInstallationView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:github_app_installation, :organization]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:inserted_at, :updated_at]
 
-  has_one :github_app_installation, serializer: CodeCorpsWeb.GithubAppInstallationView
-  has_one :organization, serializer: CodeCorpsWeb.OrganizationView
+  has_one :github_app_installation, type: "github-app-installation", field: :github_app_installation_id
+  has_one :organization, type: "organization", field: :organization_id
 end

--- a/lib/code_corps_web/views/organization_view.ex
+++ b/lib/code_corps_web/views/organization_view.ex
@@ -1,7 +1,7 @@
 defmodule CodeCorpsWeb.OrganizationView do
   @moduledoc false
   alias CodeCorps.Cloudex.CloudinaryUrl
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:organization_github_app_installations, :owner, :projects, :slugged_route, :stripe_connect_account]
+  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:organization_github_app_installations, :projects, :slugged_route, :stripe_connect_account]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
@@ -10,7 +10,7 @@ defmodule CodeCorpsWeb.OrganizationView do
     :icon_large_url, :name, :slug, :inserted_at, :updated_at
   ]
 
-  has_one :owner, serializer: CodeCorpsWeb.UserView
+  has_one :owner, type: "user", field: :owner_id
   has_one :slugged_route, serializer: CodeCorpsWeb.SluggedRouteView
   has_one :stripe_connect_account, serializer: CodeCorpsWeb.StripeConnectAccountView
 

--- a/lib/code_corps_web/views/preview_view.ex
+++ b/lib/code_corps_web/views/preview_view.ex
@@ -1,10 +1,9 @@
 defmodule CodeCorpsWeb.PreviewView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:user]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:markdown, :body, :inserted_at, :updated_at]
 
-  has_one :user, serializer: CodeCorpsWeb.UserView
+  has_one :user, type: "user", field: :user_id
 end

--- a/lib/code_corps_web/views/project_category_view.ex
+++ b/lib/code_corps_web/views/project_category_view.ex
@@ -1,9 +1,8 @@
 defmodule CodeCorpsWeb.ProjectCategoryView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:project, :category]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
-  has_one :project, serializer: CodeCorpsWeb.ProjectView
-  has_one :category, serializer: CodeCorpsWeb.CategoryView
+  has_one :project, type: "project", field: :project_id
+  has_one :category, type: "category", field: :category_id
 end

--- a/lib/code_corps_web/views/project_github_repo_view.ex
+++ b/lib/code_corps_web/views/project_github_repo_view.ex
@@ -1,9 +1,8 @@
 defmodule CodeCorpsWeb.ProjectGithubRepoView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:github_repo, :project]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
-  has_one :github_repo, serializer: CodeCorpsWeb.GithubRepoView
-  has_one :project, serializer: CodeCorpsWeb.ProjectView
+  has_one :github_repo, type: "github-repo", field: :github_repo_id
+  has_one :project, type: "project", field: :project_id
 end

--- a/lib/code_corps_web/views/project_skill_view.ex
+++ b/lib/code_corps_web/views/project_skill_view.ex
@@ -1,9 +1,8 @@
 defmodule CodeCorpsWeb.ProjectSkillView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:project, :skill]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
-  has_one :project, serializer: CodeCorpsWeb.ProjectView
-  has_one :skill, serializer: CodeCorpsWeb.SkillView
+  has_one :project, type: "project", field: :project_id
+  has_one :skill, type: "skill", field: :skill_id
 end

--- a/lib/code_corps_web/views/project_user_view.ex
+++ b/lib/code_corps_web/views/project_user_view.ex
@@ -1,11 +1,10 @@
 defmodule CodeCorpsWeb.ProjectUserView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:project, :user]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:role, :inserted_at, :updated_at]
 
-  has_one :project, serializer: CodeCorpsWeb.ProjectView
-  has_one :user, serializer: CodeCorpsWeb.UserView
+  has_one :project, type: "project", field: :project_id
+  has_one :user, type: "user", field: :user_id
 end

--- a/lib/code_corps_web/views/project_view.ex
+++ b/lib/code_corps_web/views/project_view.ex
@@ -20,7 +20,7 @@ defmodule CodeCorpsWeb.ProjectView do
     :total_monthly_donated, :updated_at, :website
   ]
 
-  has_one :organization, serializer: CodeCorpsWeb.OrganizationView
+  has_one :organization, type: "organization", field: :organization_id
   has_one :stripe_connect_plan, serializer: CodeCorpsWeb.StripeConnectPlanView
 
   has_many :donation_goals, serializer: CodeCorpsWeb.DonationGoalView, identifiers: :always

--- a/lib/code_corps_web/views/role_skill_view.ex
+++ b/lib/code_corps_web/views/role_skill_view.ex
@@ -1,9 +1,8 @@
 defmodule CodeCorpsWeb.RoleSkillView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:role, :skill]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
-  has_one :role, serializer: CodeCorpsWeb.RoleView
-  has_one :skill, serializer: CodeCorpsWeb.SkillView
+  has_one :role, type: "role", field: :role_id
+  has_one :skill, type: "skill", field: :skill_id
 end

--- a/lib/code_corps_web/views/slugged_route_view.ex
+++ b/lib/code_corps_web/views/slugged_route_view.ex
@@ -1,11 +1,10 @@
 defmodule CodeCorpsWeb.SluggedRouteView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:organization, :user]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:slug, :inserted_at, :updated_at]
 
-  has_one :organization, serializer: CodeCorpsWeb.OrganizationView
-  has_one :user, serializer: CodeCorpsWeb.UserView
+  has_one :organization, type: "organization", field: :organization_id
+  has_one :user, type: "user", field: :user_id
 end

--- a/lib/code_corps_web/views/stripe_connect_account_view.ex
+++ b/lib/code_corps_web/views/stripe_connect_account_view.ex
@@ -1,6 +1,6 @@
 defmodule CodeCorpsWeb.StripeConnectAccountView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:organization, :stripe_external_account]
+  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:stripe_external_account]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
@@ -70,7 +70,7 @@ defmodule CodeCorpsWeb.StripeConnectAccountView do
     :verification_fields_needed
   ]
 
-  has_one :organization, serializer: CodeCorpsWeb.OrganizationView
+  has_one :organization, type: "organization", field: :organization_id
 
   def can_accept_donations(stripe_connect_account, _conn) do
     case Application.get_env(:code_corps, :stripe_env) do

--- a/lib/code_corps_web/views/stripe_connect_plan_view.ex
+++ b/lib/code_corps_web/views/stripe_connect_plan_view.ex
@@ -1,10 +1,9 @@
 defmodule CodeCorpsWeb.StripeConnectPlanView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:project]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:amount, :created, :id_from_stripe, :inserted_at, :name, :updated_at]
 
-  has_one :project, serializer: CodeCorpsWeb.ProjectView
+  has_one :project, type: "project", field: :project_id
 end

--- a/lib/code_corps_web/views/stripe_connect_subscription_view.ex
+++ b/lib/code_corps_web/views/stripe_connect_subscription_view.ex
@@ -1,11 +1,11 @@
 defmodule CodeCorpsWeb.StripeConnectSubscriptionView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:user, :project]
+  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:project]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:quantity, :inserted_at, :updated_at]
 
-  has_one :user, serializer: CodeCorpsWeb.UserView
+  has_one :user, type: "user", field: :user_id
   has_one :project, serializer: CodeCorpsWeb.ProjectView, through: [:stripe_connect_plan, :project]
 end

--- a/lib/code_corps_web/views/stripe_platform_card_view.ex
+++ b/lib/code_corps_web/views/stripe_platform_card_view.ex
@@ -1,10 +1,9 @@
 defmodule CodeCorpsWeb.StripePlatformCardView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:user]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:brand, :exp_month, :exp_year, :token, :last4, :name]
 
-  has_one :user, serializer: CodeCorpsWeb.UserView
+  has_one :user, type: "user", field: :user_id
 end

--- a/lib/code_corps_web/views/stripe_platform_customer_view.ex
+++ b/lib/code_corps_web/views/stripe_platform_customer_view.ex
@@ -1,12 +1,11 @@
 defmodule CodeCorpsWeb.StripePlatformCustomerView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:user]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:created, :currency, :delinquent, :email, :id_from_stripe, :inserted_at, :updated_at]
 
-  has_one :user, serializer: CodeCorpsWeb.UserView
+  has_one :user, type: "user", field: :user_id
 
   @doc """
   Returns the email or an empty string, depending on the stripe_platform_customer record

--- a/lib/code_corps_web/views/task_list_view.ex
+++ b/lib/code_corps_web/views/task_list_view.ex
@@ -1,12 +1,12 @@
 defmodule CodeCorpsWeb.TaskListView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:project, :tasks]
+  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:tasks]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
   attributes [:inbox, :name, :order, :inserted_at, :updated_at]
 
-  has_one :project, serializer: CodeCorpsWeb.ProjectView
+  has_one :project, type: "project", field: :project_id
 
   has_many :tasks, serializer: CodeCorpsWeb.TaskView, identifiers: :always
 end

--- a/lib/code_corps_web/views/task_skill_view.ex
+++ b/lib/code_corps_web/views/task_skill_view.ex
@@ -1,9 +1,8 @@
 defmodule CodeCorpsWeb.TaskSkillView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:task, :skill]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
-  has_one :task, serializer: CodeCorpsWeb.TaskView
-  has_one :skill, serializer: CodeCorpsWeb.SkillView
+  has_one :task, type: "task", field: :task_id
+  has_one :skill, type: "skill", field: :skill_id
 end

--- a/lib/code_corps_web/views/task_view.ex
+++ b/lib/code_corps_web/views/task_view.ex
@@ -1,7 +1,7 @@
 defmodule CodeCorpsWeb.TaskView do
   @moduledoc false
   use CodeCorpsWeb.PreloadHelpers,
-      default_preloads: ~w(github_issue github_repo github_pull_request project user task_list task_skills comments user_task)a
+      default_preloads: [:comments, :github_pull_request, :task_skills, :user_task]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
@@ -10,12 +10,12 @@ defmodule CodeCorpsWeb.TaskView do
     :modified_at, :modified_from, :number, :order, :status, :title, :updated_at
   ]
 
-  has_one :github_issue, serializer: CodeCorpsWeb.GithubIssueView
-  has_one :github_pull_request, serializer: CodeCorpsWeb.GithubPullRequestView
-  has_one :github_repo, serializer: CodeCorpsWeb.GithubRepoView
-  has_one :project, serializer: CodeCorpsWeb.ProjectView
-  has_one :task_list, serializer: CodeCorpsWeb.TaskListView
-  has_one :user, serializer: CodeCorpsWeb.UserView
+  has_one :github_issue, type: "github-issue", field: :github_issue_id
+  has_one :github_pull_request, serializer: CodeCorpsWeb.GithubPullRequestView, identifiers: :always
+  has_one :github_repo, type: "github-repo", field: :github_repo_id
+  has_one :project, type: "project", field: :project_id
+  has_one :task_list, type: "task-list", field: :task_list_id
+  has_one :user, type: "user", field: :user_id
   has_one :user_task, serializer: CodeCorpsWeb.UserTaskView, identifiers: :always
 
   has_many :comments, serializer: CodeCorpsWeb.CommentView, identifiers: :always

--- a/lib/code_corps_web/views/user_category_view.ex
+++ b/lib/code_corps_web/views/user_category_view.ex
@@ -1,9 +1,8 @@
 defmodule CodeCorpsWeb.UserCategoryView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:user, :category]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
-  has_one :user, serializer: CodeCorpsWeb.UserView
-  has_one :category, serializer: CodeCorpsWeb.CategoryView
+  has_one :user, type: "user", field: :user_id
+  has_one :category, type: "category", field: :category_id
 end

--- a/lib/code_corps_web/views/user_role_view.ex
+++ b/lib/code_corps_web/views/user_role_view.ex
@@ -1,9 +1,8 @@
 defmodule CodeCorpsWeb.UserRoleView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:user, :role]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
-  has_one :user, serializer: CodeCorpsWeb.UserView
-  has_one :role, serializer: CodeCorpsWeb.RoleView
+  has_one :user, type: "user", field: :user_id
+  has_one :role, type: "role", field: :role_id
 end

--- a/lib/code_corps_web/views/user_skill_view.ex
+++ b/lib/code_corps_web/views/user_skill_view.ex
@@ -1,9 +1,8 @@
 defmodule CodeCorpsWeb.UserSkillView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:user, :skill]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
-  has_one :user, serializer: CodeCorpsWeb.UserView
-  has_one :skill, serializer: CodeCorpsWeb.SkillView
+  has_one :user, type: "user", field: :user_id
+  has_one :skill, type: "skill", field: :skill_id
 end

--- a/lib/code_corps_web/views/user_task_view.ex
+++ b/lib/code_corps_web/views/user_task_view.ex
@@ -1,9 +1,8 @@
 defmodule CodeCorpsWeb.UserTaskView do
   @moduledoc false
-  use CodeCorpsWeb.PreloadHelpers, default_preloads: [:task, :user]
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
 
-  has_one :task, serializer: CodeCorpsWeb.TaskView
-  has_one :user, serializer: CodeCorpsWeb.UserView
+  has_one :task, type: "task", field: :task_id
+  has_one :user, type: "user", field: :user_id
 end

--- a/test/lib/code_corps_web/views/github_issue_view_test.exs
+++ b/test/lib/code_corps_web/views/github_issue_view_test.exs
@@ -3,7 +3,8 @@ defmodule CodeCorpsWeb.GithubIssueViewTest do
 
   test "renders all attributes and relationships properly" do
     github_repo = insert(:github_repo)
-    github_issue = insert(:github_issue, github_repo: github_repo)
+    github_pull_request = insert(:github_pull_request)
+    github_issue = insert(:github_issue, github_pull_request: github_pull_request, github_repo: github_repo)
 
     rendered_json = render(CodeCorpsWeb.GithubIssueView, "show.json-api", data: github_issue)
 
@@ -27,6 +28,12 @@ defmodule CodeCorpsWeb.GithubIssueViewTest do
         },
         "id" => github_issue.id |> Integer.to_string,
         "relationships" => %{
+          "github-pull-request" => %{
+            "data" => %{
+              "id" => github_issue.github_pull_request_id |> Integer.to_string,
+              "type" => "github-pull-request"
+            }
+          },
           "github-repo" => %{
             "data" => %{
               "id" => github_issue.github_repo_id |> Integer.to_string,


### PR DESCRIPTION
# What's in this PR?

Fixes identifiers in views to not preload when all we need is the relationship ID displayed.