### PR TITLE
Set modified_from to "code_corps" on tasks and comments when updating from codecorps

### DIFF
--- a/lib/code_corps/model/comment.ex
+++ b/lib/code_corps/model/comment.ex
@@ -38,12 +38,14 @@ defmodule CodeCorps.Comment do
     |> validate_required([:task_id, :user_id])
     |> assoc_constraint(:task)
     |> assoc_constraint(:user)
+    |> put_change(:modified_from, "code_corps")
   end
 
   def update_changeset(struct, params) do
     struct
     |> changeset(params)
     |> update_modified_at()
+    |> put_change(:modified_from, "code_corps")
   end
 
   defp set_created_and_modified_at(changeset) do

--- a/lib/code_corps/model/task.ex
+++ b/lib/code_corps/model/task.ex
@@ -77,6 +77,7 @@ defmodule CodeCorps.Task do
     |> assoc_constraint(:project)
     |> assoc_constraint(:user)
     |> put_change(:status, "open")
+    |> put_change(:modified_from, "code_corps")
   end
 
   @spec update_changeset(struct, map) :: Ecto.Changeset.t
@@ -88,6 +89,7 @@ defmodule CodeCorps.Task do
     |> set_closed_at()
     |> update_modified_at()
     |> maybe_assoc_with_repo(params)
+    |> put_change(:modified_from, "code_corps")
   end
 
   def apply_position(changeset) do

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.9
+-- Dumped from database version 10.0
 -- Dumped by pg_dump version 10.0
 
 SET statement_timeout = 0;

--- a/test/lib/code_corps/comment/service_test.exs
+++ b/test/lib/code_corps/comment/service_test.exs
@@ -29,6 +29,11 @@ defmodule CodeCorps.Comment.ServiceTest do
       refute_received({:post, "https://api.github.com/" <> _rest, _body, _headers, _options})
     end
 
+    test "sets modified_from to 'code_corps'" do
+      {:ok, comment} = valid_attrs() |> Comment.Service.create
+      assert comment.modified_from == "code_corps"
+    end
+
     test "returns errored changeset if attributes are invalid" do
       {:error, changeset} = Comment.Service.create(@base_attrs)
       refute changeset.valid?
@@ -90,6 +95,13 @@ defmodule CodeCorps.Comment.ServiceTest do
       refute updated_comment.github_comment_id
 
       refute_received({:patch, "https://api.github.com/" <> _rest, _body, _headers, _options})
+    end
+
+    test "sets modified_from to 'code_corps'" do
+      comment = insert(:comment, modified_from: "github")
+      {:ok, updated_comment} = comment |> Comment.Service.update(@update_attrs)
+
+      assert updated_comment.modified_from == "code_corps"
     end
 
     @preloads [task: [github_repo: :github_app_installation]]

--- a/test/lib/code_corps/github/sync/issue/task/task_test.exs
+++ b/test/lib/code_corps/github/sync/issue/task/task_test.exs
@@ -3,35 +3,45 @@ defmodule CodeCorps.GitHub.Sync.Issue.TaskTest do
 
   use CodeCorps.DbAccessCase
 
-  alias CodeCorps.{
-    Project,
-    Repo,
-    Task
-  }
+  alias CodeCorps.{Repo, Task}
   alias CodeCorps.GitHub.Sync.Issue.Task, as: IssueTaskSyncer
 
   describe "sync all/3" do
-    test "creates missing, updates existing tasks for each project associated with the github repo" do
+    defp setup_test_data do
+      # Creates a user, 3 projects and a github issue all linked to a
+      # github repo. Returns that data as a map
       user = insert(:user)
+      projects = insert_list(3, :project)
+      github_repo = insert(:github_repo)
+      github_issue = insert(
+        :github_issue,
+        github_repo: github_repo,
+        github_updated_at: DateTime.utc_now |> Timex.shift(hours: 1)
+      )
 
-      %{github_repo: github_repo} = github_issue =
-        insert(:github_issue, github_updated_at: DateTime.utc_now |> Timex.shift(hours: 1))
+      projects |> Enum.each(&insert(:task_list, project: &1, inbox: true))
 
-      [%{project: project_1}, _, _] = project_github_repos =
-        insert_list(3, :project_github_repo, github_repo: github_repo)
+      projects
+      |> Enum.each(&insert(:project_github_repo, project: &1, github_repo: github_repo))
 
-      task_1 = insert(:task, project: project_1, github_issue: github_issue, github_repo: github_repo, user: user)
+      %{github_issue: github_issue, github_repo: github_repo, projects: projects, user: user}
+    end
 
-      project_ids = project_github_repos |> Enum.map(&Map.get(&1, :project_id))
+    test "creates missing, updates existing tasks for each project associated with the github repo" do
+      %{
+        github_issue: github_issue,
+        github_repo: github_repo,
+        projects: [project_1 | _] = projects,
+        user: user
+      } = setup_test_data()
 
-      project_ids |> Enum.each(fn project_id ->
-        project = Project |> Repo.get_by(id: project_id)
-        insert(:task_list, project: project, inbox: true)
-      end)
+      existing_task =
+        insert(:task, project: project_1, github_issue: github_issue, github_repo: github_repo, user: user)
 
       {:ok, tasks} = github_issue |> IssueTaskSyncer.sync_all(user)
 
-      assert Repo.aggregate(Task, :count, :id) == 3
+      assert Repo.aggregate(Task, :count, :id) == projects |> Enum.count
+      assert tasks |> Enum.count == projects |> Enum.count
 
       tasks |> Enum.each(fn task ->
         assert task.user_id == user.id
@@ -39,8 +49,13 @@ defmodule CodeCorps.GitHub.Sync.Issue.TaskTest do
         assert task.github_issue_id == github_issue.id
       end)
 
