### PR TITLE
Add update action to /github-events endpoint

### DIFF
--- a/lib/code_corps/model/github_event.ex
+++ b/lib/code_corps/model/github_event.ex
@@ -2,15 +2,18 @@ defmodule CodeCorps.GithubEvent do
   use CodeCorps.Model
   use Scrivener, page_size: 20
 
+  alias Ecto.Changeset
+
   @type t :: %__MODULE__{}
 
   schema "github_events" do
     field :action, :string
     field :data, :string
+    field :error, :string
     field :failure_reason, :string
     field :github_delivery_id, :string
     field :payload, :map
-    field :error, :string
+    field :retry, :boolean, virtual: true
     field :status, :string
     field :type, :string
 
@@ -24,5 +27,26 @@ defmodule CodeCorps.GithubEvent do
     struct
     |> cast(params, [:action, :data, :github_delivery_id, :payload, :error, :status, :type])
     |> validate_required([:action, :github_delivery_id, :payload, :status, :type])
+    |> validate_inclusion(:status, statuses())
   end
+
+  def update_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:retry, :status])
+    |> validate_acceptance(:retry)
+    |> validate_retry()
+    |> validate_inclusion(:status, statuses())
+  end
+
+  def statuses do
+    ~w{unprocessed processing processed errored unsupported reprocessing}
+  end
+
+  defp validate_retry(%Changeset{changes: %{retry: true}} = changeset) do
+    case changeset |> Changeset.get_field(:status) do
+      "errored" -> Changeset.put_change(changeset, :status, "reprocessing")
+      _ -> Changeset.add_error(changeset, :retry, "only possible when status is errored")
+    end
+  end
+  defp validate_retry(changeset), do: changeset
 end

--- a/lib/code_corps/policy/github_event.ex
+++ b/lib/code_corps/policy/github_event.ex
@@ -6,4 +6,7 @@ defmodule CodeCorps.Policy.GithubEvent do
 
   def show?(%User{admin: true}), do: true
   def show?(%User{admin: false}), do: false
+
+  def update?(%User{admin: true}), do: true
+  def update?(%User{admin: false}), do: false
 end

--- a/lib/code_corps/policy/policy.ex
+++ b/lib/code_corps/policy/policy.ex
@@ -43,6 +43,7 @@ defmodule CodeCorps.Policy do
   # GithubEvent
   defp can?(%User{} = current_user, :index, %GithubEvent{}, %{}), do: Policy.GithubEvent.index?(current_user)
   defp can?(%User{} = current_user, :show, %GithubEvent{}, %{}), do: Policy.GithubEvent.show?(current_user)
+  defp can?(%User{} = current_user, :update, %GithubEvent{}, %{}), do: Policy.GithubEvent.update?(current_user)
 
   # GithubRepo
   defp can?(%User{} = current_user, :update, %GithubRepo{} = github_repo, %{} = params), do: Policy.GithubRepo.update?(current_user, github_repo, params)

--- a/lib/code_corps_web/controllers/github_event_controller.ex
+++ b/lib/code_corps_web/controllers/github_event_controller.ex
@@ -46,16 +46,20 @@ defmodule CodeCorpsWeb.GithubEventController do
     type = conn |> get_event_type
     delivery_id = conn |> get_delivery_id()
     action = payload |> Map.get("action", "")
+    event_support = type |> EventSupport.status(action)
+    event_support |> process_event(type, delivery_id, payload)
+    conn |> respond_to_webhook(event_support)
+  end
 
-    case type |> EventSupport.status(action) do
-      :supported ->
-        Processor.process(fn -> Handler.handle_supported(type, delivery_id, payload) end)
-        conn |> send_resp(200, "")
-      :unsupported ->
-        Processor.process(fn -> Handler.handle_unsupported(type, delivery_id, payload) end)
-        conn |> send_resp(200, "")
-      :ignored ->
-        conn |> send_resp(202, "")
+  @spec update(Conn.t, map) :: Conn.t
+  def update(%Conn{} = conn, %{"id" => id} = params) do
+    with %GithubEvent{} = github_event <- GithubEvent |> Repo.get(id),
+      %User{} = current_user <- conn |> Guardian.Plug.current_resource,
+      {:ok, :authorized} <- current_user |> Policy.authorize(:update, github_event, params),
+      changeset <- github_event |> GithubEvent.update_changeset(params),
+      {:ok, updated_github_event} <- changeset |> retry_event()
+    do
+      conn |> render("show.json-api", data: updated_github_event)
     end
   end
 
