### PR TITLE
include tasks in view

### DIFF
--- a/lib/code_corps_web/controllers/task_list_controller.ex
+++ b/lib/code_corps_web/controllers/task_list_controller.ex
@@ -28,7 +28,7 @@ defmodule CodeCorpsWeb.TaskListController do
     end
   end
 
-  @preloads [tasks: [:github_pull_request]]
+  @preloads [tasks: [:github_pull_request, :github_issue, :github_repo, :user_task, :user]]
 
   def preload(data) do
     Repo.preload(data, @preloads)

--- a/lib/code_corps_web/controllers/task_list_controller.ex
+++ b/lib/code_corps_web/controllers/task_list_controller.ex
@@ -28,7 +28,7 @@ defmodule CodeCorpsWeb.TaskListController do
     end
   end
 
-  @preloads [:tasks]
+  @preloads [tasks: [:github_pull_request]]
 
   def preload(data) do
     Repo.preload(data, @preloads)

--- a/lib/code_corps_web/views/task_list_view.ex
+++ b/lib/code_corps_web/views/task_list_view.ex
@@ -7,5 +7,5 @@ defmodule CodeCorpsWeb.TaskListView do
 
   has_one :project, type: "project", field: :project_id
 
-  has_many :tasks, serializer: CodeCorpsWeb.TaskView, identifiers: :always
+  has_many :tasks, serializer: CodeCorpsWeb.TaskIncludedView, identifiers: :always, include: true
 end

--- a/lib/code_corps_web/views/task_view.ex
+++ b/lib/code_corps_web/views/task_view.ex
@@ -46,7 +46,12 @@ defmodule CodeCorpsWeb.TaskIncludedView do
   def type, do: "task"
 
   attributes [
-    :archived, :body, :created_at, :created_from, :inserted_at, :markdown, 
-    :modified_at, :modified_from, :number, :order, :status, :title, :updated_at
+    :archived, :body, :created_at, :created_from, :has_github_pull_request, :inserted_at, 
+    :markdown, :modified_at, :modified_from, :number, :order, :status, :title, :updated_at
   ]
+
+  def has_github_pull_request(%{
+    github_pull_request: %CodeCorps.GithubPullRequest{}
+  }), do: true
+  def has_github_pull_request(%{github_pull_request: nil}), do: false
 end

--- a/lib/code_corps_web/views/task_view.ex
+++ b/lib/code_corps_web/views/task_view.ex
@@ -50,6 +50,12 @@ defmodule CodeCorpsWeb.TaskIncludedView do
     :markdown, :modified_at, :modified_from, :number, :order, :status, :title, :updated_at
   ]
 
+  has_one :github_issue, type: "github-issue", field: :github_issue_id, include: true
+  has_one :github_pull_request, serializer: CodeCorpsWeb.GithubPullRequestView, include: true
+  has_one :github_repo, type: "github-repo", field: :github_repo_id
+  has_one :user, serializer: CodeCorpsWeb.UserIncludedView, include: true
+  has_one :user_task, serializer: CodeCorpsWeb.UserTaskView, include: true
+
   def has_github_pull_request(%{
     github_pull_request: %CodeCorps.GithubPullRequest{}
   }), do: true

--- a/lib/code_corps_web/views/task_view.ex
+++ b/lib/code_corps_web/views/task_view.ex
@@ -37,3 +37,16 @@ defmodule CodeCorpsWeb.TaskView do
     status
   end
 end
+
+defmodule CodeCorpsWeb.TaskIncludedView do
+  @moduledoc false
+  use CodeCorpsWeb, :view
+  use JaSerializer.PhoenixView
+
+  def type, do: "task"
+
+  attributes [
+    :archived, :body, :created_at, :created_from, :inserted_at, :markdown, 
+    :modified_at, :modified_from, :number, :order, :status, :title, :updated_at
+  ]
+end

