### PR TITLE
Add support for creation of associated conversations with message via params

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -43,7 +43,7 @@ config :code_corps, CodeCorps.Repo,
   pool_size: 10
 
 # CORS allowed origins
-config :code_corps, allowed_origins: ["http://localhost:4200"]
+config :code_corps, allowed_origins: ["http://localhost:4200", "chrome-extension://pfdhoblngboilpfeibdedpjgfnlcodoo"]
 
 config :code_corps, CodeCorps.Guardian,
   secret_key: "e62fb6e2746f6b1bf8b5b735ba816c2eae1d5d76e64f18f3fc647e308b0c159e"

--- a/lib/code_corps/messages/conversation_parts.ex
+++ b/lib/code_corps/messages/conversation_parts.ex
@@ -10,17 +10,21 @@ defmodule CodeCorps.Messages.ConversationParts do
     ConversationPart,
     Repo
   }
+  alias CodeCorpsWeb.ConversationChannel
 
   @spec create(map) :: ConversationPart.t | Ecto.Changeset.t
   def create(attrs) do
-    %ConversationPart{} |> create_changeset(attrs) |> Repo.insert()
+    with {:ok, %ConversationPart{} = conversation_part} <- %ConversationPart{} |> create_changeset(attrs) |> Repo.insert() do
+      ConversationChannel.broadcast_new_conversation_part(conversation_part)
+      {:ok, conversation_part}
+    end
   end
 
   @doc false
   @spec create_changeset(ConversationPart.t, map) :: Ecto.Changeset.t
   def create_changeset(%ConversationPart{} = conversation_part, attrs) do
     conversation_part
-    |> cast(attrs, [:author_id, :body, :conversation_id, :read_at])
+    |> cast(attrs, [:author_id, :body, :conversation_id])
     |> validate_required([:author_id, :body, :conversation_id])
     |> assoc_constraint(:author)
     |> assoc_constraint(:conversation)

--- a/lib/code_corps/messages/conversations.ex
+++ b/lib/code_corps/messages/conversations.ex
@@ -1,0 +1,19 @@
+defmodule CodeCorps.Messages.Conversations do
+  @moduledoc ~S"""
+  Subcontext aimed at managing `CodeCorps.Conversation` records aimed at a
+  specific user belonging to a `CodeCorps.Message`.
+  """
+
+  alias Ecto.Changeset
+
+  alias CodeCorps.{Conversation}
+
+  @doc false
+  @spec create_changeset(Conversation.t, map) :: Ecto.Changeset.t
+  def create_changeset(%Conversation{} = conversation, %{} = attrs) do
+    conversation
+    |> Changeset.cast(attrs, [:user_id])
+    |> Changeset.validate_required([:user_id])
+    |> Changeset.assoc_constraint(:user)
+  end
+end

--- a/lib/code_corps/messages/messages.ex
+++ b/lib/code_corps/messages/messages.ex
@@ -67,6 +67,11 @@ defmodule CodeCorps.Messages do
   def create(%{} = params) do
     %Message{}
     |> Message.changeset(params)
+    |> Changeset.cast(params, [:author_id, :project_id])
+    |> Changeset.validate_required([:author_id, :project_id])
+    |> Changeset.assoc_constraint(:author)
+    |> Changeset.assoc_constraint(:project)
+    |> Changeset.cast_assoc(:conversations, with: &Messages.Conversations.create_changeset/2)
     |> Repo.insert()
   end
 

--- a/lib/code_corps_web/channels/conversation_channel.ex
+++ b/lib/code_corps_web/channels/conversation_channel.ex
@@ -1,0 +1,34 @@
+defmodule CodeCorpsWeb.ConversationChannel do
+  use Phoenix.Channel
+
+  alias CodeCorps.{Conversation, Policy, Repo, User}
+  alias Phoenix.Socket
+
+  @spec join(String.t, map, Socket.t) :: {:ok, Socket.t} | {:error, map}
+  def join("conversation:" <> id, %{}, %Socket{} = socket) do
+    with %Conversation{} = conversation <- Conversation |> Repo.get(id),
+         %User{} = current_user <- socket.assigns[:current_user],
+         {:ok, :authorized} <- current_user |> Policy.authorize(:show, conversation, %{}) do
+
+        {:ok, socket}
+    else
+      nil -> {:error, %{reason: "unauthenticated"}}
+      {:error, :not_authorized} -> {:error, %{reason: "unauthorized"}}
+    end
+  end
+
+  def event("new:conversation-part", socket, message) do
+    broadcast socket, "new:conversation-part", message
+    {:ok, socket}
+  end
+
+  def broadcast_new_conversation_part(conversation_part) do
+    channel = "conversation:#{conversation_part.conversation_id}"
+    event = "new:conversation-part"
+    payload = %{
+      id: conversation_part.id
+    }
+
+    CodeCorpsWeb.Endpoint.broadcast(channel, event, payload)
+  end
+end