-      task_ids = tasks |> Enum.map(&Map.get(&1, :id))
-      assert task_1.id in task_ids
+      assert existing_task.id in (tasks |> Enum.map(&Map.get(&1, :id)))
+    end
+
+    test "sets task :modified_from to 'github'" do
+      %{github_issue: github_issue, user: user} = setup_test_data()
+      {:ok, tasks} = github_issue |> IssueTaskSyncer.sync_all(user)
+      assert tasks |> Enum.all?(fn task -> task.modified_from == "github" end)
     end
 
     test "fails on validation errors" do

--- a/test/lib/code_corps/model/comment_test.exs
+++ b/test/lib/code_corps/model/comment_test.exs
@@ -1,7 +1,10 @@
 defmodule CodeCorps.CommentTest do
+  @moduledoc false
+
   use CodeCorps.ModelCase
 
   alias CodeCorps.Comment
+  alias Ecto.Changeset
 
   @valid_attrs %{markdown: "I love elixir!", state: "published"}
   @invalid_attrs %{}
@@ -40,6 +43,14 @@ defmodule CodeCorps.CommentTest do
       {:ok, %Comment{created_at: created_at, modified_at: modified_at}} = Repo.insert(changeset)
       assert created_at == modified_at
     end
+
+    test "sets modified_from to 'code_corps'" do
+      assert(
+        %Comment{}
+        |> Comment.create_changeset(%{})
+        |> Changeset.get_field(:modified_from) == "code_corps"
+      )
+    end
   end
 
   describe "update_changeset/2" do
@@ -47,6 +58,15 @@ defmodule CodeCorps.CommentTest do
       comment = insert(:comment)
       changeset = Comment.update_changeset(comment, %{})
       assert comment.modified_at < changeset.changes[:modified_at]
+    end
+
+    test "sets modified_from to 'code_corps'" do
+      assert(
+        :comment
+        |> insert(modified_from: "github")
+        |> Comment.update_changeset(%{})
+        |> Changeset.get_field(:modified_from) == "code_corps"
+      )
     end
   end
 end

--- a/test/lib/code_corps/model/task_test.exs
+++ b/test/lib/code_corps/model/task_test.exs
@@ -2,6 +2,7 @@ defmodule CodeCorps.TaskTest do
   use CodeCorps.ModelCase
 
   alias CodeCorps.Task
+  alias Ecto.Changeset
 
   @valid_attrs %{
     title: "Test task",
@@ -63,6 +64,14 @@ defmodule CodeCorps.TaskTest do
       assert changeset.valid?
       {:ok, %Task{created_at: created_at, modified_at: modified_at}} = Repo.insert(changeset)
       assert created_at == modified_at
+    end
+
+    test "sets modified_from to 'code_corps'" do
+      assert(
+        %Task{}
+        |> Task.create_changeset(%{})
+        |> Changeset.get_field(:modified_from) == "code_corps"
+      )
     end
 
     test "sets the order when the task is not archived and position is set" do
@@ -133,6 +142,15 @@ defmodule CodeCorps.TaskTest do
       changeset = Task.update_changeset(task, %{title: "New title"})
       {:ok, %Task{order: order}} = Repo.update(changeset)
       refute order
+    end
+
+    test "sets :modified_from to 'code_corps'" do
+      assert(
+        :task
+        |> insert(modified_from: "github")
+        |> Task.update_changeset(%{})
+        |> Changeset.get_field(:modified_from) == "code_corps"
+      )
     end
   end
 end

--- a/test/lib/code_corps/task/service_test.exs
+++ b/test/lib/code_corps/task/service_test.exs
@@ -38,6 +38,11 @@ defmodule CodeCorps.Task.ServiceTest do
       refute_received({:post, "https://api.github.com/" <> _rest, _body, _headers, _options})
     end
 
+    test "sets modified_from to 'code_corps'" do
+      {:ok, task} = valid_attrs() |> Task.Service.create
+      assert task.modified_from == "code_corps"
+    end
+
     test "returns errored changeset if attributes are invalid" do
       {:error, changeset} = Task.Service.create(@base_attrs)
       refute changeset.valid?
@@ -106,6 +111,13 @@ defmodule CodeCorps.Task.ServiceTest do
       refute task.github_repo_id
 
       refute_received({:patch, "https://api.github.com/" <> _rest, _body, _headers, _options})
+    end
+
+    test "sets modified_from to 'code_corps'" do
+      task = insert(:task, modified_from: "github")
+      {:ok, updated_task} = task |> Task.Service.update(@update_attrs)
+
+      assert updated_task.modified_from == "code_corps"
     end
 
     test "returns {:error, changeset} if there are validation errors" do


### PR DESCRIPTION
# What's in this PR?

This PR makes it so that every time a task or comment is modified from the client application, thus, from CodeCorps, not some other location, the `:modified_from` field on that `Task` or `Comment` respectively is set to `"code_corps"`.

`"code_corps"` was already our field default, so I wen't with that, instead of `"codecorps"` as instructed in the issue.

Since it was our field default, the field was set correctly upon initial creation from the client app. However, a subsequent modification from github, followed by modification from codecorps, would result in `:modified_from` being incorrectly stuck on `"github"`, even though the last source of the modification was in fact the client app.

Note that the `create_changeset` is also used in our seeds. It makes sense as it is, but if we want to seed our db with tasks or comments linked to github, we need to take that into account.

## References
Fixes #1145
