### PR TITLE
Replace jaserializer with jsonapi

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -82,6 +82,9 @@ config :sentry,
   included_environments: ~w(prod staging)a,
   use_error_logger: true
 
+config :jsonapi,
+  underscore_to_dash: true
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/lib/code_corps_web/controllers/category_controller.ex
+++ b/lib/code_corps_web/controllers/category_controller.ex
@@ -16,7 +16,7 @@ defmodule CodeCorpsWeb.CategoryController do
   @spec show(Conn.t, map) :: Conn.t
   def show(%Conn{} = conn, %{"id" => id}) do
     with %Category{} = category <- Category |> Repo.get(id) |> preload() do
-      conn |> render("show.json-api", data: category)
+      conn |> render(CodeCorpsWeb.CategoryView, "show.json-api", %{ data: category, conn: conn, params: id })
     end
   end
 

--- a/lib/code_corps_web/views/category_view.ex
+++ b/lib/code_corps_web/views/category_view.ex
@@ -1,9 +1,13 @@
 defmodule CodeCorpsWeb.CategoryView do
   @moduledoc false
   use CodeCorpsWeb, :view
-  use JaSerializer.PhoenixView
+  use JSONAPI.View
 
-  attributes [:name, :slug, :description]
+  def render("show.json-api", %{ data: category, conn: conn, params: params }) do
+    __MODULE__.show(category, conn, params)
+  end
 
-  has_many :project_categories, serializer: CodeCorpsWeb.ProjectCategoryView, identifiers: :always
+  def fields, do: [:name, :slug, :description]
+  def type, do: "category"
+  def relationships, do: [project_categories: CodeCorpsWeb.ProjectCategoryView]
 end

--- a/lib/code_corps_web/views/category_view.ex
+++ b/lib/code_corps_web/views/category_view.ex
@@ -1,13 +1,12 @@
 defmodule CodeCorpsWeb.CategoryView do
   @moduledoc false
   use CodeCorpsWeb, :view
-  use JSONAPI.View
+  use JSONAPI.View, type: "category"
 
   def render("show.json-api", %{ data: category, conn: conn, params: params }) do
     __MODULE__.show(category, conn, params)
   end
 
   def fields, do: [:name, :slug, :description]
-  def type, do: "category"
   def relationships, do: [project_categories: CodeCorpsWeb.ProjectCategoryView]
 end

--- a/lib/code_corps_web/views/project_category_view.ex
+++ b/lib/code_corps_web/views/project_category_view.ex
@@ -1,14 +1,9 @@
 defmodule CodeCorpsWeb.ProjectCategoryView do
   @moduledoc false
   use CodeCorpsWeb, :view
-  use JSONAPI.View
-
-  def render("show.json", %{data: project_category, conn: conn, params: params}) do
-    __MODULE__.show(project_category, conn, params)
-  end
+  use JSONAPI.View, type: "project-category"
 
   def fields, do: []
-  def type, do: "project-category"
   def relationships, do: [project: CodeCorpsWeb.ProjectView,
     category: CodeCorpsWeb.CategoryView]
 end

--- a/lib/code_corps_web/views/project_category_view.ex
+++ b/lib/code_corps_web/views/project_category_view.ex
@@ -1,8 +1,14 @@
 defmodule CodeCorpsWeb.ProjectCategoryView do
   @moduledoc false
   use CodeCorpsWeb, :view
-  use JaSerializer.PhoenixView
+  use JSONAPI.View
 
-  has_one :project, type: "project", field: :project_id
-  has_one :category, type: "category", field: :category_id
+  def render("show.json", %{data: project_category, conn: conn, params: params}) do
+    __MODULE__.show(project_category, conn, params)
+  end
+
+  def fields, do: []
+  def type, do: "project-category"
+  def relationships, do: [project: CodeCorpsWeb.ProjectView,
+    category: CodeCorpsWeb.CategoryView]
 end

--- a/lib/code_corps_web/views/project_view.ex
+++ b/lib/code_corps_web/views/project_view.ex
@@ -5,6 +5,7 @@ defmodule CodeCorpsWeb.ProjectView do
 
   use CodeCorpsWeb, :view
   use JaSerializer.PhoenixView
+  use JSONAPI.View, type: "project"
 
   attributes [
   	:approved, :can_activate_donations, :cloudinary_public_id,

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule CodeCorps.Mixfile do
   def project do
     [app: :code_corps,
      version: "0.0.1",
-     elixir: "~> 1.5.0",
+     elixir: "~> 1.5.1",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      dialyzer: [plt_add_deps: :transitive],

--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,7 @@ defmodule CodeCorps.Mixfile do
       {:inflex, "~> 1.8.1"},
       {:ja_serializer, "~> 0.12"}, # JSON API
       {:joken, "~> 1.5"}, # JWT encoding
-      {:jsonapi, "~> 0.1.0"},
+      {:jsonapi, git: "https://github.com/jeregrine/jsonapi.git"},
       {:money, "~> 1.2.1"},
       {:poison, "~> 3.0", override: true},
       {:scout_apm, "~> 0.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule CodeCorps.Mixfile do
   def project do
     [app: :code_corps,
      version: "0.0.1",
-     elixir: "~> 1.5.1",
+     elixir: "~> 1.5.0",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      dialyzer: [plt_add_deps: :transitive],
@@ -71,6 +71,7 @@ defmodule CodeCorps.Mixfile do
       {:inflex, "~> 1.8.1"},
       {:ja_serializer, "~> 0.12"}, # JSON API
       {:joken, "~> 1.5"}, # JWT encoding
+      {:jsonapi, "~> 0.1.0"},
       {:money, "~> 1.2.1"},
       {:poison, "~> 3.0", override: true},
       {:scout_apm, "~> 0.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -37,7 +37,7 @@
   "ja_serializer": {:hex, :ja_serializer, "0.12.0", "ba4ec5fc7afa6daba815b5cb2b9bd0de410554ac4f0ed54e954d39decb353ca4", [:mix], [{:inflex, "~> 1.4", [hex: :inflex, optional: false]}, {:plug, "> 1.0.0", [hex: :plug, optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, optional: false]}, {:scrivener, "~> 1.2 or ~> 2.0", [hex: :scrivener, optional: true]}]},
   "joken": {:hex, :joken, "1.5.0", "42a0953e80bd933fc98a0874e156771f78bf0e92abe6c3a9c22feb6da28efb0b", [:mix], [{:jose, "~> 1.8", [hex: :jose, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: true]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: true]}]},
   "jose": {:hex, :jose, "1.8.4", "7946d1e5c03a76ac9ef42a6e6a20001d35987afd68c2107bcd8f01a84e75aa73", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, optional: false]}]},
-  "jsonapi": {:hex, :jsonapi, "0.1.2", "b53784e277ef175fced8efd6dde80141da72013d59a317e7f77c838d359faf4c", [], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "jsonapi": {:git, "https://github.com/jeregrine/jsonapi.git", "1cb176095773c8d481c38ec0f6b22c36fbff618a", []},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], []},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -37,6 +37,7 @@
   "ja_serializer": {:hex, :ja_serializer, "0.12.0", "ba4ec5fc7afa6daba815b5cb2b9bd0de410554ac4f0ed54e954d39decb353ca4", [:mix], [{:inflex, "~> 1.4", [hex: :inflex, optional: false]}, {:plug, "> 1.0.0", [hex: :plug, optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, optional: false]}, {:scrivener, "~> 1.2 or ~> 2.0", [hex: :scrivener, optional: true]}]},
   "joken": {:hex, :joken, "1.5.0", "42a0953e80bd933fc98a0874e156771f78bf0e92abe6c3a9c22feb6da28efb0b", [:mix], [{:jose, "~> 1.8", [hex: :jose, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: true]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: true]}]},
   "jose": {:hex, :jose, "1.8.4", "7946d1e5c03a76ac9ef42a6e6a20001d35987afd68c2107bcd8f01a84e75aa73", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, optional: false]}]},