--- a/lib/code_corps_web/channels/user_socket.ex
+++ b/lib/code_corps_web/channels/user_socket.ex
@@ -2,7 +2,7 @@ defmodule CodeCorpsWeb.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  # channel "room:*", CodeCorps.RoomChannel
+  channel "conversation:*", CodeCorpsWeb.ConversationChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket,
@@ -20,8 +20,13 @@ defmodule CodeCorpsWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(_params, socket) do
-    {:ok, socket}
+  def connect(%{"token" => token}, socket) do
+    with {:ok, claims} <- CodeCorps.Guardian.decode_and_verify(token),
+         {:ok, user} <- CodeCorps.Guardian.resource_from_claims(claims) do
+      {:ok, assign(socket, :current_user, user)}
+    else
+      _ -> {:ok, socket}
+    end
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:

--- a/lib/code_corps_web/views/conversation_view.ex
+++ b/lib/code_corps_web/views/conversation_view.ex
@@ -7,4 +7,6 @@ defmodule CodeCorpsWeb.ConversationView do
 
   has_one :user, type: "user", field: :user_id
   has_one :message, type: "message", field: :message_id
+
+  has_many :conversation_parts, serializer: CodeCorpsWeb.ConversationPartView, identifiers: :always
 end

--- a/lib/code_corps_web/views/message_view.ex
+++ b/lib/code_corps_web/views/message_view.ex
@@ -7,4 +7,6 @@ defmodule CodeCorpsWeb.MessageView do
 
   has_one :author, type: "user", field: :author_id
   has_one :project, type: "project", field: :project_id
+
+  has_many :conversations, serializer: CodeCorpsWeb.ConversationView, identifiers: :always
 end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.10
--- Dumped by pg_dump version 10.1
+-- Dumped from database version 10.0
+-- Dumped by pg_dump version 10.0
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/test/lib/code_corps_web/channels/conversation_channel_test.exs
+++ b/test/lib/code_corps_web/channels/conversation_channel_test.exs
@@ -1,0 +1,52 @@
+defmodule CodeCorpsWeb.ConversationChannelTest do
+  use CodeCorpsWeb.ChannelCase
+
+  alias CodeCorps.{Conversation, User}
+  alias CodeCorpsWeb.ConversationChannel
+
+  def build_socket(%Conversation{id: id}, %User{} = current_user) do
+    "test"
+    |> socket(%{current_user: current_user})
+    |> subscribe_and_join(ConversationChannel, "conversation:#{id}")
+  end
+
+  describe "conversation:id" do
+    test "requires authentication" do
+      %{id: id} = insert(:conversation)
+
+      response =
+        "test"
+        |> socket(%{})
+        |> subscribe_and_join(ConversationChannel, "conversation:#{id}")
+
+      assert response == {:error, %{reason: "unauthenticated"}}
+    end
+
+    test "ensures current user is authorized for :show on resource" do
+      user = insert(:user)
+      %{id: id} = insert(:conversation)
+
+      response =
+        "test"
+        |> socket(%{current_user: user})
+        |> subscribe_and_join(ConversationChannel, "conversation:#{id}")
+
+      assert response == {:error, %{reason: "unauthorized"}}
+    end
+
+    test "broadcasts new conversation part" do
+      %{id: id, user: user} = conversation = insert(:conversation)
+
+      {:ok, %{}, _socket} =
+        "test"
+        |> socket(%{current_user: user})
+        |> subscribe_and_join(ConversationChannel, "conversation:#{id}")
+
+      %{id: conversation_part_id} = conversation_part =
+        insert(:conversation_part, conversation: conversation)
+      ConversationChannel.broadcast_new_conversation_part(conversation_part)
+
+      assert_broadcast("new:conversation-part", %{id: ^conversation_part_id})
+    end
+  end
+end

