### PR TITLE
Fixes seeds in an ugly, temporary way.

### DIFF
--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.10
--- Dumped by pg_dump version 10.1
+-- Dumped from database version 10.0
+-- Dumped by pg_dump version 10.0
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
This is a temporary fix for broken seeds. 

To deal with this properly, we will probably have to move them out of a script into a mix task. That would allow us to

- have them fail in some cases during compilation
- allow us to write a basic test, ensuring they at least run fully