@@ -76,4 +80,39 @@ defmodule CodeCorpsWeb.GithubEventController do
   defp paginate(query, _) do
     query |> Repo.all()
   end
+
+  @spec process_event(atom, String.t, String.t, map) :: any | :ok
+  defp process_event(:supported, type, delivery_id, payload) do
+    Processor.process(fn -> Handler.handle_supported(type, delivery_id, payload) end)
+  end
+  defp process_event(:unsupported, type, delivery_id, payload) do
+    Processor.process(fn -> Handler.handle_unsupported(type, delivery_id, payload) end)
+  end
+  defp process_event(:ignored, _, _, _), do: :ok
+
+  @type retry_outcome :: {:ok, GithubEvent.t} | {:error, Ecto.Changeset.t} | :ok
+
+  @spec retry_event(Ecto.Changeset.t) :: retry_outcome
+  defp retry_event(%Ecto.Changeset{data: %GithubEvent{action: action, type: type}} = changeset) do
+    type
+    |> EventSupport.status(action)
+    |> do_retry_event(changeset)
+  end
+
+  @spec do_retry_event(atom, Ecto.Changeset.t) :: retry_outcome
+  defp do_retry_event(:ignored, _changeset), do: nil
+  defp do_retry_event(support, %Ecto.Changeset{data: %GithubEvent{github_delivery_id: delivery_id, payload: payload, type: type}} = changeset) do
+    case changeset |> Repo.update() do
+      {:ok, %GithubEvent{} = github_event} ->
+        process_event(support, type, delivery_id, payload)
+        {:ok, github_event}
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @spec respond_to_webhook(Conn.t, atom) :: Conn.t
+  defp respond_to_webhook(conn, :supported), do: conn |> send_resp(200, "")
+  defp respond_to_webhook(conn, :unsupported), do: conn |> send_resp(200, "")
+  defp respond_to_webhook(conn, :ignored), do: conn |> send_resp(202, "")
 end

--- a/lib/code_corps_web/router.ex
+++ b/lib/code_corps_web/router.ex
@@ -70,7 +70,7 @@ defmodule CodeCorpsWeb.Router do
     resources "/donation-goals", DonationGoalController, only: [:create, :update, :delete]
     post "/oauth/github", UserController, :github_oauth
     resources "/github-app-installations", GithubAppInstallationController, only: [:create]
-    resources "/github-events", GithubEventController, only: [:index, :show]
+    resources "/github-events", GithubEventController, only: [:index, :show, :update]
     resources "/github-repos", GithubRepoController, only: [:update]
     resources "/organization-github-app-installations", OrganizationGithubAppInstallationController, only: [:create, :delete]
     resources "/organizations", OrganizationController, only: [:create, :update]

--- a/test/lib/code_corps/model/github_event_test.exs
+++ b/test/lib/code_corps/model/github_event_test.exs
@@ -7,18 +7,50 @@ defmodule CodeCorps.GithubEventTest do
     action: "some content",
     github_delivery_id: "71aeab80-9e59-11e7-81ac-198364bececc",
     payload: %{"key" => "value"},
-    status: "some content",
+    status: "processing",
     type: "some content"
   }
   @invalid_attrs %{}
 