--- a/test/lib/code_corps_web/plugs/data_to_attributes_test.exs
+++ b/test/lib/code_corps_web/plugs/data_to_attributes_test.exs
@@ -1,0 +1,142 @@
+defmodule CodeCorpsWeb.Plug.DataToAttributesTest do
+  use CodeCorpsWeb.ConnCase
+
+  alias CodeCorpsWeb.Plug.DataToAttributes
+
+  test "converts basic JSON API payload to params suitable for Ecto", %{conn: conn} do
+    payload = %{
+      "id" => "1",
+      "data" => %{
+        "attributes" => %{"foo" => "bar", "baz" => "bat"},
+        "type" => "resource"
+      }
+    }
+
+    converted_params =
+      conn
+      |> Map.put(:params, payload)
+      |> DataToAttributes.call
+      |> Map.get(:params)
+
+    assert converted_params == %{
+      "baz" => "bat",
+      "foo" => "bar",
+      "id" => "1",
+      "type" => "resource"
+    }
+  end
+
+  test "converts belongs_to specified via identifier map into proper id", %{conn: conn} do
+    payload = %{
+      "id" => "1",
+      "data" => %{
+        "attributes" => %{"foo" => "bar"},
+        "relationships" => %{
+          "baz" => %{"data" => %{"id" => "2", "type" => "baz"}}
+        },
+        "type" => "resource"
+      }
+    }
+
+    converted_params =
+      conn
+      |> Map.put(:params, payload)
+      |> DataToAttributes.call
+      |> Map.get(:params)
+
+    assert converted_params == %{
+      "baz_id" => "2",
+      "foo" => "bar",
+      "id" => "1",
+      "type" => "resource"
+    }
+  end
+
+  test "converts has_many specified via identifier maps into proper ids", %{conn: conn} do
+    payload = %{
+      "id" => "1",
+      "data" => %{
+        "attributes" => %{"foo" => "bar"},
+        "relationships" => %{
+          "baz" => %{"data" => [
+            %{"id" => "2", "type" => "baz"},
+            %{"id" => "3", "type" => "baz"}
+          ]}
+        },
+        "type" => "resource"
+      }
+    }
+
+    converted_params =
+      conn
+      |> Map.put(:params, payload)
+      |> DataToAttributes.call
+      |> Map.get(:params)
+
+    assert converted_params == %{
+      "baz_ids" => ["2", "3"],
+      "foo" => "bar",
+      "id" => "1",
+      "type" => "resource"
+    }
+  end
+
+  test "converts included belongs_to into proper subpayload", %{conn: conn} do
+    payload = %{
+      "id" => "1",
+      "data" => %{
+        "attributes" => %{"foo" => "bar"},
+        "type" => "resource"
+      },
+      "included" => [
+        %{"data" => %{"attributes" => %{"baz_foo" => "baz_bar"}, "type" => "baz"}}
+      ]
+    }
+
+    converted_params =
+      conn
+      |> Map.put(:params, payload)
+      |> DataToAttributes.call
+      |> Map.get(:params)
+
+    assert converted_params == %{
+      "baz" => %{
+        "baz_foo" => "baz_bar",
+        "type" => "baz"
+      },
+      "foo" => "bar",
+      "id" => "1",
+      "type" => "resource"
+    }
+  end
+
+  test "converts included has_many into proper subpayload", %{conn: conn} do
+    payload = %{
+      "id" => "1",
+      "data" => %{
+        "attributes" => %{"foo" => "bar"},
+        "type" => "resource"
+      },
+      "included" => [
+        %{"data" => %{"attributes" => %{"baz_foo" => "baz_bar"}, "type" => "baz"}},
+        %{"data" => %{"attributes" => %{"baz_foo_2" => "baz_bar_2"}, "type" => "baz"}}
+      ]
+    }
+
+    converted_params =
+      conn
+      |> Map.put(:params, payload)
+      |> DataToAttributes.call([includes_many: ["baz"]])
+      |> Map.get(:params)
+
+    assert converted_params == %{
+      "bazs" => [
+        %{"baz_foo" => "baz_bar", "type" => "baz"},
+        %{"baz_foo_2" => "baz_bar_2", "type" => "baz"},
+      ],
+      "foo" => "bar",
+      "id" => "1",
+      "type" => "resource"
+    }
+  end
+end

--- a/test/lib/code_corps_web/views/conversation_view_test.exs
+++ b/test/lib/code_corps_web/views/conversation_view_test.exs
@@ -1,11 +1,18 @@
 defmodule CodeCorpsWeb.ConversationViewTest do
   use CodeCorpsWeb.ViewCase
 
+  alias CodeCorps.Repo
+
   test "renders all attributes and relationships properly" do
     conversation = insert(:conversation)
+    conversation_part = insert(:conversation_part, conversation: conversation)
 
     rendered_json =
