### PR TITLE
Archived tasks don't need task lists or order

### DIFF
--- a/test/lib/code_corps/model/task_test.exs
+++ b/test/lib/code_corps/model/task_test.exs
@@ -16,18 +16,36 @@ defmodule CodeCorps.TaskTest do
     end
 
     test "renders body html from markdown" do
-      user = insert(:user)
-      project = insert(:project)
-      task_list = insert(:task_list)
       changes = Map.merge(@valid_attrs, %{
         markdown: "A **strong** body",
-        project_id: project.id,
-        task_list_id: task_list.id,
-        user_id: user.id
+        project_id: 1,
+        task_list_id: 1,
+        user_id: 1
       })
       changeset = Task.changeset(%Task{}, changes)
       assert changeset.valid?
       assert changeset |> get_change(:body) == "<p>A <strong>strong</strong> body</p>\n"
+    end
+
+    test "removes the order and task list when the task is archived" do
+      changes = Map.put(@valid_attrs, :archived, true)
+      changeset = Task.update_changeset(%Task{order: 1, task_list_id: 1}, changes)
+      %{archived: archived, order: order, task_list_id: task_list_id} = changeset.changes
+      assert changeset.valid?
+      assert archived
+      refute order
+      refute task_list_id
+    end
+
+    test "validates task list when the task is not archived and position is set" do
+      changes = Map.merge(@valid_attrs, %{
+        position: 1,
+        project_id: 1,
+        user_id: 1
+      })
+      changeset = Task.changeset(%Task{}, changes)
+      refute changeset.valid?
+      assert changeset.errors[:task_list_id]
     end
   end
 
@@ -45,6 +63,26 @@ defmodule CodeCorps.TaskTest do
       assert changeset.valid?
       {:ok, %Task{created_at: created_at, modified_at: modified_at}} = Repo.insert(changeset)
       assert created_at == modified_at
+    end
+
+    test "sets the order when the task is not archived and position is set" do
+      project = insert(:project)
+      task_list = insert(:task_list)
+      insert(:task, task_list: task_list, order: 1)
+      user = insert(:user)
+      changes = Map.merge(@valid_attrs, %{
+        position: 1,
+        project_id: project.id,
+        task_list_id: task_list.id,
+        user_id: user.id
+      })
+      changeset = Task.create_changeset(%Task{}, changes)
+      assert changeset.valid?
+      {:ok, %Task{order: order}} = Repo.insert(changeset)
+
+      # We really want to test the order is set, but we have no good way to
+      # test this since the column default is `0`
+      assert order !== 0
     end
   end
 
@@ -77,6 +115,24 @@ defmodule CodeCorps.TaskTest do
       %{archived: archived} = changeset.changes
       assert changeset.valid?
       assert archived
+    end
+
+    test "does not reset order when task was already archived" do
+      project = insert(:project)
+      user = insert(:user)
+      changes = Map.merge(@valid_attrs, %{
+        archived: true,
+        position: 1,
+        project_id: project.id,
+        user_id: user.id
+      })
+      changeset = Task.create_changeset(%Task{}, changes)
+      {:ok, %Task{order: order} = task} = Repo.insert(changeset)
+      refute order
+
+      changeset = Task.update_changeset(task, %{title: "New title"})
+      {:ok, %Task{order: order}} = Repo.update(changeset)
+      refute order
     end
   end
 end


### PR DESCRIPTION
# What's in this PR?

- Moves `:archived` casting up into `changeset` since it can happen on creation (e.g. importing from GitHub)
- Removes any `task_list_id` or `order` when archived
- Moves required validation on `task_list_id` to only the case when task is not archived

## References
Fixes #1150 
Fixes #1154 