+  "jsonapi": {:hex, :jsonapi, "0.1.2", "b53784e277ef175fced8efd6dde80141da72013d59a317e7f77c838d359faf4c", [], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], []},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,17 +2,12 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.9
--- Dumped by pg_dump version 10.0
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -52,7 +47,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: auth_token; Type: TABLE; Schema: public; Owner: -
+-- Name: auth_token; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE auth_token (
@@ -84,7 +79,7 @@ ALTER SEQUENCE auth_token_id_seq OWNED BY auth_token.id;
 
 
 --
--- Name: categories; Type: TABLE; Schema: public; Owner: -
+-- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE categories (
@@ -117,7 +112,7 @@ ALTER SEQUENCE categories_id_seq OWNED BY categories.id;
 
 
 --
--- Name: comments; Type: TABLE; Schema: public; Owner: -
+-- Name: comments; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE comments (
@@ -156,7 +151,7 @@ ALTER SEQUENCE comments_id_seq OWNED BY comments.id;
 
 
 --
--- Name: donation_goals; Type: TABLE; Schema: public; Owner: -
+-- Name: donation_goals; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE donation_goals (
@@ -190,7 +185,7 @@ ALTER SEQUENCE donation_goals_id_seq OWNED BY donation_goals.id;
 
 
 --
--- Name: github_app_installations; Type: TABLE; Schema: public; Owner: -
+-- Name: github_app_installations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE github_app_installations (
@@ -233,7 +228,7 @@ ALTER SEQUENCE github_app_installations_id_seq OWNED BY github_app_installations
 
 
 --
--- Name: github_comments; Type: TABLE; Schema: public; Owner: -
+-- Name: github_comments; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE github_comments (
@@ -270,7 +265,7 @@ ALTER SEQUENCE github_comments_id_seq OWNED BY github_comments.id;
 
 
 --
--- Name: github_events; Type: TABLE; Schema: public; Owner: -
+-- Name: github_events; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE github_events (
@@ -306,7 +301,7 @@ ALTER SEQUENCE github_events_id_seq OWNED BY github_events.id;
 
 
 --
--- Name: github_issues; Type: TABLE; Schema: public; Owner: -
+-- Name: github_issues; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE github_issues (
@@ -352,7 +347,7 @@ ALTER SEQUENCE github_issues_id_seq OWNED BY github_issues.id;
 
 
 --
--- Name: github_pull_requests; Type: TABLE; Schema: public; Owner: -
+-- Name: github_pull_requests; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE github_pull_requests (
@@ -412,7 +407,7 @@ ALTER SEQUENCE github_pull_requests_id_seq OWNED BY github_pull_requests.id;
 
 
 --
--- Name: github_repos; Type: TABLE; Schema: public; Owner: -
+-- Name: github_repos; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE github_repos (
@@ -449,7 +444,7 @@ ALTER SEQUENCE github_repos_id_seq OWNED BY github_repos.id;
 
 
 --
--- Name: organization_github_app_installations; Type: TABLE; Schema: public; Owner: -
+-- Name: organization_github_app_installations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organization_github_app_installations (
@@ -481,7 +476,7 @@ ALTER SEQUENCE organization_github_app_installations_id_seq OWNED BY organizatio
 
 
 --
--- Name: organization_invites; Type: TABLE; Schema: public; Owner: -
+-- Name: organization_invites; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organization_invites (
@@ -515,7 +510,7 @@ ALTER SEQUENCE organization_invites_id_seq OWNED BY organization_invites.id;
 
 
 --
--- Name: organizations; Type: TABLE; Schema: public; Owner: -
+-- Name: organizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE organizations (
@@ -552,7 +547,7 @@ ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
 
 
 --
--- Name: previews; Type: TABLE; Schema: public; Owner: -
+-- Name: previews; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE previews (
@@ -585,7 +580,7 @@ ALTER SEQUENCE previews_id_seq OWNED BY previews.id;
 
 
 --
--- Name: project_categories; Type: TABLE; Schema: public; Owner: -
+-- Name: project_categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_categories (
@@ -617,7 +612,7 @@ ALTER SEQUENCE project_categories_id_seq OWNED BY project_categories.id;
 
 
 --
--- Name: project_github_repos; Type: TABLE; Schema: public; Owner: -
+-- Name: project_github_repos; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_github_repos (
@@ -649,7 +644,7 @@ ALTER SEQUENCE project_github_repos_id_seq OWNED BY project_github_repos.id;
 
 
 --
--- Name: project_skills; Type: TABLE; Schema: public; Owner: -
+-- Name: project_skills; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_skills (
@@ -681,7 +676,7 @@ ALTER SEQUENCE project_skills_id_seq OWNED BY project_skills.id;
 
 
 --
--- Name: project_users; Type: TABLE; Schema: public; Owner: -
+-- Name: project_users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE project_users (
@@ -714,7 +709,7 @@ ALTER SEQUENCE project_users_id_seq OWNED BY project_users.id;
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -
+-- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE projects (
@@ -759,7 +754,7 @@ ALTER SEQUENCE projects_id_seq OWNED BY projects.id;
 
 
 --
--- Name: role_skills; Type: TABLE; Schema: public; Owner: -
+-- Name: role_skills; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE role_skills (
@@ -792,7 +787,7 @@ ALTER SEQUENCE role_skills_id_seq OWNED BY role_skills.id;
 
 
 --
--- Name: roles; Type: TABLE; Schema: public; Owner: -
+-- Name: roles; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE roles (
@@ -825,7 +820,7 @@ ALTER SEQUENCE roles_id_seq OWNED BY roles.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE schema_migrations (
@@ -835,7 +830,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: skills; Type: TABLE; Schema: public; Owner: -
+-- Name: skills; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE skills (
@@ -868,7 +863,7 @@ ALTER SEQUENCE skills_id_seq OWNED BY skills.id;
 
 
 --
--- Name: slugged_routes; Type: TABLE; Schema: public; Owner: -
+-- Name: slugged_routes; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE slugged_routes (
@@ -901,7 +896,7 @@ ALTER SEQUENCE slugged_routes_id_seq OWNED BY slugged_routes.id;
 
 
 --
--- Name: stripe_connect_accounts; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_connect_accounts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_connect_accounts (
@@ -983,7 +978,7 @@ ALTER SEQUENCE stripe_connect_accounts_id_seq OWNED BY stripe_connect_accounts.i
 
 
 --
--- Name: stripe_connect_cards; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_connect_cards; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_connect_cards (
@@ -1016,7 +1011,7 @@ ALTER SEQUENCE stripe_connect_cards_id_seq OWNED BY stripe_connect_cards.id;
 
 
 --
--- Name: stripe_connect_charges; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_connect_charges; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_connect_charges (
@@ -1069,7 +1064,7 @@ ALTER SEQUENCE stripe_connect_charges_id_seq OWNED BY stripe_connect_charges.id;
 
 
 --
--- Name: stripe_connect_customers; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_connect_customers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_connect_customers (
@@ -1103,7 +1098,7 @@ ALTER SEQUENCE stripe_connect_customers_id_seq OWNED BY stripe_connect_customers
 
 
 --
--- Name: stripe_connect_plans; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_connect_plans; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_connect_plans (
@@ -1138,7 +1133,7 @@ ALTER SEQUENCE stripe_connect_plans_id_seq OWNED BY stripe_connect_plans.id;
 
 
 --
--- Name: stripe_connect_subscriptions; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_connect_subscriptions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_connect_subscriptions (
@@ -1182,7 +1177,7 @@ ALTER SEQUENCE stripe_connect_subscriptions_id_seq OWNED BY stripe_connect_subsc
 
 
 --
--- Name: stripe_events; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_events; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_events (
@@ -1220,7 +1215,7 @@ ALTER SEQUENCE stripe_events_id_seq OWNED BY stripe_events.id;
 
 
 --
--- Name: stripe_external_accounts; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_external_accounts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_external_accounts (
@@ -1263,7 +1258,7 @@ ALTER SEQUENCE stripe_external_accounts_id_seq OWNED BY stripe_external_accounts
 
 
 --
--- Name: stripe_file_upload; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_file_upload; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_file_upload (
@@ -1298,7 +1293,7 @@ ALTER SEQUENCE stripe_file_upload_id_seq OWNED BY stripe_file_upload.id;
 
 
 --
--- Name: stripe_invoices; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_invoices; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_invoices (
@@ -1357,7 +1352,7 @@ ALTER SEQUENCE stripe_invoices_id_seq OWNED BY stripe_invoices.id;
 
 
 --
--- Name: stripe_platform_cards; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_platform_cards; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_platform_cards (
@@ -1396,7 +1391,7 @@ ALTER SEQUENCE stripe_platform_cards_id_seq OWNED BY stripe_platform_cards.id;
 
 
 --
--- Name: stripe_platform_customers; Type: TABLE; Schema: public; Owner: -
+-- Name: stripe_platform_customers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE stripe_platform_customers (
@@ -1432,7 +1427,7 @@ ALTER SEQUENCE stripe_platform_customers_id_seq OWNED BY stripe_platform_custome
 
 
 --
--- Name: task_lists; Type: TABLE; Schema: public; Owner: -
+-- Name: task_lists; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE task_lists (
@@ -1466,7 +1461,7 @@ ALTER SEQUENCE task_lists_id_seq OWNED BY task_lists.id;
 
 
 --
--- Name: task_skills; Type: TABLE; Schema: public; Owner: -
+-- Name: task_skills; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE task_skills (
@@ -1498,7 +1493,7 @@ ALTER SEQUENCE task_skills_id_seq OWNED BY task_skills.id;
 
 
 --
--- Name: tasks; Type: TABLE; Schema: public; Owner: -
+-- Name: tasks; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE tasks (
@@ -1545,7 +1540,7 @@ ALTER SEQUENCE tasks_id_seq OWNED BY tasks.id;
 
 
 --
--- Name: user_categories; Type: TABLE; Schema: public; Owner: -
+-- Name: user_categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_categories (
@@ -1577,7 +1572,7 @@ ALTER SEQUENCE user_categories_id_seq OWNED BY user_categories.id;
 
 
 --
--- Name: user_roles; Type: TABLE; Schema: public; Owner: -
+-- Name: user_roles; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_roles (
@@ -1609,7 +1604,7 @@ ALTER SEQUENCE user_roles_id_seq OWNED BY user_roles.id;
 
 
 --
--- Name: user_skills; Type: TABLE; Schema: public; Owner: -
+-- Name: user_skills; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_skills (
@@ -1641,7 +1636,7 @@ ALTER SEQUENCE user_skills_id_seq OWNED BY user_skills.id;
 
 
 --
--- Name: user_tasks; Type: TABLE; Schema: public; Owner: -
+-- Name: user_tasks; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE user_tasks (
@@ -1673,7 +1668,7 @@ ALTER SEQUENCE user_tasks_id_seq OWNED BY user_tasks.id;
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -
+-- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE users (
@@ -1722,308 +1717,308 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: auth_token id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY auth_token ALTER COLUMN id SET DEFAULT nextval('auth_token_id_seq'::regclass);
 
 
 --
--- Name: categories id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY categories ALTER COLUMN id SET DEFAULT nextval('categories_id_seq'::regclass);
 
 
 --
--- Name: comments id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY comments ALTER COLUMN id SET DEFAULT nextval('comments_id_seq'::regclass);
 
 
 --
--- Name: donation_goals id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY donation_goals ALTER COLUMN id SET DEFAULT nextval('donation_goals_id_seq'::regclass);
 
 
 --
--- Name: github_app_installations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_app_installations ALTER COLUMN id SET DEFAULT nextval('github_app_installations_id_seq'::regclass);
 
 
 --
--- Name: github_comments id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_comments ALTER COLUMN id SET DEFAULT nextval('github_comments_id_seq'::regclass);
 
 
 --
--- Name: github_events id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_events ALTER COLUMN id SET DEFAULT nextval('github_events_id_seq'::regclass);
 
 
 --
--- Name: github_issues id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_issues ALTER COLUMN id SET DEFAULT nextval('github_issues_id_seq'::regclass);
 
 
 --
--- Name: github_pull_requests id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_pull_requests ALTER COLUMN id SET DEFAULT nextval('github_pull_requests_id_seq'::regclass);
 
 
 --
--- Name: github_repos id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_repos ALTER COLUMN id SET DEFAULT nextval('github_repos_id_seq'::regclass);
 
 
 --
--- Name: organization_github_app_installations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organization_github_app_installations ALTER COLUMN id SET DEFAULT nextval('organization_github_app_installations_id_seq'::regclass);
 
 
 --
--- Name: organization_invites id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organization_invites ALTER COLUMN id SET DEFAULT nextval('organization_invites_id_seq'::regclass);
 
 
 --
--- Name: organizations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organizations ALTER COLUMN id SET DEFAULT nextval('organizations_id_seq'::regclass);
 
 
 --
--- Name: previews id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY previews ALTER COLUMN id SET DEFAULT nextval('previews_id_seq'::regclass);
 
 
 --
--- Name: project_categories id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_categories ALTER COLUMN id SET DEFAULT nextval('project_categories_id_seq'::regclass);
 
 
 --
--- Name: project_github_repos id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_github_repos ALTER COLUMN id SET DEFAULT nextval('project_github_repos_id_seq'::regclass);
 
 
 --
--- Name: project_skills id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_skills ALTER COLUMN id SET DEFAULT nextval('project_skills_id_seq'::regclass);
 
 
 --
--- Name: project_users id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_users ALTER COLUMN id SET DEFAULT nextval('project_users_id_seq'::regclass);
 
 
 --
--- Name: projects id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY projects ALTER COLUMN id SET DEFAULT nextval('projects_id_seq'::regclass);
 
 
 --
--- Name: role_skills id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY role_skills ALTER COLUMN id SET DEFAULT nextval('role_skills_id_seq'::regclass);
 
 
 --
--- Name: roles id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY roles ALTER COLUMN id SET DEFAULT nextval('roles_id_seq'::regclass);
 
 
 --
--- Name: skills id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY skills ALTER COLUMN id SET DEFAULT nextval('skills_id_seq'::regclass);
 
 
 --
--- Name: slugged_routes id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY slugged_routes ALTER COLUMN id SET DEFAULT nextval('slugged_routes_id_seq'::regclass);
 
 
 --
--- Name: stripe_connect_accounts id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_accounts ALTER COLUMN id SET DEFAULT nextval('stripe_connect_accounts_id_seq'::regclass);
 
 
 --
--- Name: stripe_connect_cards id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_cards ALTER COLUMN id SET DEFAULT nextval('stripe_connect_cards_id_seq'::regclass);
 
 
 --
--- Name: stripe_connect_charges id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_charges ALTER COLUMN id SET DEFAULT nextval('stripe_connect_charges_id_seq'::regclass);
 
 
 --
--- Name: stripe_connect_customers id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_customers ALTER COLUMN id SET DEFAULT nextval('stripe_connect_customers_id_seq'::regclass);
 
 
 --
--- Name: stripe_connect_plans id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_plans ALTER COLUMN id SET DEFAULT nextval('stripe_connect_plans_id_seq'::regclass);
 
 
 --
--- Name: stripe_connect_subscriptions id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_subscriptions ALTER COLUMN id SET DEFAULT nextval('stripe_connect_subscriptions_id_seq'::regclass);
 
 
 --
--- Name: stripe_events id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_events ALTER COLUMN id SET DEFAULT nextval('stripe_events_id_seq'::regclass);
 
 
 --
--- Name: stripe_external_accounts id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_external_accounts ALTER COLUMN id SET DEFAULT nextval('stripe_external_accounts_id_seq'::regclass);
 
 
 --
--- Name: stripe_file_upload id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_file_upload ALTER COLUMN id SET DEFAULT nextval('stripe_file_upload_id_seq'::regclass);
 
 
 --
--- Name: stripe_invoices id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_invoices ALTER COLUMN id SET DEFAULT nextval('stripe_invoices_id_seq'::regclass);
 
 
 --
--- Name: stripe_platform_cards id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_platform_cards ALTER COLUMN id SET DEFAULT nextval('stripe_platform_cards_id_seq'::regclass);
 
 
 --
--- Name: stripe_platform_customers id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_platform_customers ALTER COLUMN id SET DEFAULT nextval('stripe_platform_customers_id_seq'::regclass);
 
 
 --
--- Name: task_lists id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY task_lists ALTER COLUMN id SET DEFAULT nextval('task_lists_id_seq'::regclass);
 
 
 --
--- Name: task_skills id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY task_skills ALTER COLUMN id SET DEFAULT nextval('task_skills_id_seq'::regclass);
 
 
 --
--- Name: tasks id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tasks ALTER COLUMN id SET DEFAULT nextval('tasks_id_seq'::regclass);
 
 
 --
--- Name: user_categories id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_categories ALTER COLUMN id SET DEFAULT nextval('user_categories_id_seq'::regclass);
 
 
 --
--- Name: user_roles id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_roles ALTER COLUMN id SET DEFAULT nextval('user_roles_id_seq'::regclass);
 
 
 --
--- Name: user_skills id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_skills ALTER COLUMN id SET DEFAULT nextval('user_skills_id_seq'::regclass);
 
 
 --
--- Name: user_tasks id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_tasks ALTER COLUMN id SET DEFAULT nextval('user_tasks_id_seq'::regclass);
 
 
 --
--- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
--- Name: auth_token auth_token_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: auth_token_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY auth_token
@@ -2031,7 +2026,7 @@ ALTER TABLE ONLY auth_token
 
 
 --
--- Name: categories categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY categories
@@ -2039,7 +2034,7 @@ ALTER TABLE ONLY categories
 
 
 --
--- Name: comments comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY comments
@@ -2047,7 +2042,7 @@ ALTER TABLE ONLY comments
 
 
 --
--- Name: donation_goals donation_goals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: donation_goals_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY donation_goals
@@ -2055,7 +2050,7 @@ ALTER TABLE ONLY donation_goals
 
 
 --
--- Name: github_app_installations github_app_installations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: github_app_installations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY github_app_installations
@@ -2063,7 +2058,7 @@ ALTER TABLE ONLY github_app_installations
 
 
 --
--- Name: github_comments github_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: github_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY github_comments
@@ -2071,7 +2066,7 @@ ALTER TABLE ONLY github_comments
 
 
 --
--- Name: github_events github_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: github_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY github_events
@@ -2079,7 +2074,7 @@ ALTER TABLE ONLY github_events
 
 
 --
--- Name: github_issues github_issues_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: github_issues_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY github_issues
@@ -2087,7 +2082,7 @@ ALTER TABLE ONLY github_issues
 
 
 --
--- Name: github_pull_requests github_pull_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: github_pull_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY github_pull_requests
@@ -2095,7 +2090,7 @@ ALTER TABLE ONLY github_pull_requests
 
 
 --
--- Name: github_repos github_repos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: github_repos_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY github_repos
@@ -2103,7 +2098,7 @@ ALTER TABLE ONLY github_repos
 
 
 --
--- Name: organization_github_app_installations organization_github_app_installations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: organization_github_app_installations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organization_github_app_installations
@@ -2111,7 +2106,7 @@ ALTER TABLE ONLY organization_github_app_installations
 
 
 --
--- Name: organization_invites organization_invites_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: organization_invites_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organization_invites
@@ -2119,7 +2114,7 @@ ALTER TABLE ONLY organization_invites
 
 
 --
--- Name: organizations organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY organizations
@@ -2127,7 +2122,7 @@ ALTER TABLE ONLY organizations
 
 
 --
--- Name: previews previews_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: previews_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY previews
@@ -2135,7 +2130,7 @@ ALTER TABLE ONLY previews
 
 
 --
--- Name: project_categories project_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: project_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_categories
@@ -2143,7 +2138,7 @@ ALTER TABLE ONLY project_categories
 
 
 --
--- Name: project_github_repos project_github_repos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: project_github_repos_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_github_repos
@@ -2151,7 +2146,7 @@ ALTER TABLE ONLY project_github_repos
 
 
 --
--- Name: project_skills project_skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: project_skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_skills
@@ -2159,7 +2154,7 @@ ALTER TABLE ONLY project_skills
 
 
 --
--- Name: project_users project_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: project_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY project_users
@@ -2167,7 +2162,7 @@ ALTER TABLE ONLY project_users
 
 
 --
--- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY projects
@@ -2175,7 +2170,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: role_skills role_skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: role_skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY role_skills
@@ -2183,7 +2178,7 @@ ALTER TABLE ONLY role_skills
 
 
 --
--- Name: roles roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY roles
@@ -2191,7 +2186,7 @@ ALTER TABLE ONLY roles
 
 
 --
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -2199,7 +2194,7 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: skills skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY skills
@@ -2207,7 +2202,7 @@ ALTER TABLE ONLY skills
 
 
 --
--- Name: slugged_routes slugged_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: slugged_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY slugged_routes
@@ -2215,7 +2210,7 @@ ALTER TABLE ONLY slugged_routes
 
 
 --
--- Name: stripe_connect_cards stripe_connect_cards_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_cards_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY stripe_connect_cards
@@ -2223,7 +2218,7 @@ ALTER TABLE ONLY stripe_connect_cards
 
 
 --
--- Name: stripe_connect_charges stripe_connect_charges_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_charges_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY stripe_connect_charges
@@ -2231,7 +2226,7 @@ ALTER TABLE ONLY stripe_connect_charges
 
 
 --
--- Name: stripe_connect_customers stripe_connect_customers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_customers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY stripe_connect_customers
@@ -2239,7 +2234,7 @@ ALTER TABLE ONLY stripe_connect_customers
 
 
 --
--- Name: stripe_events stripe_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY stripe_events
@@ -2247,7 +2242,7 @@ ALTER TABLE ONLY stripe_events
 
 
 --
--- Name: stripe_external_accounts stripe_external_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_external_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY stripe_external_accounts
@@ -2255,7 +2250,7 @@ ALTER TABLE ONLY stripe_external_accounts
 
 
 --
--- Name: stripe_file_upload stripe_file_upload_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_file_upload_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY stripe_file_upload
@@ -2263,7 +2258,7 @@ ALTER TABLE ONLY stripe_file_upload
 
 
 --
--- Name: stripe_invoices stripe_invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY stripe_invoices
@@ -2271,7 +2266,7 @@ ALTER TABLE ONLY stripe_invoices
 
 
 --
--- Name: task_lists task_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: task_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY task_lists
@@ -2279,7 +2274,7 @@ ALTER TABLE ONLY task_lists
 
 
 --
--- Name: task_skills task_skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: task_skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY task_skills
@@ -2287,7 +2282,7 @@ ALTER TABLE ONLY task_skills
 
 
 --
--- Name: user_categories user_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_categories
@@ -2295,7 +2290,7 @@ ALTER TABLE ONLY user_categories
 
 
 --
--- Name: user_roles user_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_roles
@@ -2303,7 +2298,7 @@ ALTER TABLE ONLY user_roles
 
 
 --
--- Name: user_skills user_skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_skills
@@ -2311,7 +2306,7 @@ ALTER TABLE ONLY user_skills
 
 
 --
--- Name: user_tasks user_tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY user_tasks
@@ -2319,7 +2314,7 @@ ALTER TABLE ONLY user_tasks
 
 
 --
--- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY users
@@ -2327,854 +2322,854 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: auth_token_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: auth_token_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX auth_token_user_id_index ON auth_token USING btree (user_id);
 
 
 --
--- Name: auth_token_value_index; Type: INDEX; Schema: public; Owner: -
+-- Name: auth_token_value_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX auth_token_value_index ON auth_token USING btree (value);
 
 
 --
--- Name: comments_github_comment_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: comments_github_comment_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX comments_github_comment_id_index ON comments USING btree (github_comment_id);
 
 
 --
--- Name: comments_task_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: comments_task_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX comments_task_id_index ON comments USING btree (task_id);
 
 
 --
--- Name: comments_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: comments_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX comments_user_id_index ON comments USING btree (user_id);
 
 
 --
--- Name: donation_goals_current_unique_to_project; Type: INDEX; Schema: public; Owner: -
+-- Name: donation_goals_current_unique_to_project; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX donation_goals_current_unique_to_project ON donation_goals USING btree (project_id) WHERE current;
 
 
 --
--- Name: donation_goals_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: donation_goals_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX donation_goals_project_id_index ON donation_goals USING btree (project_id);
 
 
 --
--- Name: github_app_installations_github_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_app_installations_github_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX github_app_installations_github_id_index ON github_app_installations USING btree (github_id);
 
 
 --
--- Name: github_app_installations_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_app_installations_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX github_app_installations_project_id_index ON github_app_installations USING btree (project_id);
 
 
 --
--- Name: github_app_installations_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_app_installations_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX github_app_installations_user_id_index ON github_app_installations USING btree (user_id);
 
 
 --
--- Name: github_comments_github_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_comments_github_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX github_comments_github_id_index ON github_comments USING btree (github_id);
 
 
 --
--- Name: github_comments_github_issue_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_comments_github_issue_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX github_comments_github_issue_id_index ON github_comments USING btree (github_issue_id);
 
 
 --
--- Name: github_events_github_delivery_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_events_github_delivery_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX github_events_github_delivery_id_index ON github_events USING btree (github_delivery_id);
 
 
 --
--- Name: github_events_status_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_events_status_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX github_events_status_index ON github_events USING btree (status);
 
 
 --
--- Name: github_issues_github_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_issues_github_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX github_issues_github_id_index ON github_issues USING btree (github_id);
 
 
 --
--- Name: github_issues_github_pull_request_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_issues_github_pull_request_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX github_issues_github_pull_request_id_index ON github_issues USING btree (github_pull_request_id);
 
 
 --
--- Name: github_issues_github_repo_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_issues_github_repo_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX github_issues_github_repo_id_index ON github_issues USING btree (github_repo_id);
 
 
 --
--- Name: github_pull_requests_github_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_pull_requests_github_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX github_pull_requests_github_id_index ON github_pull_requests USING btree (github_id);
 
 
 --
--- Name: github_pull_requests_github_repo_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_pull_requests_github_repo_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX github_pull_requests_github_repo_id_index ON github_pull_requests USING btree (github_repo_id);
 
 
 --
--- Name: github_repos_github_app_installation_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_repos_github_app_installation_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX github_repos_github_app_installation_id_index ON github_repos USING btree (github_app_installation_id);
 
 
 --
--- Name: github_repos_github_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: github_repos_github_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX github_repos_github_id_index ON github_repos USING btree (github_id);
 
 
 --
--- Name: index_categories_on_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: index_categories_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_categories_on_slug ON categories USING btree (lower((slug)::text));
 
 
 --
--- Name: index_projects_on_role_id_skill_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_role_id_skill_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_projects_on_role_id_skill_id ON role_skills USING btree (role_id, skill_id);
 
 
 --
--- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_projects_on_slug ON projects USING btree (lower((slug)::text));
 
 
 --
--- Name: index_projects_on_user_id_skill_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_projects_on_user_id_skill_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_projects_on_user_id_skill_id ON user_skills USING btree (user_id, skill_id);
 
 
 --
--- Name: index_skills_on_title; Type: INDEX; Schema: public; Owner: -
+-- Name: index_skills_on_title; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_skills_on_title ON skills USING btree (lower((title)::text));
 
 
 --
--- Name: organization_github_app_installations_github_app_installation_i; Type: INDEX; Schema: public; Owner: -
+-- Name: organization_github_app_installations_github_app_installation_i; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX organization_github_app_installations_github_app_installation_i ON organization_github_app_installations USING btree (github_app_installation_id);
 
 
 --
--- Name: organization_github_app_installations_organization_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: organization_github_app_installations_organization_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX organization_github_app_installations_organization_id_index ON organization_github_app_installations USING btree (organization_id);
 
 
 --
--- Name: organization_invites_code_index; Type: INDEX; Schema: public; Owner: -
+-- Name: organization_invites_code_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX organization_invites_code_index ON organization_invites USING btree (code);
 
 
 --
--- Name: organization_invites_email_index; Type: INDEX; Schema: public; Owner: -
+-- Name: organization_invites_email_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX organization_invites_email_index ON organization_invites USING btree (email);
 
 
 --
--- Name: organizations_approved_index; Type: INDEX; Schema: public; Owner: -
+-- Name: organizations_approved_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX organizations_approved_index ON organizations USING btree (approved);
 
 
 --
--- Name: organizations_lower_slug_index; Type: INDEX; Schema: public; Owner: -
+-- Name: organizations_lower_slug_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX organizations_lower_slug_index ON organizations USING btree (lower((slug)::text));
 
 
 --
--- Name: organizations_owner_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: organizations_owner_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX organizations_owner_id_index ON organizations USING btree (owner_id);
 
 
 --
--- Name: previews_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: previews_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX previews_user_id_index ON previews USING btree (user_id);
 
 
 --
--- Name: project_categories_category_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_categories_category_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX project_categories_category_id_index ON project_categories USING btree (category_id);
 
 
 --
--- Name: project_categories_project_id_category_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_categories_project_id_category_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX project_categories_project_id_category_id_index ON project_categories USING btree (project_id, category_id);
 
 
 --
--- Name: project_categories_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_categories_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX project_categories_project_id_index ON project_categories USING btree (project_id);
 
 
 --
--- Name: project_github_repos_github_repo_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_github_repos_github_repo_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX project_github_repos_github_repo_id_index ON project_github_repos USING btree (github_repo_id);
 
 
 --
--- Name: project_github_repos_project_id_github_repo_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_github_repos_project_id_github_repo_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX project_github_repos_project_id_github_repo_id_index ON project_github_repos USING btree (project_id, github_repo_id);
 
 
 --
--- Name: project_github_repos_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_github_repos_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX project_github_repos_project_id_index ON project_github_repos USING btree (project_id);
 
 
 --
--- Name: project_skills_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_skills_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX project_skills_project_id_index ON project_skills USING btree (project_id);
 
 
 --
--- Name: project_skills_project_id_skill_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_skills_project_id_skill_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX project_skills_project_id_skill_id_index ON project_skills USING btree (project_id, skill_id);
 
 
 --
--- Name: project_skills_skill_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_skills_skill_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX project_skills_skill_id_index ON project_skills USING btree (skill_id);
 
 
 --
--- Name: project_users_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_users_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX project_users_project_id_index ON project_users USING btree (project_id);
 
 
 --
--- Name: project_users_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_users_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX project_users_user_id_index ON project_users USING btree (user_id);
 
 
 --
--- Name: project_users_user_id_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: project_users_user_id_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX project_users_user_id_project_id_index ON project_users USING btree (user_id, project_id);
 
 
 --
--- Name: projects_approved_index; Type: INDEX; Schema: public; Owner: -
+-- Name: projects_approved_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX projects_approved_index ON projects USING btree (approved);
 
 
 --
--- Name: projects_organization_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: projects_organization_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX projects_organization_id_index ON projects USING btree (organization_id);
 
 
 --
--- Name: role_skills_role_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: role_skills_role_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX role_skills_role_id_index ON role_skills USING btree (role_id);
 
 
 --
--- Name: role_skills_skill_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: role_skills_skill_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX role_skills_skill_id_index ON role_skills USING btree (skill_id);
 
 
 --
--- Name: slugged_routes_lower_slug_index; Type: INDEX; Schema: public; Owner: -
+-- Name: slugged_routes_lower_slug_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX slugged_routes_lower_slug_index ON slugged_routes USING btree (lower((slug)::text));
 
 
 --
--- Name: slugged_routes_organization_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: slugged_routes_organization_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX slugged_routes_organization_id_index ON slugged_routes USING btree (organization_id);
 
 
 --
--- Name: slugged_routes_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: slugged_routes_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX slugged_routes_user_id_index ON slugged_routes USING btree (user_id);
 
 
 --
--- Name: stripe_connect_accounts_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_accounts_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_accounts_id_from_stripe_index ON stripe_connect_accounts USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_connect_accounts_organization_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_accounts_organization_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_accounts_organization_id_index ON stripe_connect_accounts USING btree (organization_id);
 
 
 --
--- Name: stripe_connect_accounts_pkey; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_accounts_pkey; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_accounts_pkey ON stripe_connect_accounts USING btree (id);
 
 
 --
--- Name: stripe_connect_cards_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_cards_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_cards_id_from_stripe_index ON stripe_connect_cards USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_connect_cards_stripe_connect_account_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_cards_stripe_connect_account_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_connect_cards_stripe_connect_account_id_index ON stripe_connect_cards USING btree (stripe_connect_account_id);
 
 
 --
--- Name: stripe_connect_cards_stripe_connect_account_id_stripe_platform_; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_cards_stripe_connect_account_id_stripe_platform_; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_cards_stripe_connect_account_id_stripe_platform_ ON stripe_connect_cards USING btree (stripe_connect_account_id, stripe_platform_card_id);
 
 
 --
--- Name: stripe_connect_charges_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_charges_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_charges_id_from_stripe_index ON stripe_connect_charges USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_connect_charges_stripe_connect_account_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_charges_stripe_connect_account_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_connect_charges_stripe_connect_account_id_index ON stripe_connect_charges USING btree (stripe_connect_account_id);
 
 
 --
--- Name: stripe_connect_charges_stripe_connect_customer_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_charges_stripe_connect_customer_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_connect_charges_stripe_connect_customer_id_index ON stripe_connect_charges USING btree (stripe_connect_customer_id);
 
 
 --
--- Name: stripe_connect_charges_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_charges_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_connect_charges_user_id_index ON stripe_connect_charges USING btree (user_id);
 
 
 --
--- Name: stripe_connect_customers_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_customers_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_customers_id_from_stripe_index ON stripe_connect_customers USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_connect_customers_stripe_connect_account_id_stripe_platf; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_customers_stripe_connect_account_id_stripe_platf; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_customers_stripe_connect_account_id_stripe_platf ON stripe_connect_customers USING btree (stripe_connect_account_id, stripe_platform_customer_id);
 
 
 --
--- Name: stripe_connect_customers_stripe_platform_customer_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_customers_stripe_platform_customer_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_connect_customers_stripe_platform_customer_id_index ON stripe_connect_customers USING btree (stripe_platform_customer_id);
 
 
 --
--- Name: stripe_connect_customers_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_customers_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_connect_customers_user_id_index ON stripe_connect_customers USING btree (user_id);
 
 
 --
--- Name: stripe_connect_plans_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_plans_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_plans_id_from_stripe_index ON stripe_connect_plans USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_connect_plans_pkey; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_plans_pkey; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_plans_pkey ON stripe_connect_plans USING btree (id);
 
 
 --
--- Name: stripe_connect_plans_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_plans_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_plans_project_id_index ON stripe_connect_plans USING btree (project_id);
 
 
 --
--- Name: stripe_connect_subscriptions_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_subscriptions_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_subscriptions_id_from_stripe_index ON stripe_connect_subscriptions USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_connect_subscriptions_pkey; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_subscriptions_pkey; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_connect_subscriptions_pkey ON stripe_connect_subscriptions USING btree (id);
 
 
 --
--- Name: stripe_connect_subscriptions_plan_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_subscriptions_plan_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_connect_subscriptions_plan_id_from_stripe_index ON stripe_connect_subscriptions USING btree (plan_id_from_stripe);
 
 
 --
--- Name: stripe_connect_subscriptions_stripe_connect_plan_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_subscriptions_stripe_connect_plan_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_connect_subscriptions_stripe_connect_plan_id_index ON stripe_connect_subscriptions USING btree (stripe_connect_plan_id);
 
 
 --
--- Name: stripe_connect_subscriptions_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_connect_subscriptions_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_connect_subscriptions_user_id_index ON stripe_connect_subscriptions USING btree (user_id);
 
 
 --
--- Name: stripe_events_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_events_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_events_id_from_stripe_index ON stripe_events USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_external_accounts_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_external_accounts_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_external_accounts_id_from_stripe_index ON stripe_external_accounts USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_external_accounts_stripe_connect_account_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_external_accounts_stripe_connect_account_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_external_accounts_stripe_connect_account_id_index ON stripe_external_accounts USING btree (stripe_connect_account_id);
 
 
 --
--- Name: stripe_file_upload_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_file_upload_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_file_upload_id_from_stripe_index ON stripe_file_upload USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_file_upload_stripe_connect_account_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_file_upload_stripe_connect_account_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_file_upload_stripe_connect_account_id_index ON stripe_file_upload USING btree (stripe_connect_account_id);
 
 
 --
--- Name: stripe_invoices_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_invoices_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_invoices_id_from_stripe_index ON stripe_invoices USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_invoices_stripe_connect_subscription_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_invoices_stripe_connect_subscription_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_invoices_stripe_connect_subscription_id_index ON stripe_invoices USING btree (stripe_connect_subscription_id);
 
 
 --
--- Name: stripe_invoices_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_invoices_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX stripe_invoices_user_id_index ON stripe_invoices USING btree (user_id);
 
 
 --
--- Name: stripe_platform_cards_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_platform_cards_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_platform_cards_id_from_stripe_index ON stripe_platform_cards USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_platform_cards_pkey; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_platform_cards_pkey; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_platform_cards_pkey ON stripe_platform_cards USING btree (id);
 
 
 --
--- Name: stripe_platform_cards_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_platform_cards_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_platform_cards_user_id_index ON stripe_platform_cards USING btree (user_id);
 
 
 --
--- Name: stripe_platform_customers_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_platform_customers_id_from_stripe_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_platform_customers_id_from_stripe_index ON stripe_platform_customers USING btree (id_from_stripe);
 
 
 --
--- Name: stripe_platform_customers_pkey; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_platform_customers_pkey; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_platform_customers_pkey ON stripe_platform_customers USING btree (id);
 
 
 --
--- Name: stripe_platform_customers_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: stripe_platform_customers_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX stripe_platform_customers_user_id_index ON stripe_platform_customers USING btree (user_id);
 
 
 --
--- Name: task_lists_inbox_index; Type: INDEX; Schema: public; Owner: -
+-- Name: task_lists_inbox_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX task_lists_inbox_index ON task_lists USING btree (inbox);
 
 
 --
--- Name: task_lists_order_index; Type: INDEX; Schema: public; Owner: -
+-- Name: task_lists_order_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX task_lists_order_index ON task_lists USING btree ("order");
 
 
 --
--- Name: task_lists_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: task_lists_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX task_lists_project_id_index ON task_lists USING btree (project_id);
 
 
 --
--- Name: task_skills_skill_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: task_skills_skill_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX task_skills_skill_id_index ON task_skills USING btree (skill_id);
 
 
 --
--- Name: task_skills_task_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: task_skills_task_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX task_skills_task_id_index ON task_skills USING btree (task_id);
 
 
 --
--- Name: task_skills_task_id_skill_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: task_skills_task_id_skill_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX task_skills_task_id_skill_id_index ON task_skills USING btree (task_id, skill_id);
 
 
 --
--- Name: tasks_archived_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_archived_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX tasks_archived_index ON tasks USING btree (archived);
 
 
 --
--- Name: tasks_github_issue_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_github_issue_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX tasks_github_issue_id_index ON tasks USING btree (github_issue_id);
 
 
 --
--- Name: tasks_github_repo_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_github_repo_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX tasks_github_repo_id_index ON tasks USING btree (github_repo_id);
 
 
 --
--- Name: tasks_number_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_number_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX tasks_number_index ON tasks USING btree (number);
 
 
 --
--- Name: tasks_number_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_number_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX tasks_number_project_id_index ON tasks USING btree (number, project_id);
 
 
 --
--- Name: tasks_order_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_order_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX tasks_order_index ON tasks USING btree ("order");
 
 
 --
--- Name: tasks_pkey; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_pkey; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX tasks_pkey ON tasks USING btree (id);
 
 
 --
--- Name: tasks_project_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_project_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX tasks_project_id_index ON tasks USING btree (project_id);
 
 
 --
--- Name: tasks_status_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_status_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX tasks_status_index ON tasks USING btree (status);
 
 
 --
--- Name: tasks_task_list_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_task_list_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX tasks_task_list_id_index ON tasks USING btree (task_list_id);
 
 
 --
--- Name: tasks_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: tasks_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX tasks_user_id_index ON tasks USING btree (user_id);
 
 
 --
--- Name: user_categories_category_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_categories_category_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX user_categories_category_id_index ON user_categories USING btree (category_id);
 
 
 --
--- Name: user_categories_user_id_category_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_categories_user_id_category_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX user_categories_user_id_category_id_index ON user_categories USING btree (user_id, category_id);
 
 
 --
--- Name: user_categories_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_categories_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX user_categories_user_id_index ON user_categories USING btree (user_id);
 
 
 --
--- Name: user_roles_role_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_roles_role_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX user_roles_role_id_index ON user_roles USING btree (role_id);
 
 
 --
--- Name: user_roles_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_roles_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX user_roles_user_id_index ON user_roles USING btree (user_id);
 
 
 --
--- Name: user_roles_user_id_role_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_roles_user_id_role_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX user_roles_user_id_role_id_index ON user_roles USING btree (user_id, role_id);
 
 
 --
--- Name: user_skills_skill_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_skills_skill_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX user_skills_skill_id_index ON user_skills USING btree (skill_id);
 
 
 --
--- Name: user_skills_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_skills_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX user_skills_user_id_index ON user_skills USING btree (user_id);
 
 
 --
--- Name: user_tasks_task_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_tasks_task_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX user_tasks_task_id_index ON user_tasks USING btree (task_id);
 
 
 --
--- Name: user_tasks_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_tasks_user_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX user_tasks_user_id_index ON user_tasks USING btree (user_id);
 
 
 --
--- Name: user_tasks_user_id_task_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: user_tasks_user_id_task_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX user_tasks_user_id_task_id_index ON user_tasks USING btree (user_id, task_id);
 
 
 --
--- Name: users_email_index; Type: INDEX; Schema: public; Owner: -
+-- Name: users_email_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX users_email_index ON users USING btree (email);
 
 
 --
--- Name: users_github_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: users_github_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX users_github_id_index ON users USING btree (github_id);
 
 
 --
--- Name: users_lower_username_index; Type: INDEX; Schema: public; Owner: -
+-- Name: users_lower_username_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX users_lower_username_index ON users USING btree (lower((username)::text));
 
 
 --
--- Name: tasks task_created; Type: TRIGGER; Schema: public; Owner: -
+-- Name: task_created; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER task_created BEFORE INSERT ON tasks FOR EACH ROW EXECUTE PROCEDURE assign_number();
 
 
 --
--- Name: auth_token auth_token_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: auth_token_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY auth_token
@@ -3182,7 +3177,7 @@ ALTER TABLE ONLY auth_token
 
 
 --
--- Name: comments comments_github_comment_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: comments_github_comment_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY comments
@@ -3190,7 +3185,7 @@ ALTER TABLE ONLY comments
 
 
 --
--- Name: comments comments_task_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: comments_task_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY comments
@@ -3198,7 +3193,7 @@ ALTER TABLE ONLY comments
 
 
 --
--- Name: comments comments_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: comments_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY comments
@@ -3206,7 +3201,7 @@ ALTER TABLE ONLY comments
 
 
 --
--- Name: donation_goals donation_goals_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: donation_goals_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY donation_goals
@@ -3214,7 +3209,7 @@ ALTER TABLE ONLY donation_goals
 
 
 --
--- Name: github_app_installations github_app_installations_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: github_app_installations_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_app_installations
@@ -3222,7 +3217,7 @@ ALTER TABLE ONLY github_app_installations
 
 
 --
--- Name: github_app_installations github_app_installations_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: github_app_installations_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_app_installations
@@ -3230,7 +3225,7 @@ ALTER TABLE ONLY github_app_installations
 
 
 --
--- Name: github_comments github_comments_github_issue_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: github_comments_github_issue_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_comments
@@ -3238,7 +3233,7 @@ ALTER TABLE ONLY github_comments
 
 
 --
--- Name: github_issues github_issues_github_pull_request_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: github_issues_github_pull_request_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_issues
@@ -3246,7 +3241,7 @@ ALTER TABLE ONLY github_issues
 
 
 --
--- Name: github_issues github_issues_github_repo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: github_issues_github_repo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_issues
@@ -3254,7 +3249,7 @@ ALTER TABLE ONLY github_issues
 
 
 --
--- Name: github_pull_requests github_pull_requests_github_repo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: github_pull_requests_github_repo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_pull_requests
@@ -3262,7 +3257,7 @@ ALTER TABLE ONLY github_pull_requests
 
 
 --
--- Name: github_repos github_repos_github_app_installation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: github_repos_github_app_installation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY github_repos
@@ -3270,7 +3265,7 @@ ALTER TABLE ONLY github_repos
 
 
 --
--- Name: organization_github_app_installations organization_github_app_installations_github_app_installation_i; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: organization_github_app_installations_github_app_installation_i; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organization_github_app_installations
@@ -3278,7 +3273,7 @@ ALTER TABLE ONLY organization_github_app_installations
 
 
 --
--- Name: organization_github_app_installations organization_github_app_installations_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: organization_github_app_installations_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organization_github_app_installations
@@ -3286,7 +3281,7 @@ ALTER TABLE ONLY organization_github_app_installations
 
 
 --
--- Name: organizations organizations_owner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: organizations_owner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY organizations
@@ -3294,7 +3289,7 @@ ALTER TABLE ONLY organizations
 
 
 --
--- Name: previews previews_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: previews_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY previews
@@ -3302,7 +3297,7 @@ ALTER TABLE ONLY previews
 
 
 --
--- Name: project_categories project_categories_category_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: project_categories_category_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_categories
@@ -3310,7 +3305,7 @@ ALTER TABLE ONLY project_categories
 
 
 --
--- Name: project_categories project_categories_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: project_categories_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_categories
@@ -3318,7 +3313,7 @@ ALTER TABLE ONLY project_categories
 
 
 --
--- Name: project_github_repos project_github_repos_github_repo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: project_github_repos_github_repo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_github_repos
@@ -3326,7 +3321,7 @@ ALTER TABLE ONLY project_github_repos
 
 
 --
--- Name: project_github_repos project_github_repos_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: project_github_repos_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_github_repos
@@ -3334,7 +3329,7 @@ ALTER TABLE ONLY project_github_repos
 
 
 --
--- Name: project_skills project_skills_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: project_skills_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_skills
@@ -3342,7 +3337,7 @@ ALTER TABLE ONLY project_skills
 
 
 --
--- Name: project_skills project_skills_skill_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: project_skills_skill_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_skills
@@ -3350,7 +3345,7 @@ ALTER TABLE ONLY project_skills
 
 
 --
--- Name: project_users project_users_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: project_users_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_users
@@ -3358,7 +3353,7 @@ ALTER TABLE ONLY project_users
 
 
 --
--- Name: project_users project_users_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: project_users_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY project_users
@@ -3366,7 +3361,7 @@ ALTER TABLE ONLY project_users
 
 
 --
--- Name: projects projects_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: projects_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY projects
@@ -3374,7 +3369,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: role_skills role_skills_role_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: role_skills_role_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY role_skills
@@ -3382,7 +3377,7 @@ ALTER TABLE ONLY role_skills
 
 
 --
--- Name: role_skills role_skills_skill_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: role_skills_skill_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY role_skills
@@ -3390,7 +3385,7 @@ ALTER TABLE ONLY role_skills
 
 
 --
--- Name: slugged_routes slugged_routes_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: slugged_routes_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY slugged_routes
@@ -3398,7 +3393,7 @@ ALTER TABLE ONLY slugged_routes
 
 
 --
--- Name: slugged_routes slugged_routes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: slugged_routes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY slugged_routes
@@ -3406,7 +3401,7 @@ ALTER TABLE ONLY slugged_routes
 
 
 --
--- Name: stripe_connect_accounts stripe_connect_accounts_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_accounts_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_accounts
@@ -3414,7 +3409,7 @@ ALTER TABLE ONLY stripe_connect_accounts
 
 
 --
--- Name: stripe_connect_cards stripe_connect_cards_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_cards_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_cards
@@ -3422,7 +3417,7 @@ ALTER TABLE ONLY stripe_connect_cards
 
 
 --
--- Name: stripe_connect_cards stripe_connect_cards_stripe_platform_card_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_cards_stripe_platform_card_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_cards
@@ -3430,7 +3425,7 @@ ALTER TABLE ONLY stripe_connect_cards
 
 
 --
--- Name: stripe_connect_charges stripe_connect_charges_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_charges_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_charges
@@ -3438,7 +3433,7 @@ ALTER TABLE ONLY stripe_connect_charges
 
 
 --
--- Name: stripe_connect_charges stripe_connect_charges_stripe_connect_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_charges_stripe_connect_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_charges
@@ -3446,7 +3441,7 @@ ALTER TABLE ONLY stripe_connect_charges
 
 
 --
--- Name: stripe_connect_charges stripe_connect_charges_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_charges_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_charges
@@ -3454,7 +3449,7 @@ ALTER TABLE ONLY stripe_connect_charges
 
 
 --
--- Name: stripe_connect_customers stripe_connect_customers_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_customers_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_customers
@@ -3462,7 +3457,7 @@ ALTER TABLE ONLY stripe_connect_customers
 
 
 --
--- Name: stripe_connect_customers stripe_connect_customers_stripe_platform_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_customers_stripe_platform_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_customers
@@ -3470,7 +3465,7 @@ ALTER TABLE ONLY stripe_connect_customers
 
 
 --
--- Name: stripe_connect_customers stripe_connect_customers_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_customers_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_customers
@@ -3478,7 +3473,7 @@ ALTER TABLE ONLY stripe_connect_customers
 
 
 --
--- Name: stripe_connect_plans stripe_connect_plans_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_plans_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_plans
@@ -3486,7 +3481,7 @@ ALTER TABLE ONLY stripe_connect_plans
 
 
 --
--- Name: stripe_connect_subscriptions stripe_connect_subscriptions_stripe_connect_plan_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_subscriptions_stripe_connect_plan_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_subscriptions
@@ -3494,7 +3489,7 @@ ALTER TABLE ONLY stripe_connect_subscriptions
 
 
 --
--- Name: stripe_connect_subscriptions stripe_connect_subscriptions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_connect_subscriptions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_connect_subscriptions
@@ -3502,7 +3497,7 @@ ALTER TABLE ONLY stripe_connect_subscriptions
 
 
 --
--- Name: stripe_external_accounts stripe_external_accounts_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_external_accounts_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_external_accounts
@@ -3510,7 +3505,7 @@ ALTER TABLE ONLY stripe_external_accounts
 
 
 --
--- Name: stripe_file_upload stripe_file_upload_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_file_upload_stripe_connect_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_file_upload
@@ -3518,7 +3513,7 @@ ALTER TABLE ONLY stripe_file_upload
 
 
 --
--- Name: stripe_invoices stripe_invoices_stripe_connect_subscription_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_invoices_stripe_connect_subscription_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_invoices
@@ -3526,7 +3521,7 @@ ALTER TABLE ONLY stripe_invoices
 
 
 --
--- Name: stripe_invoices stripe_invoices_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_invoices_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_invoices
@@ -3534,7 +3529,7 @@ ALTER TABLE ONLY stripe_invoices
 
 
 --
--- Name: stripe_platform_cards stripe_platform_cards_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_platform_cards_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_platform_cards
@@ -3542,7 +3537,7 @@ ALTER TABLE ONLY stripe_platform_cards
 
 
 --
--- Name: stripe_platform_customers stripe_platform_customers_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: stripe_platform_customers_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY stripe_platform_customers
@@ -3550,7 +3545,7 @@ ALTER TABLE ONLY stripe_platform_customers
 
 
 --
--- Name: task_lists task_lists_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: task_lists_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY task_lists
@@ -3558,7 +3553,7 @@ ALTER TABLE ONLY task_lists
 
 
 --
--- Name: task_skills task_skills_skill_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: task_skills_skill_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY task_skills
@@ -3566,7 +3561,7 @@ ALTER TABLE ONLY task_skills
 
 
 --
--- Name: task_skills task_skills_task_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: task_skills_task_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY task_skills
@@ -3574,7 +3569,7 @@ ALTER TABLE ONLY task_skills
 
 
 --
--- Name: tasks tasks_github_issue_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: tasks_github_issue_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tasks
@@ -3582,7 +3577,7 @@ ALTER TABLE ONLY tasks
 
 
 --
--- Name: tasks tasks_github_repo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: tasks_github_repo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tasks
@@ -3590,7 +3585,7 @@ ALTER TABLE ONLY tasks
 
 
 --
--- Name: tasks tasks_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: tasks_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tasks
@@ -3598,7 +3593,7 @@ ALTER TABLE ONLY tasks
 
 
 --
--- Name: tasks tasks_task_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: tasks_task_list_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tasks
@@ -3606,7 +3601,7 @@ ALTER TABLE ONLY tasks
 
 
 --
--- Name: tasks tasks_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: tasks_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tasks
@@ -3614,7 +3609,7 @@ ALTER TABLE ONLY tasks
 
 
 --
--- Name: user_categories user_categories_category_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_categories_category_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_categories
@@ -3622,7 +3617,7 @@ ALTER TABLE ONLY user_categories
 
 
 --
--- Name: user_categories user_categories_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_categories_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_categories
@@ -3630,7 +3625,7 @@ ALTER TABLE ONLY user_categories
 
 
 --
--- Name: user_roles user_roles_role_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_roles_role_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_roles
@@ -3638,7 +3633,7 @@ ALTER TABLE ONLY user_roles
 
 
 --
--- Name: user_roles user_roles_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_roles_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_roles
@@ -3646,7 +3641,7 @@ ALTER TABLE ONLY user_roles
 
 
 --
--- Name: user_skills user_skills_skill_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_skills_skill_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_skills
@@ -3654,7 +3649,7 @@ ALTER TABLE ONLY user_skills
 
 
 --
--- Name: user_skills user_skills_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_skills_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_skills
@@ -3662,7 +3657,7 @@ ALTER TABLE ONLY user_skills
 
 
 --
--- Name: user_tasks user_tasks_task_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_tasks_task_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_tasks
@@ -3670,7 +3665,7 @@ ALTER TABLE ONLY user_tasks
 
 
 --
--- Name: user_tasks user_tasks_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_tasks_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_tasks
@@ -3681,5 +3676,5 @@ ALTER TABLE ONLY user_tasks
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO "schema_migrations" (version) VALUES (20160723215749), (20160804000000), (20160804001111), (20160805132301), (20160805203929), (20160808143454), (20160809214736), (20160810124357), (20160815125009), (20160815143002), (20160816020347), (20160816034021), (20160817220118), (20160818000944), (20160818132546), (20160820113856), (20160820164905), (20160822002438), (20160822004056), (20160822011624), (20160822020401), (20160822044612), (20160830081224), (20160830224802), (20160911233738), (20160912002705), (20160912145957), (20160918003206), (20160928232404), (20161003185918), (20161019090945), (20161019110737), (20161020144622), (20161021131026), (20161031001615), (20161121005339), (20161121014050), (20161121043941), (20161121045709), (20161122015942), (20161123081114), (20161123150943), (20161124085742), (20161125200620), (20161126045705), (20161127054559), (20161205024856), (20161207112519), (20161209192504), (20161212005641), (20161214005935), (20161215052051), (20161216051447), (20161218005913), (20161219160401), (20161219163909), (20161220141753), (20161221085759), (20161226213600), (20161231063614), (20170102130055), (20170102181053), (20170104113708), (20170104212623), (20170104235423), (20170106013143), (20170115035159), (20170115230549), (20170121014100), (20170131234029), (20170201014901), (20170201025454), (20170201035458), (20170201183258), (20170220032224), (20170224233516), (20170226050552), (20170228085250), (20170308214128), (20170308220713), (20170308222552), (20170313130611), (20170318032449), (20170318082740), (20170324194827), (20170424215355), (20170501225441), (20170505224222), (20170526095401), (20170602000208), (20170622205732), (20170626231059), (20170628092119), (20170628213609), (20170629183404), (20170630140136), (20170706132431), (20170707213648), (20170711122252), (20170717092127), (20170725060612), (20170727052644), (20170731130121), (20170814131722), (20170913114958), (20170921014405), (20170925214512), (20170925230419), (20170926134646), (20170927100300), (20170928234412), (20171003134956), (20171003225853), (20171006063358), (20171006161407), (20171012215106), (20171012221231), (20171016125229), (20171016125516), (20171016223356), (20171016235656), (20171017235433), (20171019191035), (20171025184225), (20171026010933), (20171027061833);
+INSERT INTO "schema_migrations" (version) VALUES (20160723215749), (20160804000000), (20160804001111), (20160805132301), (20160805203929), (20160808143454), (20160809214736), (20160810124357), (20160815125009), (20160815143002), (20160816020347), (20160816034021), (20160817220118), (20160818000944), (20160818132546), (20160820113856), (20160820164905), (20160822002438), (20160822004056), (20160822011624), (20160822020401), (20160822044612), (20160830081224), (20160830224802), (20160911233738), (20160912002705), (20160912145957), (20160918003206), (20160928232404), (20161003185918), (20161019090945), (20161019110737), (20161020144622), (20161021131026), (20161031001615), (20161121005339), (20161121014050), (20161121043941), (20161121045709), (20161122015942), (20161123081114), (20161123150943), (20161124085742), (20161125200620), (20161126045705), (20161127054559), (20161205024856), (20161207112519), (20161209192504), (20161212005641), (20161214005935), (20161215052051), (20161216051447), (20161218005913), (20161219160401), (20161219163909), (20161220141753), (20161221085759), (20161226213600), (20161231063614), (20170102130055), (20170102181053), (20170104113708), (20170104212623), (20170104235423), (20170106013143), (20170115035159), (20170115230549), (20170121014100), (20170131234029), (20170201014901), (20170201025454), (20170201035458), (20170201183258), (20170220032224), (20170224233516), (20170226050552), (20170228085250), (20170308214128), (20170308220713), (20170308222552), (20170313130611), (20170318032449), (20170318082740), (20170324194827), (20170424215355), (20170501225441), (20170505224222), (20170526095401), (20170602000208), (20170622205732), (20170626231059), (20170628092119), (20170628213609), (20170629183404), (20170630140136), (20170706132431), (20170707213648), (20170711122252), (20170717092127), (20170725060612), (20170727052644), (20170731130121), (20170814131722), (20170913114958), (20170921014405), (20170925214512), (20170925230419), (20170926134646), (20170927100300), (20170928234412), (20171003134956), (20171003225853), (20171006063358), (20171006161407), (20171012215106), (20171012221231), (20171016125229), (20171016125516), (20171016223356), (20171016235656), (20171017235433), (20171019191035), (20171025184225), (20171026010933), (20171027061833), (20171028011642), (20171028173508);
 

--- a/test/lib/code_corps_web/views/category_view_test.exs
+++ b/test/lib/code_corps_web/views/category_view_test.exs
@@ -6,7 +6,7 @@ defmodule CodeCorpsWeb.CategoryViewTest do
     project_category = insert(:project_category, category: category)
 
     category = CodeCorpsWeb.CategoryController.preload(category)
-    rendered_json =  render(CodeCorpsWeb.CategoryView, "show.json-api", data: category)
+    rendered_json = render(CodeCorpsWeb.CategoryView, "show.json-api", %{ data: category, conn: nil, params: category.id })
 
     expected_json = %{
       "data" => %{


### PR DESCRIPTION
Ref https://github.com/code-corps/code-corps-api/issues/1139

This is a very initial commit using jsonapi.  Can try it out by running `category_view_test.exs`.

Essentially, this lib gives us a `show` and `index` function for which we can call.

Couple of things.

1.  The [jsonapi](https://github.com/jeregrine/jsonapi) lib might need some TLC to make it easier to work with.
~~2. We use dasherized plural types.  The dasherized config is not working for relationships right now.~~ Solved with master branch

TODO:
- [ ] cleanup and w/ potentially abstractions for working with lib
- [ ] Identify PR's to lib
- [ ] move to separate view and perf test against category_view w/ ja_serializer