### PR TITLE
Add project user request email

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -62,6 +62,7 @@ config :code_corps,
   postmark_forgot_password_template: "123",
   postmark_organization_invite_email_template: "123",
   postmark_project_acceptance_template: "123",
+  postmark_project_request_template: "123",
   postmark_receipt_template: "123"
 
 # If the dev environment has no CLOUDEX_API_KEY set, we want the app

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -63,6 +63,7 @@ config :code_corps,
   postmark_forgot_password_template: "1989483",
   postmark_organization_invite_email_template: "3441863",
   postmark_project_acceptance_template: "1447041",
+  postmark_project_request_template: "4017262",
   postmark_receipt_template: "1255222"
 
 # ## SSL Support

--- a/config/remote-development.exs
+++ b/config/remote-development.exs
@@ -45,6 +45,7 @@ config :code_corps, CodeCorps.Mailer,
 config :code_corps,
   postmark_forgot_password_template: "123",
   postmark_project_acceptance_template: "123",
+  postmark_project_request_template: "123",
   postmark_receipt_template: "123"
 
 # ## SSL Support

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -62,6 +62,7 @@ config :code_corps,
   postmark_forgot_password_template: "1989481",
   postmark_organization_invite_email_template: "3442401",
   postmark_project_acceptance_template: "1447022",
+  postmark_project_request_template: "4017261",
   postmark_receipt_template: "1252361"
 
 # ## SSL Support

--- a/config/test.exs
+++ b/config/test.exs
@@ -67,6 +67,7 @@ config :code_corps, CodeCorps.Mailer,
 config :code_corps,
   postmark_forgot_password_template: "123",
   postmark_project_acceptance_template: "123",
+  postmark_project_request_template: "123",
   postmark_receipt_template: "123"
 
 config :code_corps, :cloudex, CloudexTest

--- a/emails/project_user_request.html
+++ b/emails/project_user_request.html
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>{{project_title}} just added you as a contributor</title>
+    <title>{{user_first_name}} wants to join {{project_title}}</title>
     <!--
     Make sure you copy the styles from styles.css into the email template in Postmark before saving there.
 
@@ -13,7 +13,7 @@
     <link rel="stylesheet" type="text/css" href="styles.css" media="screen" />
   </head>
   <body>
-    <span class="preheader">See what you can do to help on {{project_title}}.</span>
+    <span class="preheader">Head over to the app to process their request.</span>
     <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td align="center">
@@ -43,22 +43,29 @@
                           <td>
                             <ul class="joined_images center">
                               <li class="photo">
-                                <img src="{{user_image_url}}" width="70" height="70" />
-                              </li>
-                              <li class="icon">
-                                <img src="https://d3pgew4wbk2vb1.cloudfront.net/emails/images/joined-email@2x.png" width="25" height="70" />
-                              </li>
-                              <li class="photo">
                                 <img src="{{project_logo_url}}" width="70" height="70" />
                               </li>
+                              <li class="icon">
+                                <img src="https://d3pgew4wbk2vb1.cloudfront.net/emails/images/requested-email@2x.png" width="25" height="70" />
+                              </li>
+                              <li class="photo">
+                                <img src="{{user_image_url}}" width="70" height="70" />
+                              </li>
                             </ul>
-                            <p class="project-membership--accepted">
-                              <strong>{{user_first_name}}</strong>, you're in!
+                            <p>
+                              Hi {{project_title}} team,
+                            </p>
+                            <p class="project-membership--requested">
+                              <strong>{{user_first_name}}</strong> just requested to join {{project_title}}.
                             </p>
                             <p>
-                              <a href="{{project_url}}">{{project_title}}</a> just accepted your request to start contributing.
+                              You can head over to <a href="{{contributors_url}}">your project's contributors page</a> to process their request.
                             </p>
-                            <p>Go check out the project and see what you can do to get started.
+                            <p>
+                              Take a look at the skills they bring and think about how you can integrate them into your project.
+                            </p>
+                            <p>
+                              We also recommend reading GitHub's guides for <a href="https://opensource.guide/building-community/#setting-your-project-up-for-success">how to build a welcoming open source community</a>.
                             </p>
                           </td>
                         </tr>
