### PR TITLE
Fix migration for adding done to task lists

### DIFF
--- a/priv/repo/migrations/20171106045740_add_done_to_task_list.exs
+++ b/priv/repo/migrations/20171106045740_add_done_to_task_list.exs
@@ -18,15 +18,17 @@ defmodule CodeCorps.Repo.Migrations.AddDoneToTaskList do
     task_list_query =
       from(tl in "task_lists", where: [done: true], select: [:id])
 
-    # tests do not have any data, so we need to account for potential nil
-    case task_list_query |> Repo.one do
-      %{id: done_list_id} ->
-        task_update_query = from t in "tasks",
-          where: [status: "closed"],
-          update: [set: [task_list_id: ^done_list_id]]
-        task_update_query |> Repo.update_all([])
-      nil -> nil
-    end
+    task_list_query |> Repo.all() |> Enum.each(fn task ->
+      # tests do not have any data, so we need to account for potential nil
+      case task do
+        %{id: done_list_id} ->
+          task_update_query = from t in "tasks",
+            where: [status: "closed"],
+            update: [set: [task_list_id: ^done_list_id]]
+          task_update_query |> Repo.update_all([])
+        nil -> nil
+      end
+    end)
   end
 
   def down do


### PR DESCRIPTION
# What's in this PR?

Fixes the migration to look for _all_ task lists and not assume there's only one.