-      render(CodeCorpsWeb.ConversationView, "show.json-api", data: conversation)
+      CodeCorpsWeb.ConversationView
+      |> render(
+        "show.json-api",
+        data: conversation |> Repo.preload(:conversation_parts)
+      )
 
     expected_json = %{
       "data" => %{
@@ -18,16 +25,24 @@ defmodule CodeCorpsWeb.ConversationViewTest do
           "updated-at" => conversation.updated_at
         },
         "relationships" => %{
-          "user" => %{
-            "data" => %{
-              "id" => conversation.user_id |> Integer.to_string,
-              "type" => "user"
-            }
+          "conversation-parts" => %{
+            "data" => [
+              %{
+                "id" => conversation_part.id |> Integer.to_string,
+                "type" => "conversation-part"
+              }
+            ]
           },
           "message" => %{
             "data" => %{
               "id" => conversation.message_id |> Integer.to_string,
               "type" => "message"
+            }
+          },
+          "user" => %{
+            "data" => %{
+              "id" => conversation.user_id |> Integer.to_string,
+              "type" => "user"
             }
           }
         }

--- a/test/lib/code_corps_web/views/message_view_test.exs
+++ b/test/lib/code_corps_web/views/message_view_test.exs
@@ -1,12 +1,15 @@
 defmodule CodeCorpsWeb.MessageViewTest do
   use CodeCorpsWeb.ViewCase
 
+  alias CodeCorps.Repo
+
   test "renders all attributes and relationships properly" do
     project = insert(:project)
     user = insert(:user)
     message = insert(:message, author: user, project: project)
+    conversation = insert(:conversation, message: message)
 
-    rendered_json = render(CodeCorpsWeb.MessageView, "show.json-api", data: message)
+    rendered_json = render(CodeCorpsWeb.MessageView, "show.json-api", data: message |> Repo.preload(:conversations))
 
     expected_json = %{
       "data" => %{
@@ -22,6 +25,9 @@ defmodule CodeCorpsWeb.MessageViewTest do
         "relationships" => %{
           "author" => %{
             "data" => %{"id" => message.author_id |> Integer.to_string, "type" => "user"}
+          },
+          "conversations" => %{
+              "data" => [%{"id" => conversation.id |> Integer.to_string, "type" => "conversation"}]
           },
           "project" => %{
             "data" => %{"id" => message.project_id |> Integer.to_string, "type" => "project"}

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -20,11 +20,12 @@ defmodule CodeCorpsWeb.ChannelCase do
       # Import conveniences for testing with channels
       use Phoenix.ChannelTest
 
-      alias CodeCorps.Repo
-      import Ecto
-      import Ecto.Changeset
+      import CodeCorps.Factories
+      import CodeCorpsWeb.ChannelCase
+
       import Ecto.Query
 
+      alias CodeCorps.Repo
 
       # The default endpoint for testing
       @endpoint CodeCorpsWeb.Endpoint

--- a/test/support/json_api_helpers.ex
+++ b/test/support/json_api_helpers.ex
@@ -5,11 +5,12 @@ defmodule CodeCorps.JsonAPIHelpers do
   """
 
   @spec build_json_payload(map) :: map
-  def build_json_payload(attrs = %{}) do
+  def build_json_payload(attrs = %{}, type \\ nil) do
     %{
       "data" => %{
         "attributes" => attrs |> build_attributes(),
-        "relationships" => attrs |> build_relationships()
+        "relationships" => attrs |> build_relationships(),
+        "type" => type
       }
     }
   end


### PR DESCRIPTION
# What's in this PR?

**Update**

Still need:

- [x] tests for `DataToAttributes` plug
- [x] tests for `Messages.create` to check it's possible to create a `Conversation` alongside
- [x] tests for controller create action, to serve as integration between `DataToAttributes` and `Messages.create`

**Original text**

This PR progress on and hopefully closes #1293 

It's been marked as discussion, but due to requiring the set of features described there for client PR code-corps/code-corps-ember#1597, I was forced to start on some type of implementation.

Will comment on specific changes, but to put it in short

`ember-data`, by default, does not support including records during post. It has a basic level of support for associating with existing has-many/many-to-many children in the form of the basic `{type, id}` identifier map, but not a full include, with all the child record's attributes.

ja_serializer does not support it either, so I was forced to provide my own implementation on both ends.

The alternatives are

- **create conversation manually from client, after creating message** - To me, this may actually make sense. It makes the API less opinionated and allows potential other clients later on more flexibility on how they implement their own flow. On the downside, there's no clean way to clean up a message without child conversations if the process is interrupted.

- **Let the API infer which child records to create** - This makes the API extremely opinionated, forces the client down an inflexible route and creates coupling between the two, so I'm against it. We would have to agree on some non-standard way to provide a list of user ids to create conversations for. I guess, we could define a `message has many users through conversations` relationship and do what we do with project skills, project categories, etc, but really, which is one way where I could agree to do it that way

- Can't think of any other approach at the moment

## References

Progress on: #1293
Tied to: code-corps/code-corps-ember#1597
