### PR TITLE
Fix accidental nulling of pull request in Task.Service

### DIFF
--- a/lib/code_corps/github/sync/issue/github_issue/github_issue.ex
+++ b/lib/code_corps/github/sync/issue/github_issue/github_issue.ex
@@ -37,11 +37,19 @@ defmodule CodeCorps.GitHub.Sync.Issue.GithubIssue do
       |> GithubIssue.changeset(payload |> Adapters.Issue.to_issue())
       |> Changeset.put_assoc(:github_user, github_user)
       |> Changeset.put_assoc(:github_repo, github_repo)
-      |> Changeset.put_assoc(:github_pull_request, github_pull_request)
+      |> maybe_put_github_pull_request(github_pull_request)
       |> Repo.insert_or_update()
     else
       {:error, error} -> {:error, error}
     end
+  end
+
+  @spec maybe_put_github_pull_request(Changeset.t, GithubPullRequest.t | nil) :: Changeset.t
+  defp maybe_put_github_pull_request(%Changeset{} = changeset, %GithubPullRequest{} = github_pull_request) do
+    changeset |> Changeset.put_assoc(:github_pull_request, github_pull_request)
+  end
+  defp maybe_put_github_pull_request(%Changeset{} = changeset, nil) do
+    changeset
   end
 
   @spec find_or_init(map) :: GithubIssue.t

--- a/test/lib/code_corps/skills/skills_test.exs
+++ b/test/lib/code_corps/skills/skills_test.exs
@@ -1,4 +1,4 @@
-defmodule CodeCorps.AccountsTest do
+defmodule CodeCorps.SkillsTest do
   @moduledoc false
 
   use CodeCorps.DbAccessCase


### PR DESCRIPTION
# What's in this PR?

Fixes an issue where we putting a `nil` assoc with `github_pull_request` upon receipt of the payload from GitHub's API.

## References
Fixes #1253 