### PR TITLE
Fix GitHub sync dialyzer errors and add some specs to pagination errors

### DIFF
--- a/lib/code_corps/github/api/errors/pagination_error.ex
+++ b/lib/code_corps/github/api/errors/pagination_error.ex
@@ -1,30 +1,34 @@
 defmodule CodeCorps.GitHub.API.Errors.PaginationError do
-  alias CodeCorps.GitHub.{HTTPClientError, APIError}
+  alias CodeCorps.GitHub.{APIError, HTTPClientError}
 
   @type t :: %__MODULE__{
-    message: String.t,
     api_errors: list,
     client_errors: list,
+    message: String.t,
     retrieved_pages: list
   }
 
   defstruct [
-    message: "One or more pages failed to retrieve during a GitHub API Pagination Request",
-    retrieved_pages: [],
+    api_errors: [],
     client_errors: [],
-    api_errors: []
+    message: "One or more pages failed to retrieve when paginating GitHub API resources",
+    retrieved_pages: []
   ]
 
+  @spec new({list, list}) :: t
   def new({pages, errors}) do
     %__MODULE__{
-      retrieved_pages: pages,
+      api_errors: errors |> Enum.filter(&api_error?/1),
       client_errors: errors |> Enum.filter(&client_error?/1),
-      api_errors: errors |> Enum.filter(&api_error?/1)
+      retrieved_pages: pages
     }
   end
 
-  defp client_error?(%HTTPClientError{}), do: true
-  defp client_error?(_), do: false
+  @spec api_error?(APIError.t | any) :: boolean
   defp api_error?(%APIError{}), do: true
   defp api_error?(_), do: false
+
+  @spec client_error?(HTTPClientError.t | any) :: boolean
+  defp client_error?(%HTTPClientError{}), do: true
+  defp client_error?(_), do: false
 end

--- a/lib/code_corps/github/sync/issue/task/task.ex
+++ b/lib/code_corps/github/sync/issue/task/task.ex
@@ -11,15 +11,15 @@ defmodule CodeCorps.GitHub.Sync.Issue.Task do
   }
   alias Ecto.Changeset
 
-  @type outcome :: {:ok, list(Task.t)} |
-                   {:error, {list(Task.t), list(Changeset.t)}}
+  @type outcome :: {:ok, list(Task.t)}
+                 | {:error, {list(Task.t), list(Changeset.t)}}
 
   @doc """
   When provided a `CodeCorps.GithubIssue` and a `CodeCorps.User`, for the
   `CodeCorps.Project` associated to that `CodeCorps.GithubRepo`, it creates or
   updates a `CodeCorps.Task`.
   """
-  @spec sync_github_issue(GithubIssue.t, User.t) :: {:ok, Task.t}
+  @spec sync_github_issue(GithubIssue.t, User.t) :: {:ok, Task.t} | {:error, Changeset.t}
   def sync_github_issue(%GithubIssue{} = github_issue, %User{} = user) do
     %GithubIssue{
       github_repo: %GithubRepo{} = github_repo

--- a/lib/code_corps/github/sync/sync.ex
+++ b/lib/code_corps/github/sync/sync.ex
@@ -127,7 +127,7 @@ defmodule CodeCorps.GitHub.Sync do
 
   @spec sync_step(tuple, atom) :: tuple
   defp sync_step({:ok, _} = result, _step), do: result
-  defp sync_step({:error, _ = error}, _step), do: {:error, error}
+  defp sync_step({:error, _}, step), do: {:error, step}
 
   @spec mark_repo(GithubRepo.t, String.t, map) :: {:ok, GithubRepo.t} | {:error, Changeset.t}
   defp mark_repo(%GithubRepo{} = repo, sync_state, params \\ %{}) do
@@ -158,7 +158,7 @@ defmodule CodeCorps.GitHub.Sync do
   - Creates or updates `Comment` records, and relates them to any related
     `GithubComment` and `User` records created previously
   """
-  @spec sync_repo(GithubRepo.t) :: {:ok, GithubRepo.t}
+  @spec sync_repo(GithubRepo.t) :: {:ok, GithubRepo.t} | {:error, Changeset.t}
   def sync_repo(%GithubRepo{} = repo) do
     repo = preload_github_repo(repo)
     with {:ok, repo} <- repo |> mark_repo("fetching_pull_requests"),
@@ -185,6 +185,7 @@ defmodule CodeCorps.GitHub.Sync do
     do
       {:ok, repo}
     else
+      {:error, %Changeset{} = changeset} -> {:error, changeset}
       {:error, :fetch_pull_requests} -> repo |> mark_repo("errored_fetching_pull_requests")
       {:error, :sync_pull_requests} -> repo |> mark_repo("errored_syncing_pull_requests")
       {:error, :fetch_issues} -> repo |> mark_repo("errored_fetching_issues")


### PR DESCRIPTION
# What's in this PR?

- A bit of code cleaning of pagination error
- Fixes some type specing and return issues in github sync