### PR TITLE
Handle error in StripeConnectSubscriptionService.find_or_create/1

### DIFF
--- a/lib/code_corps/stripe_service/stripe_connect_subscription_service.ex
+++ b/lib/code_corps/stripe_service/stripe_connect_subscription_service.ex
@@ -35,10 +35,9 @@ defmodule CodeCorps.StripeService.StripeConnectSubscriptionService do
     with {:ok, %Project{} = project} <- get_project_with_preloads(project_id),
          {:ok, %Project{}} <- ProjectSubscribable.validate(project),
          {:ok, %User{} = user} <- get_user_with_preloads(user_id),
-         {:ok, %User{}} <- UserCanSubscribe.validate(user)
+         {:ok, %User{}} <- UserCanSubscribe.validate(user),
+         {:ok, %StripeConnectSubscription{} = subscription} <- do_find_or_create(project, user, attributes)
     do
-      {:ok, %StripeConnectSubscription{} = subscription} = do_find_or_create(project, user, attributes)
-
       ProjectService.update_project_totals(project)
       DonationGoalsService.update_project_goals(project)
 


### PR DESCRIPTION
Handle error case in `StripeConnectSubscriptionService.find_or_create/1`

## References
Fixes #1164 