-  test "changeset with valid attributes" do
-    changeset = GithubEvent.changeset(%GithubEvent{}, @valid_attrs)
-    assert changeset.valid?
+  describe "changeset/2" do
+    test "with valid attributes" do
+      changeset = GithubEvent.changeset(%GithubEvent{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "with invalid attributes" do
+      changeset = GithubEvent.changeset(%GithubEvent{}, @invalid_attrs)
+      refute changeset.valid?
+    end
+
+    test "validates inclusion of status" do
+      attrs = @valid_attrs |> Map.put(:status, "foo")
+      changeset = GithubEvent.changeset(%GithubEvent{}, attrs)
+      refute changeset.valid?
+      assert changeset.errors[:status] == {"is invalid", [validation: :inclusion]}
+    end
   end
 
-  test "changeset with invalid attributes" do
-    changeset = GithubEvent.changeset(%GithubEvent{}, @invalid_attrs)
-    refute changeset.valid?
+  describe "update_changeset/2" do
+    test "with retry true and status errored" do
+      attrs = @valid_attrs |> Map.merge(%{retry: true, status: "errored"})
+      changeset = GithubEvent.update_changeset(%GithubEvent{status: "errored"}, attrs)
+      assert changeset.valid?
+      assert changeset.changes[:status] == "reprocessing"
+    end
+
+    test "with retry true and status not errored" do
+      attrs = @valid_attrs |> Map.put(:retry, true)
+      changeset = GithubEvent.update_changeset(%GithubEvent{status: "foo"}, attrs)
+      refute changeset.valid?
+      assert_error_message(changeset, :retry, "only possible when status is errored")
+    end
+
+    test "with retry false" do
+      attrs = @valid_attrs |> Map.put(:retry, false)
+      changeset = GithubEvent.update_changeset(%GithubEvent{}, attrs)
+      refute changeset.valid?
+      refute changeset.changes[:status] == "reprocessing"
+    end
   end
 end

--- a/test/lib/code_corps/policy/github_event_test.exs
+++ b/test/lib/code_corps/policy/github_event_test.exs
@@ -1,7 +1,7 @@
 defmodule CodeCorps.GithubEventPolicyTest do
   use CodeCorps.PolicyCase
 
-  import CodeCorps.Policy.GithubEvent, only: [index?: 1, show?: 1]
+  import CodeCorps.Policy.GithubEvent, only: [index?: 1, show?: 1, update?: 1]
 
   describe "index" do
     test "returns true when user is an admin" do
@@ -24,6 +24,18 @@ defmodule CodeCorps.GithubEventPolicyTest do
     test "returns false when user is not an admin" do
       user = insert(:user, admin: false)
       refute show?(user)
+    end
+  end
+
+  describe "update" do
+    test "returns true when user is an admin" do
+      user = insert(:user, admin: true)
+      assert update?(user)
+    end
+
+    test "returns false when user is not an admin" do
+      user = insert(:user, admin: false)
+      refute update?(user)
     end
   end
 end

--- a/test/lib/code_corps_web/controllers/github_event_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/github_event_controller_test.exs
@@ -114,4 +114,33 @@ defmodule CodeCorpsWeb.GithubEventControllerTest do
       refute Repo.get_by(GithubEvent, github_delivery_id: "foo")
     end
   end
+
+  describe "update" do
+    @valid_attrs %{retry: true}
+
+    @tag authenticated: :admin
+    test "updates when the status was errored", %{conn: conn} do
+      payload = load_event_fixture("pull_request_opened")
+      github_event = insert(:github_event, action: "opened", payload: payload, status: "errored", type: "pull_request")
+
+      assert conn |> request_update(github_event, @valid_attrs) |> json_response(200)
+    end
+
+    @tag authenticated: :admin
+    test "does not update for any other status", %{conn: conn} do
+      payload = load_event_fixture("pull_request_opened")
+      github_event = insert(:github_event, action: "opened", payload: payload, status: "processed", type: "pull_request")
+
+      assert conn |> request_update(github_event, @valid_attrs) |> json_response(422)
+    end
+
+    test "renders 401 when unauthenticated", %{conn: conn} do
+      assert conn |> request_update |> json_response(401)
+    end
+
+    @tag :authenticated
+    test "renders 403 when unauthorized", %{conn: conn} do
+      assert conn |> request_update |> json_response(403)
+    end
+  end
 end

--- a/test/lib/code_corps_web/controllers/github_event_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/github_event_controller_test.exs
@@ -121,7 +121,7 @@ defmodule CodeCorpsWeb.GithubEventControllerTest do
     @tag authenticated: :admin
     test "updates when the status was errored", %{conn: conn} do
       payload = load_event_fixture("pull_request_opened")
-      github_event = insert(:github_event, action: "opened", payload: payload, status: "errored", type: "pull_request")
+      github_event = insert(:github_event, action: "opened", github_delivery_id: "foo", payload: payload, status: "errored", type: "pull_request")
 
       assert conn |> request_update(github_event, @valid_attrs) |> json_response(200)
     end


### PR DESCRIPTION
# What's in this PR?

- adds validation of `retry` param when updating
- adds `update_changeset` to the event
- adds inclusion validation of the various statuses
- adds update policy
- adds update action to the controller
- adds tests for all of the above

## References
Fixes #1168