### PR TITLE
Conversation index endpoint with supporting infrastructure

### DIFF
--- a/lib/code_corps/messages/conversation_query.ex
+++ b/lib/code_corps/messages/conversation_query.ex
@@ -1,0 +1,46 @@
+defmodule CodeCorps.Messages.ConversationQuery do
+  @moduledoc ~S"""
+  Holds helpers to query `CodeCorps.Conversation` records using a map of params.
+  """
+
+  import Ecto.Query
+
+  alias CodeCorps.{Conversation, ConversationPart, Message, Repo}
+  alias Ecto.Queryable
+
+  @doc ~S"""
+  Narrows down a `CodeCorps.Conversation` query by `project_id` of the parent
+  `CodeCorps.Message`, if specified in a params map
+  """
+  @spec project_filter(Queryable.t, map) :: Queryable.t
+  def project_filter(queryable, %{"project_id" => project_id}) do
+    queryable
+    |> join(:left, [c], m in Message, c.message_id == m.id)
+    |> where([_c, m], m.project_id == ^project_id)
+  end
+  def project_filter(queryable, %{}), do: queryable
+
+
+  @doc ~S"""
+  Narrows down a `CodeCorps.Conversation` query to return only those records
+  considered to have a specific status.
+
+  The status of `active` means that only those records are included which either
+  - belong to a `CodeCorps.Message` initiated by user
+  - belong to a `CodeCorps.Message` initiated by admin, with at least a single
+    reply in the form of a `CodeCorps.ConversationPart`
+  """
+  @spec status_filter(Queryable.t, map) :: Queryable.t
+  def status_filter(queryable, %{"status" => "active"}) do
+    prefiltered_ids = queryable |> select([c], c.id) |> Repo.all
+
+    Conversation
+    |> where([c], c.id in ^prefiltered_ids)
+    |> join(:left, [c], m in Message, c.message_id == m.id)
+    |> join(:left, [c, _m], cp in ConversationPart, c.id == cp.conversation_id)
+    |> group_by([c, m, _cp], [c.id, m.initiated_by])
+    |> having([_c, m, _cp], m.initiated_by == "user")
+    |> or_having([c, m, cp], m.initiated_by == "admin" and count(cp.id) > 0)
+  end
+  def status_filter(query, %{}), do: query
+end

--- a/lib/code_corps/messages/messages.ex
+++ b/lib/code_corps/messages/messages.ex
@@ -3,7 +3,7 @@ defmodule CodeCorps.Messages do
   Main context for work with the Messaging feature.
   """
 
-  alias CodeCorps.{Helpers.Query, Message, Messages, Repo}
+  alias CodeCorps.{Conversation, Helpers.Query, Message, Messages, Repo}
   alias Ecto.{Changeset, Queryable}
 
   @doc ~S"""
@@ -15,6 +15,17 @@ defmodule CodeCorps.Messages do
     |> Query.id_filter(params)
     |> Messages.Query.author_filter(params)
     |> Messages.Query.project_filter(params)
+    |> Repo.all()
+  end
+
+  @doc ~S"""
+  Lists pre-scoped `CodeCorps.Conversation` records filtered by parameters
+  """
+  @spec list_conversations(Queryable.t, map) :: list(Conversation.t)
+  def list_conversations(scope, %{} = params) do
+    scope
+    |> Messages.ConversationQuery.project_filter(params)
+    |> Messages.ConversationQuery.status_filter(params)
     |> Repo.all()
   end
 

--- a/lib/code_corps/model/conversation.ex
+++ b/lib/code_corps/model/conversation.ex
@@ -16,8 +16,8 @@ defmodule CodeCorps.Conversation do
   @type t :: %__MODULE__{}
 
   schema "conversations" do
-    field :status, :string, null: false, default: "open"
     field :read_at, :utc_datetime, null: true
+    field :status, :string, null: false, default: "open"
 
     belongs_to :message, CodeCorps.Message
     belongs_to :user, CodeCorps.User

--- a/lib/code_corps/policy/conversation.ex
+++ b/lib/code_corps/policy/conversation.ex
@@ -1,0 +1,24 @@
+defmodule CodeCorps.Policy.Conversation do
+  @moduledoc ~S"""
+  Handles `CodeCorps.User` authorization of actions on `CodeCorps.Conversation`
+  records.
+  """
+
+  import Ecto.Query
+
+  alias CodeCorps.{Message, Policy, Repo, User}
+
+  @spec scope(Ecto.Queryable.t, User.t) :: Ecto.Queryable.t
+  def scope(queryable, %User{admin: true}), do: queryable
+  def scope(queryable, %User{id: id} = current_user) do
+    scoped_message_ids =
+      Message
+      |> Policy.Message.scope(current_user)
+      |> select([m], m.id)
+      |> Repo.all
+
+    queryable
+    |> where(user_id: ^id)
+    |> or_where([c], c.message_id in ^scoped_message_ids)
+  end
+end

