### PR TITLE
Make project acceptance filter optional

### DIFF
--- a/lib/code_corps/project/query.ex
+++ b/lib/code_corps/project/query.ex
@@ -3,12 +3,11 @@ defmodule CodeCorps.Project.Query do
   Contains queries for retrieving projects
   """
   alias CodeCorps.{
+    Helpers.Query,
     Project,
     SluggedRoute,
     Repo
   }
-
-  import Ecto.Query
 
   @doc ~S"""
   Returns a list of `Project` records based on the provided filter.
@@ -16,7 +15,7 @@ defmodule CodeCorps.Project.Query do
   If the filter contains a `slug` key, returns all projects for the specified
   `Organization.`
 
-  If the filter does not contain a `slug` key, returns all `approved` projects.
+  If the filter does not contain a `slug` key, filters by optional params.
   """
   @spec list(map) :: list(Project.t)
   def list(%{"slug" => slug}) do
@@ -26,10 +25,10 @@ defmodule CodeCorps.Project.Query do
     |> Map.get(:organization)
     |> Map.get(:projects)
   end
-  def list(%{}) do
+  def list(%{} = params) do
     Project
-    |> where(approved: true)
-    |> Repo.all
+    |> Query.optional_filters(params, ~w(approved)a)
+    |> Repo.all()
   end
 
   @doc ~S"""

--- a/test/lib/code_corps_web/controllers/project_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/project_controller_test.exs
@@ -11,13 +11,15 @@ defmodule CodeCorpsWeb.ProjectControllerTest do
   @invalid_attrs %{title: ""}
 
   describe "index" do
-    test "lists all approved entries on index", %{conn: conn} do
+    test "filters on index", %{conn: conn} do
       [project_1, project_2] = insert_pair(:project, approved: true)
       project_3 = insert(:project, approved: false)
 
+      path = "/projects?approved=true"
+
       returned_ids =
         conn
-        |> request_index
+        |> get(path)
         |> json_response(200)
         |> ids_from_response
 


### PR DESCRIPTION
# What's in this PR?

This fixes issues where Ember keeps assuming projects are in the store but they're not due to automatic filtering.

Instead, we pass `approved` as a query param.