### PR TITLE
1125 update existing timestamps

### DIFF
--- a/priv/repo/migrations/20171028011642_update_null_task_values_from_github_integration.exs
+++ b/priv/repo/migrations/20171028011642_update_null_task_values_from_github_integration.exs
@@ -1,0 +1,61 @@
+defmodule CodeCorps.Repo.Migrations.UpdateNullTaskValuesFromGithubIntegration do
+  use Ecto.Migration
+
+  @consecutive_whitespace_regex ~r/\s+/
+
+  def up do
+    execute created_at_update()
+    execute created_from_update()
+
+    execute modified_at_update()
+    execute modified_from_update()
+  end
+
+  def down do
+    # no-op
+  end
+
+  defp created_at_update do
+    squish(
+      """
+        UPDATE tasks
+        SET created_at = inserted_at
+        WHERE created_at IS NULL
+      """
+    )
+  end
+
+  defp created_from_update do
+    squish(
+      """
+        UPDATE tasks
+        SET created_from = 'code_corps'
+        WHERE created_from IS NULL
+      """
+    )
+  end
+
+  defp modified_at_update do
+    squish(
+      """
+        UPDATE tasks
+        SET modified_at = updated_at
+        WHERE modified_at IS NULL
+      """
+    )
+  end
+
+  defp modified_from_update do
+    squish(
+      """
+        UPDATE tasks
+        SET modified_from = 'code_corps'
+        WHERE modified_from IS NULL
+      """
+    )
+  end
+
+  defp squish(query) do
+    String.replace(query, @consecutive_whitespace_regex, " ") |> String.trim
+  end
+end

--- a/priv/repo/migrations/20171028173508_update_null_comment_values_from_github_integrations.exs
+++ b/priv/repo/migrations/20171028173508_update_null_comment_values_from_github_integrations.exs
@@ -1,0 +1,61 @@
+defmodule CodeCorps.Repo.Migrations.UpdateNullCommentValuesFromGithubIntegrations do
+  use Ecto.Migration
+
+  @consecutive_whitespace_regex ~r/\s+/
+
+  def up do
+    execute created_at_update()
+    execute created_from_update()
+
+    execute modified_at_update()
+    execute modified_from_update()
+  end
+
+  def down do
+    # no-op
+  end
+
+  defp created_at_update do
+    squish(
+      """
+        UPDATE comments
+        SET created_at = inserted_at
+        WHERE created_at IS NULL
+      """
+    )
+  end
+
+  defp created_from_update do
+    squish(
+      """
+        UPDATE comments
+        SET created_from = 'code_corps'
+        WHERE created_from IS NULL
+      """
+    )
+  end
+
+  defp modified_at_update do
+    squish(
+      """
+        UPDATE comments
+        SET modified_at = updated_at
+        WHERE modified_at IS NULL
+      """
+    )
+  end
+
+  defp modified_from_update do
+    squish(
+      """
+        UPDATE comments
+        SET modified_from = 'code_corps'
+        WHERE modified_from IS NULL
+      """
+    )
+  end
+
+  defp squish(query) do
+    String.replace(query, @consecutive_whitespace_regex, " ") |> String.trim
+  end
+end


### PR DESCRIPTION
 - Updates existing task `created_at` and `modified_at` timestamps (where `nil`) to 'inserted_at` and `updated_at`, respectively.
 - Updates existing task `created_from` and `modified_from` columns (where `nil`) to `'code_corps'`.
 - Updates existing comment `created_at` and `modified_at` timestamps (where `nil`) to 'inserted_at` and `updated_at`, respectively.
 - Updates existing comment `created_from` and `modified_from` columns (where `nil`) to `'code_corps'`.

## References
Closes #1125 