--- a/lib/code_corps/policy/policy.ex
+++ b/lib/code_corps/policy/policy.ex
@@ -3,7 +3,7 @@ defmodule CodeCorps.Policy do
   Handles authorization for various API actions performed on objects in the database.
   """
 
-  alias CodeCorps.{Category, Comment, DonationGoal, GithubAppInstallation, GithubEvent, GithubRepo, Message, Organization, OrganizationInvite, OrganizationGithubAppInstallation, Preview, Project, ProjectCategory, ProjectSkill, ProjectUser, Role, RoleSkill, Skill, StripeConnectAccount, StripeConnectPlan, StripeConnectSubscription, StripePlatformCard, StripePlatformCustomer, Task, TaskSkill, User, UserCategory, UserRole, UserSkill, UserTask}
+  alias CodeCorps.{Category, Comment, Conversation, DonationGoal, GithubAppInstallation, GithubEvent, GithubRepo, Message, Organization, OrganizationInvite, OrganizationGithubAppInstallation, Preview, Project, ProjectCategory, ProjectSkill, ProjectUser, Role, RoleSkill, Skill, StripeConnectAccount, StripeConnectPlan, StripeConnectSubscription, StripePlatformCard, StripePlatformCustomer, Task, TaskSkill, User, UserCategory, UserRole, UserSkill, UserTask}
 
   alias CodeCorps.Policy
 
@@ -28,6 +28,7 @@ defmodule CodeCorps.Policy do
   """
   @spec scope(module, User.t) :: Ecto.Queryable.t
   def scope(Message, %User{} = current_user), do: Message |> Policy.Message.scope(current_user)
+  def scope(Conversation, %User{} = current_user), do: Conversation |> Policy.Conversation.scope(current_user)
 
   @spec can?(User.t, atom, struct, map) :: boolean
 

--- a/lib/code_corps_web/controllers/conversation_controller.ex
+++ b/lib/code_corps_web/controllers/conversation_controller.ex
@@ -1,0 +1,22 @@
+defmodule CodeCorpsWeb.ConversationController do
+  @moduledoc false
+  use CodeCorpsWeb, :controller
+
+  alias CodeCorps.{
+    Conversation,
+    Messages,
+    User
+  }
+
+  action_fallback CodeCorpsWeb.FallbackController
+  plug CodeCorpsWeb.Plug.DataToAttributes
+  plug CodeCorpsWeb.Plug.IdsToIntegers
+
+  @spec index(Conn.t, map) :: Conn.t
+  def index(%Conn{} = conn, %{} = params) do
+    with %User{} = current_user <- conn |> CodeCorps.Guardian.Plug.current_resource,
+         conversations <- Conversation |> Policy.scope(current_user) |> Messages.list_conversations(params) do
+      conn |> render("index.json-api", data: conversations)
+    end
+  end
+end

--- a/lib/code_corps_web/router.ex
+++ b/lib/code_corps_web/router.ex
@@ -71,6 +71,7 @@ defmodule CodeCorpsWeb.Router do
 
     resources "/categories", CategoryController, only: [:create, :update]
     resources "/comments", CommentController, only: [:create, :update]
+    resources "/conversations", ConversationController, only: [:index]
     resources "/donation-goals", DonationGoalController, only: [:create, :update, :delete]
     post "/oauth/github", UserController, :github_oauth
     resources "/github-app-installations", GithubAppInstallationController, only: [:create]

--- a/lib/code_corps_web/views/conversation_view.ex
+++ b/lib/code_corps_web/views/conversation_view.ex
@@ -1,0 +1,10 @@
+defmodule CodeCorpsWeb.ConversationView do
+  @moduledoc false
+  use CodeCorpsWeb, :view
+  use JaSerializer.PhoenixView
+
+  attributes [:read_at, :status, :inserted_at, :updated_at]
+
+  has_one :user, type: "user", field: :user_id
+  has_one :message, type: "message", field: :message_id
+end

