### PR TITLE
Report all errors to Sentry

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -79,8 +79,8 @@ config :stripity_stripe,
 
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),
-  included_environments: ~w(prod staging)a,
-  use_error_logger: true
+  enable_source_code_context: true,
+  included_environments: ~w(prod staging)a
 
 config :code_corps, :sentry, CodeCorps.Sentry.Async
 

--- a/lib/code_corps.ex
+++ b/lib/code_corps.ex
@@ -26,6 +26,11 @@ defmodule CodeCorps do
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: CodeCorps.Supervisor]
+
+    if !(Sentry.Logger in :gen_event.which_handlers(:error_logger)) do
+      :ok = :error_logger.add_report_handler(Sentry.Logger)
+    end
+
     Supervisor.start_link(children, opts)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule CodeCorps.Mixfile do
   def application do
     [
       mod: {CodeCorps, []},
-      extra_applications: [:scout_apm, :timex, :tzdata]
+      extra_applications: [:sentry, :logger, :scout_apm, :timex, :tzdata]
     ]
   end
 


### PR DESCRIPTION
# What's in this PR?

Adds source code context and ensures that Sentry.Logger is running and reporting non-Plug errors.