--- a/lib/code_corps_web/views/user_view.ex
+++ b/lib/code_corps_web/views/user_view.ex
@@ -66,3 +66,48 @@ defmodule CodeCorpsWeb.UserView do
   defp normalize_name(name) when name in ["", nil], do: nil
   defp normalize_name(name), do: name
 end
+
+defmodule CodeCorpsWeb.UserIncludedView do
+  @moduledoc false
+  alias CodeCorps.Presenters.ImagePresenter
+
+  use CodeCorpsWeb, :view
+  use JaSerializer.PhoenixView
+
+  def type, do: "user"
+
+  attributes [
+    :admin, :biography, :cloudinary_public_id, :email, :first_name,
+    :github_avatar_url, :github_id, :github_username,
+    :inserted_at, :last_name, :name, :photo_large_url, :photo_thumb_url,
+    :sign_up_context, :state, :state_transition, :twitter, :username,
+    :website, :updated_at
+  ]
+
+  def photo_large_url(user, _conn), do: ImagePresenter.large(user)
+
+  def photo_thumb_url(user, _conn), do: ImagePresenter.thumbnail(user)
+
+  @doc """
+  Returns the user email or an empty string, depending on the user
+  being rendered is the authenticated user, or some other user.
+
+  Users can only see their own emails. Everyone else's are private.
+  """
+  def email(user, %Plug.Conn{assigns: %{current_user: current_user}}) do
+    if user.id == current_user.id, do: user.email, else: ""
+  end
+  def email(_user, _conn), do: ""
+
+  @doc """
+  Returns the user's full name when both first and last name are present.
+  Returns the only user's first name or last name when the other is missing,
+  otherwise returns nil.
+  """
+  def name(%{first_name: first_name, last_name: last_name}, _conn) do
+    "#{first_name} #{last_name}" |> String.trim |> normalize_name
+  end
+
+  defp normalize_name(name) when name in ["", nil], do: nil
+  defp normalize_name(name), do: name
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.10
--- Dumped by pg_dump version 10.1
+-- Dumped from database version 9.6.6
+-- Dumped by pg_dump version 9.6.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/test/lib/code_corps_web/views/task_list_view_test.exs
+++ b/test/lib/code_corps_web/views/task_list_view_test.exs
@@ -39,7 +39,26 @@ defmodule CodeCorpsWeb.TaskListViewTest do
       },
       "jsonapi" => %{
         "version" => "1.0"
-      }
+      },
+      "included" => [%{
+        "attributes" => %{
+          "archived" => task.archived, 
+          "body" => task.body, 
+          "created-at" => task.created_at, 
+          "created-from" => task.created_from, 
+          "inserted-at" => task.inserted_at, 
+          "markdown" => task.markdown, 
+          "modified-at" => task.modified_at, 
+          "modified-from" => task.modified_from, 
+          "number" => task.number, 
+          "order" => task.order, 
+          "status" => task.status, 
+          "title" => task.title, 
+          "updated-at" => task.updated_at
+        },
+        "id" => task.id |> Integer.to_string, 
+        "type" => "task"
+      }]
     }
 
     assert rendered_json == expected_json

--- a/test/lib/code_corps_web/views/task_list_view_test.exs
+++ b/test/lib/code_corps_web/views/task_list_view_test.exs
@@ -2,7 +2,7 @@ defmodule CodeCorpsWeb.TaskListViewTest do
   use CodeCorpsWeb.ViewCase
 
   test "renders all attributes and relationships properly" do
-    user = insert(:user, default_color: "blue")
+    user = insert(:user, first_name: "First", last_name: "Last", default_color: "blue")
     host = Application.get_env(:code_corps, :asset_host)
     project = insert(:project)
     task_list = insert(:task_list, order: 1000, project: project)
@@ -88,13 +88,13 @@ defmodule CodeCorpsWeb.TaskListViewTest do
           "biography" => user.biography,
           "cloudinary-public-id" => nil,
           "email" => "",
-          "first-name" => "First0",
+          "first-name" => user.first_name,
           "github-avatar-url" => nil,
           "github-id" => nil,
           "github-username" => nil,
           "inserted-at" => user.inserted_at,
