### PR TITLE
Track member approval

### DIFF
--- a/lib/code_corps/analytics/in_memory_api.ex
+++ b/lib/code_corps/analytics/in_memory_api.ex
@@ -9,13 +9,14 @@ defmodule CodeCorps.Analytics.InMemoryAPI do
 
   def identify(user_id, _traits), do: log_identify(user_id)
 
-  def track(user_id, event_name, _properties), do: log_track(user_id, event_name)
+  def track(user_id, event_name, properties), do: log_track(user_id, event_name, properties)
 
   defp log_identify(user_id) do
     Logger.info "Called identify for User #{user_id}"
   end
 
-  defp log_track(user_id, event_name) do
-    Logger.info "Called track for event #{event_name} for User #{user_id}"
+  defp log_track(user_id, event_name, properties) do
+    props = Poison.encode!(properties)
+    Logger.info "Called track for event #{event_name} for User #{user_id} and properties #{props}"
   end
 end

--- a/lib/code_corps/analytics/segment_traits_builder.ex
+++ b/lib/code_corps/analytics/segment_traits_builder.ex
@@ -78,10 +78,12 @@ defmodule CodeCorps.Analytics.SegmentTraitsBuilder do
     }
   end
   defp traits(%CodeCorps.ProjectUser{} = record) do
-    record = record |> Repo.preload(:project)
+    record = record |> Repo.preload([:project, :user])
     %{
       project: record.project.title,
-      project_id: record.project_id
+      project_id: record.project_id,
+      member: record.user.username,
+      member_id: record.user.id
     }
   end
   defp traits(%CodeCorps.StripeConnectAccount{} = account) do

--- a/test/lib/code_corps_web/controllers/project_user_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/project_user_controller_test.exs
@@ -54,7 +54,9 @@ defmodule CodeCorpsWeb.ProjectUserControllerTest do
 
       tracking_properties = %{
         project: project.title,
-        project_id: project.id
+        project_id: project.id,
+        member: user.username,
+        member_id: user.id
       }
 
       assert_received {:track, ^user_id, "Requested Project Membership", ^tracking_properties}
@@ -106,7 +108,9 @@ defmodule CodeCorpsWeb.ProjectUserControllerTest do
 
       tracking_properties = %{
         project: project.title,
-        project_id: project.id
+        project_id: project.id,
+        member: record.user.username,
+        member_id: record.user.id
       }
 
       assert_received {:track, ^user_id, "Approved Project Membership", ^tracking_properties}


### PR DESCRIPTION
# What's in this PR?

* Added member username and member_id to tracking events on `project_user`,
* Added event properties logging to in-memory analytics api for simpler debugging.

These changes should enable conversion funnel analytics using member_id in queries.

## References
Progress on #1285