--- a/test/lib/code_corps/policy/conversation_test.exs
+++ b/test/lib/code_corps/policy/conversation_test.exs
@@ -1,0 +1,74 @@
+defmodule CodeCorps.Policy.ConversationTest do
+  use CodeCorps.PolicyCase
+
+  import CodeCorps.Policy.Conversation, only: [scope: 2]
+
+  alias CodeCorps.{Conversation, Repo}
+
+  describe "scope" do
+    test "returns all records for admin user" do
+      insert_list(3, :conversation)
+      user = insert(:user, admin: true)
+
+      assert Conversation |> scope(user) |> Repo.all |> Enum.count == 3
+    end
+
+    test "returns records where user is the author or they administer the project" do
+      user = insert(:user, admin: false)
+
+      %{project: project_user_applied_to} =
+        insert(:project_user, user: user, role: "pending")
+
+      %{project: project_user_contributes_to} =
+        insert(:project_user, user: user, role: "contributor")
+
+      %{project: project_user_administers} =
+        insert(:project_user, user: user, role: "admin")
+
+      %{project: project_user_owns} =
+        insert(:project_user, user: user, role: "owner")
+
+      message_authored_by = insert(:message, author: user)
+
+      message_from_project_applied_to =
+        insert(:message, project: project_user_applied_to)
+
+      message_from_contributing_project =
+        insert(:message, project: project_user_contributes_to)
+
+      message_from_administered_project =
+        insert(:message, project: project_user_administers)
+
+      message_from_owned_project =
+        insert(:message, project: project_user_owns)
+
+      conversation_with = insert(:conversation, user: user)
+      conversation_authored_by =
+        insert(:conversation, message: message_authored_by)
+      some_other_conversation = insert(:conversation)
+
+      conversation_from_project_applied_to =
+        insert(:conversation, message: message_from_project_applied_to)
+      conversation_from_contributing_project =
+        insert(:conversation, message: message_from_contributing_project)
+      conversation_from_administered_project =
+        insert(:conversation, message: message_from_administered_project)
+      conversation_from_owned_project =
+        insert(:conversation, message: message_from_owned_project)
+
+      result_ids =
+        Conversation
+        |> scope(user)
+        |> Repo.all
+        |> Enum.map(&Map.get(&1, :id))
+
+      assert conversation_with.id in result_ids
+      assert conversation_authored_by.id in result_ids
+      refute conversation_from_project_applied_to.id in result_ids
+      refute conversation_from_contributing_project.id in result_ids
+      assert conversation_from_administered_project.id in result_ids
+      assert conversation_from_owned_project.id in result_ids
+      refute some_other_conversation.id in result_ids
+    end
+  end
+end

--- a/test/lib/code_corps_web/controllers/conversation_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/conversation_controller_test.exs
@@ -1,0 +1,33 @@
+defmodule CodeCorpsWeb.ConversationControllerTest do
+  use CodeCorpsWeb.ApiCase, resource_name: :conversation
+
+  describe "index" do
+    @tag :authenticated
+    test "lists all entries user is authorized to view", %{conn: conn, current_user: user} do
+      %{project: project} = insert(:project_user, role: "admin", user: user)
+      message_on_user_administered_project = insert(:message, project: project)
+      conversation_on_user_administered_project =
+        insert(:conversation, message: message_on_user_administered_project)
+      conversation_by_user = insert(:conversation, user: user)
+      _other_conversation = insert(:conversation)
+
+      conn
+      |> request_index
+      |> json_response(200)
+      |> assert_ids_from_response([
+        conversation_on_user_administered_project.id,
+        conversation_by_user.id
+      ])
+    end
+
+    @tag authenticated: :admin
+    test "lists all entries if user is admin", %{conn: conn} do
+      [conversation_1, conversation_2] = insert_pair(:conversation)
+
+      conn
+      |> request_index
+      |> json_response(200)
+      |> assert_ids_from_response([conversation_1.id, conversation_2.id])
+    end
+  end
+end

--- a/test/lib/code_corps_web/views/conversation_view_test.exs
+++ b/test/lib/code_corps_web/views/conversation_view_test.exs
@@ -1,0 +1,42 @@
+defmodule CodeCorpsWeb.ConversationViewTest do
+  use CodeCorpsWeb.ViewCase
+
+  test "renders all attributes and relationships properly" do
+    conversation = insert(:conversation)
+
+    rendered_json =
+      render(CodeCorpsWeb.ConversationView, "show.json-api", data: conversation)
+
+    expected_json = %{
+      "data" => %{
+        "id" => conversation.id |> Integer.to_string,
+        "type" => "conversation",
+        "attributes" => %{
+          "read-at" => conversation.read_at,
+          "status" => conversation.status,
+          "inserted-at" => conversation.inserted_at,
+          "updated-at" => conversation.updated_at
+        },
+        "relationships" => %{
+          "user" => %{
+            "data" => %{
+              "id" => conversation.user_id |> Integer.to_string,
+              "type" => "user"
+            }
+          },
+          "message" => %{
+            "data" => %{
+              "id" => conversation.message_id |> Integer.to_string,
+              "type" => "message"
+            }
+          }
+        }
+      },
+      "jsonapi" => %{
+        "version" => "1.0"
+      }
+    }
+
+    assert rendered_json == expected_json
+  end
+end


### PR DESCRIPTION
# What's in this PR?

___This PR basess off of #1295 to facilitate review. Should be rebased to `develop` once #1295 is merged.___

This PR adds a ConversationController with an `:index` endpoint as well as all associated infrastructure
- `Messages.list_conversations/2`
- `ConversationView`
- `Policy.Conversation.scope/2`

Tests have also been added.

## References

Fixes #1288

Progress on: https://github.com/code-corps/code-corps-api/milestone/22