-          "last-name" => nil,
-          "name" => "First0",
+          "last-name" => user.last_name,
+          "name" => "First Last",
           "photo-large-url" => "#{host}/icons/user_default_large_blue.png",
           "photo-thumb-url" => "#{host}/icons/user_default_thumb_blue.png",
           "sign-up-context" => "default",

--- a/test/lib/code_corps_web/views/task_list_view_test.exs
+++ b/test/lib/code_corps_web/views/task_list_view_test.exs
@@ -46,6 +46,7 @@ defmodule CodeCorpsWeb.TaskListViewTest do
           "body" => task.body, 
           "created-at" => task.created_at, 
           "created-from" => task.created_from, 
+          "has-github-pull-request" => false,
           "inserted-at" => task.inserted_at, 
           "markdown" => task.markdown, 
           "modified-at" => task.modified_at, 

--- a/test/lib/code_corps_web/views/task_list_view_test.exs
+++ b/test/lib/code_corps_web/views/task_list_view_test.exs
@@ -2,9 +2,11 @@ defmodule CodeCorpsWeb.TaskListViewTest do
   use CodeCorpsWeb.ViewCase
 
   test "renders all attributes and relationships properly" do
+    user = insert(:user, default_color: "blue")
+    host = Application.get_env(:code_corps, :asset_host)
     project = insert(:project)
     task_list = insert(:task_list, order: 1000, project: project)
-    task = insert(:task, order: 1000, task_list: task_list)
+    task = insert(:task, order: 1000, task_list: task_list, user: user)
 
     task_list = CodeCorpsWeb.TaskListController.preload(task_list)
     rendered_json =  render(CodeCorpsWeb.TaskListView, "show.json-api", data: task_list)
@@ -57,8 +59,54 @@ defmodule CodeCorpsWeb.TaskListViewTest do
           "title" => task.title, 
           "updated-at" => task.updated_at
         },
+        "relationships" => %{
+          "github-issue" => %{
+            "data" => nil
+          },
+          "github-repo" => %{
+            "data" => nil
+          },
+          "user-task" => %{
+            "data" => nil
+          },
+          "user" => %{
+            "data" => %{
+              "id" => task.user.id |> Integer.to_string,
+              "type" => "user"
+            }
+          },
+          "github-pull-request" => %{
+            "data" => nil
+          },
+        },
         "id" => task.id |> Integer.to_string, 
         "type" => "task"
+      },
+      %{
+        "attributes" => %{
+          "admin" => false,
+          "biography" => user.biography,
+          "cloudinary-public-id" => nil,
+          "email" => "",
+          "first-name" => "First0",
+          "github-avatar-url" => nil,
+          "github-id" => nil,
+          "github-username" => nil,
+          "inserted-at" => user.inserted_at,
+          "last-name" => nil,
+          "name" => "First0",
+          "photo-large-url" => "#{host}/icons/user_default_large_blue.png",
+          "photo-thumb-url" => "#{host}/icons/user_default_thumb_blue.png",
+          "sign-up-context" => "default",
+          "state" => "signed_up",
+          "state-transition" => nil,
+          "twitter" => user.twitter,
+          "username" => user.username,
+          "updated-at" => user.updated_at,
+          "website" => user.website
+        },
+        "id" => user.id |> Integer.to_string, 
+        "type" => "user"
       }]
     }
 


### PR DESCRIPTION
WIP

So this is a first stab at including tasks in the task_list view and would remove the need for this line `taskLists.forEach((taskList) => get(taskList, 'tasks').reload());` in the tasks index route.

A couple of notes:
1.  This is using a separate TaskIncludedView with just the attrs needed for the tasks index route.  Also note the has_github_pull_request and overall_status is not in the attrs.  I can add back, but wasn't seeing it on the index route.
2.  This should just work on the frontend.  Further refactors to the tasks index route and task detail route will follow.

Progress on: #1156 
