### PR TITLE
Push to production

### DIFF
--- a/lib/code_corps/github/sync/issue/github_issue/github_issue.ex
+++ b/lib/code_corps/github/sync/issue/github_issue/github_issue.ex
@@ -37,11 +37,19 @@ defmodule CodeCorps.GitHub.Sync.Issue.GithubIssue do
       |> GithubIssue.changeset(payload |> Adapters.Issue.to_issue())
       |> Changeset.put_assoc(:github_user, github_user)
       |> Changeset.put_assoc(:github_repo, github_repo)
-      |> Changeset.put_assoc(:github_pull_request, github_pull_request)
+      |> maybe_put_github_pull_request(github_pull_request)
       |> Repo.insert_or_update()
     else
       {:error, error} -> {:error, error}
     end
+  end
+
+  @spec maybe_put_github_pull_request(Changeset.t, GithubPullRequest.t | nil) :: Changeset.t
+  defp maybe_put_github_pull_request(%Changeset{} = changeset, %GithubPullRequest{} = github_pull_request) do
+    changeset |> Changeset.put_assoc(:github_pull_request, github_pull_request)
+  end
+  defp maybe_put_github_pull_request(%Changeset{} = changeset, nil) do
+    changeset
   end
 
   @spec find_or_init(map) :: GithubIssue.t

--- a/lib/code_corps_web/controllers/github_event_controller.ex
+++ b/lib/code_corps_web/controllers/github_event_controller.ex
@@ -1,9 +1,11 @@
 defmodule CodeCorpsWeb.GithubEventController do
   @moduledoc false
   use CodeCorpsWeb, :controller
+  import Ecto.Query, only: [from: 2]
 
   alias CodeCorps.{
     GithubEvent,
+    GithubRepo,
     GitHub.Webhook.Handler,
     GitHub.Webhook.EventSupport,
     Helpers.Query,
@@ -43,13 +45,28 @@ defmodule CodeCorpsWeb.GithubEventController do
 
   @spec create(Conn.t, map) :: Conn.t
   def create(%Conn{} = conn, %{} = payload) do
-    type = conn |> get_event_type
-    delivery_id = conn |> get_delivery_id()
+    type = conn |> event_type()
+    delivery_id = conn |> delivery_id()
     action = payload |> Map.get("action", "")
-    event_support = type |> EventSupport.status(action)
-    event_support |> process_event(type, delivery_id, payload)
+    event_support =
+      if should_process?(payload) do
+        process_status = type |> EventSupport.status(action)
+        process_status |> process_event(type, delivery_id, payload)
+        process_status
+      else
+        :ignored
+      end
     conn |> respond_to_webhook(event_support)
   end
+
+  @spec should_process?(map) :: boolean
+  defp should_process?(%{"repository" => %{"id" => repository_id}}) do
+    query = from repo in GithubRepo,
+      where: repo.github_id == ^repository_id,
+      where: not(is_nil(repo.project_id))
+    Repo.one(query) != nil
+  end
+  defp should_process?(_), do: true
 
   @spec update(Conn.t, map) :: Conn.t
   def update(%Conn{} = conn, %{"id" => id} = params) do
@@ -63,13 +80,13 @@ defmodule CodeCorpsWeb.GithubEventController do
     end
   end
 
-  @spec get_event_type(Conn.t) :: String.t
-  defp get_event_type(%Conn{} = conn) do
+  @spec event_type(Conn.t) :: String.t
+  defp event_type(%Conn{} = conn) do
     conn |> get_req_header("x-github-event") |> List.first
   end
 
-  @spec get_delivery_id(Conn.t) :: String.t
-  defp get_delivery_id(%Conn{} = conn) do
+  @spec delivery_id(Conn.t) :: String.t
+  defp delivery_id(%Conn{} = conn) do
     conn |> get_req_header("x-github-delivery") |> List.first
   end
 

--- a/test/lib/code_corps/skills/skills_test.exs
+++ b/test/lib/code_corps/skills/skills_test.exs
@@ -1,4 +1,4 @@
-defmodule CodeCorps.AccountsTest do
+defmodule CodeCorps.SkillsTest do
   @moduledoc false
 
   use CodeCorps.DbAccessCase


### PR DESCRIPTION
- Fixes error when GitHub tried to sync events for repos without a project
- Fixes nulling of PRs in Task.Service