@@ -67,7 +74,7 @@
                         <tr>
                           <td>
                             <p>
-                              Happy helping!
+                              Cheers,
                               <br><strong>The Code Corps Team</strong>
                             </p>
                             <p class="center small">

--- a/lib/code_corps/emails/project_user_request_email.ex
+++ b/lib/code_corps/emails/project_user_request_email.ex
@@ -1,0 +1,59 @@
+defmodule CodeCorps.Emails.ProjectUserRequestEmail do
+  import Bamboo.Email, only: [to: 2]
+  import Bamboo.PostmarkHelper
+  import Ecto.Query
+
+  alias CodeCorps.{Project, ProjectUser, Repo, User, WebClient}
+  alias CodeCorps.Emails.BaseEmail
+  alias CodeCorps.Presenters.ImagePresenter
+
+  @spec create(ProjectUser.t) :: Bamboo.Email.t
+  def create(%ProjectUser{project: project, user: user}) do
+    BaseEmail.create
+    |> to(project |> get_owners_emails())
+    |> template(template_id(), build_model(project, user))
+  end
+
+  @spec build_model(Project.t, User.t) :: map
+  defp build_model(%Project{} = project, %User{} = user) do
+    %{
+      contributors_url: project |> preload() |> url(),
+      project_logo_url: ImagePresenter.large(project),
+      project_title: project.title,
+      subject: "#{user.first_name} wants to join #{project.title}",
+      user_first_name: user.first_name,
+      user_image_url: ImagePresenter.large(user)
+    }
+  end
+
+  @spec preload(Project.t) :: Project.t
+  defp preload(%Project{} = project), do: project |> Repo.preload(:organization)
+
+  @spec url(Project.t) :: String.t
+  defp url(project) do
+    WebClient.url()
+    |> URI.merge(project.organization.slug <> "/" <> project.slug <> "/settings/contributors")
+    |> URI.to_string
+  end
+
+  @spec template_id :: String.t
+  defp template_id, do: Application.get_env(:code_corps, :postmark_project_request_template)
+
+  @spec get_owners_emails(Project.t) :: list(String.t)
+  defp get_owners_emails(%Project{} = project) do
+    project |> get_owners() |> Enum.map(&extract_email/1)
+  end
+
+  @spec extract_email(User.t) :: String.t
+  defp extract_email(%User{email: email}), do: email
+
+  @spec get_owners(Project.t) :: list(User.t)
+  defp get_owners(%Project{id: project_id}) do
+    query = from u in User,
+      join: pu in ProjectUser, on: u.id == pu.user_id,
+      where: pu.project_id == ^project_id,
+      where: pu.role == "owner"
+
+    query |> Repo.all()
+  end
+end

--- a/lib/code_corps_web/controllers/project_user_controller.ex
+++ b/lib/code_corps_web/controllers/project_user_controller.ex
@@ -7,7 +7,7 @@ defmodule CodeCorpsWeb.ProjectUserController do
   action_fallback CodeCorpsWeb.FallbackController
   plug CodeCorpsWeb.Plug.DataToAttributes
   plug CodeCorpsWeb.Plug.IdsToIntegers
-  
+
   @preloads [:project, :user]
 
   @spec index(Conn.t, map) :: Conn.t
@@ -28,7 +28,8 @@ defmodule CodeCorpsWeb.ProjectUserController do
   def create(%Conn{} = conn, %{} = params) do
     with %User{} = current_user <- conn |> Guardian.Plug.current_resource,
          {:ok, :authorized} <- current_user |> Policy.authorize(:create, %ProjectUser{}, params),
-         {:ok, %ProjectUser{} = project_user} <- %ProjectUser{} |> ProjectUser.create_changeset(params) |> Repo.insert 
+         {:ok, %ProjectUser{} = project_user} <- %ProjectUser{} |> ProjectUser.create_changeset(params) |> Repo.insert,
+         _ <- maybe_send_create_email(project_user)
     do
       conn |> put_status(:created) |> render("show.json-api", data: project_user)
     end
