### PR TITLE
Syncing does not match ResultAggregator errors

### DIFF
--- a/test/lib/code_corps/github/sync/sync_test.exs
+++ b/test/lib/code_corps/github/sync/sync_test.exs
@@ -120,6 +120,12 @@ defmodule CodeCorps.GitHub.SyncTest do
       assert Repo.aggregate(Task, :count, :id) == 8
       assert Repo.aggregate(User, :count, :id) == 13
 
+      # Simulate disconnecting the repo and updating a task locally
+
+      [task | _] = Repo.all(Task, limit: 1)
+      changeset = Task.update_changeset(task, %{title: "New title", updated_from: "codecorps"})
+      Repo.update!(changeset)
+
       # Sync a second time – should run without trouble
 
       Sync.sync_repo(github_repo)


### PR DESCRIPTION
# What's in this PR?

Right now this PR just has a failing test case demonstrating that syncing does not match `ResultAggregator` errors in the form of `{:error, {list, list}}`.

This also indicates a much larger problem lurking beneath the surface: once a project disconnects from GitHub, the sync logic when reconnecting will not work if anything has changed. Even worse, we have no way of queue up a sync of the newly re-connected tasks back up to GitHub in order to bring everything back into place.