### PR TITLE
Add overall status to task

### DIFF
--- a/lib/code_corps_web/views/task_view.ex
+++ b/lib/code_corps_web/views/task_view.ex
@@ -4,8 +4,9 @@ defmodule CodeCorpsWeb.TaskView do
   use JaSerializer.PhoenixView
 
   attributes [
-    :archived, :body, :created_at, :created_from, :inserted_at, :markdown,
-    :modified_at, :modified_from, :number, :order, :status, :title, :updated_at
+    :archived, :body, :created_at, :created_from, :has_github_pull_request,
+    :inserted_at, :markdown, :modified_at, :modified_from, :number, :order,
+    :overall_status, :status, :title, :updated_at
   ]
 
   has_one :github_issue, type: "github-issue", field: :github_issue_id
@@ -18,4 +19,21 @@ defmodule CodeCorpsWeb.TaskView do
 
   has_many :comments, serializer: CodeCorpsWeb.CommentView, identifiers: :always
   has_many :task_skills, serializer: CodeCorpsWeb.TaskSkillView, identifiers: :always
+
+  def has_github_pull_request(%{
+    github_pull_request: %CodeCorps.GithubPullRequest{}
+  }), do: true
+  def has_github_pull_request(%{github_pull_request: nil}), do: false
+
+  def overall_status(%{
+    github_pull_request: %CodeCorps.GithubPullRequest{merged: merged, state: state}
+  }, _conn) do
+    case merged do
+      true -> "merged"
+      false -> state
+    end
+  end
+  def overall_status(%{github_pull_request: nil, status: status}, _conn) do
+    status
+  end
 end


### PR DESCRIPTION
# What's in this PR?

Adds `has-github-pull-request` and `overall-status` to `TaskView`.