@@ -40,7 +41,7 @@ defmodule CodeCorpsWeb.ProjectUserController do
          %User{} = current_user <- conn |> Guardian.Plug.current_resource,
          {:ok, :authorized} <- current_user |> Policy.authorize(:update, project_user, params),
          {:ok, %ProjectUser{} = updated_project_user} <- project_user |> ProjectUser.update_changeset(params) |> Repo.update,
-         _ <- maybe_send_email(updated_project_user, project_user)
+         _ <- maybe_send_update_email(updated_project_user, project_user)
     do
       conn |> render("show.json-api", data: project_user)
     end
@@ -57,14 +58,30 @@ defmodule CodeCorpsWeb.ProjectUserController do
     end
   end
 
-  defp maybe_send_email(%ProjectUser{role: updated_role} = project_user, %ProjectUser{role: previous_role}) do
+  @spec maybe_send_create_email(ProjectUser.t) :: Bamboo.Email.t | nil
+  defp maybe_send_create_email(%ProjectUser{role: "pending"} = project_user) do
+    send_request_email(project_user)
+  end
+  defp maybe_send_create_email(_), do: nil
+
+  @spec send_request_email(ProjectUser.t) :: Bamboo.Email.t
+  defp send_request_email(project_user) do
+    project_user
+    |> Repo.preload(@preloads)
+    |> Emails.ProjectUserRequestEmail.create()
+    |> Mailer.deliver_now()
+  end
+
+  @spec maybe_send_update_email(ProjectUser.t, ProjectUser.t) :: Bamboo.Email.t | nil
+  defp maybe_send_update_email(%ProjectUser{role: updated_role} = project_user, %ProjectUser{role: previous_role}) do
     case {updated_role, previous_role} do
-      {"contributor", "pending"} -> 
+      {"contributor", "pending"} ->
         send_acceptance_email(project_user)
       _ -> nil
     end
   end
-  
+
+  @spec send_acceptance_email(ProjectUser.t) :: Bamboo.Email.t
   defp send_acceptance_email(project_user) do
     project_user
     |> Repo.preload(@preloads)

--- a/test/lib/code_corps/emails/project_user_acceptance_email_test.exs
+++ b/test/lib/code_corps/emails/project_user_acceptance_email_test.exs
@@ -4,7 +4,7 @@ defmodule CodeCorps.Emails.ProjectUserAcceptanceEmailTest do
 
   alias CodeCorps.Emails.ProjectUserAcceptanceEmail
 
-  test "receipt email works" do
+  test "acceptance email works" do
     %{project: project, user: user} = project_user = insert(:project_user)
 
     email = ProjectUserAcceptanceEmail.create(project_user)

--- a/test/lib/code_corps/emails/project_user_request_email_test.exs
+++ b/test/lib/code_corps/emails/project_user_request_email_test.exs
@@ -1,0 +1,28 @@
+defmodule CodeCorps.Emails.ProjectUserRequestEmailTest do
+  use CodeCorps.ModelCase
+  use Bamboo.Test
+
+  alias CodeCorps.Emails.ProjectUserRequestEmail
+
+  test "request email works" do
+    project = insert(:project)
+    %{user: requesting_user} = project_user = insert(:project_user, project: project)
+    %{user: owner1} = insert(:project_user, project: project, role: "owner")
+    %{user: owner2} = insert(:project_user, project: project, role: "owner")
+
+    email = ProjectUserRequestEmail.create(project_user)
+    assert email.from == "Code Corps<team@codecorps.org>"
+    assert email.to == [owner1.email, owner2.email]
+
+    template_model = email.private.template_model
+
+    assert template_model == %{
+      contributors_url: "http://localhost:4200/#{project.organization.slug}/#{project.slug}/settings/contributors",
+      project_title: project.title,
+      project_logo_url: "#{Application.get_env(:code_corps, :asset_host)}/icons/project_default_large_.png",
+      user_image_url: "#{Application.get_env(:code_corps, :asset_host)}/icons/user_default_large_.png",
+      user_first_name: requesting_user.first_name,
+      subject: "#{requesting_user.first_name} wants to join #{project.title}"
+    }
+  end
+end


### PR DESCRIPTION
# What's in this PR?

Adds an email to all of the owners of a project letting them know that a contributor has asked to join the project, with a link to their project's contributor settings page.