### PR TITLE
Added missing reserved routes to slug validator

### DIFF
--- a/lib/code_corps/validators/slug_validator.ex
+++ b/lib/code_corps/validators/slug_validator.ex
@@ -30,18 +30,29 @@ defmodule CodeCorps.Validators.SlugValidator do
     # Routes for the API – api. subdomain
     api_routes = ~w(
       api
-      categories comments contributors
+      categories comments contributors connect conversations conversation-parts
+      donation-goals
+      email_available
+      forgot
+      github-app-installations github-events github-issues github-pull-requests
+      github-repos
       images issues
       mentions
+      messages
       notifications
-      oauth oauth_clients organizations
-      ping projects project-categories
-      project-skills
-      repositories roles
-      skills slugged-route stars
-      tags tasks task-images task-likes
+      oauth oauth_clients organizations organization-github-app-installations
+      organization-invites
+      password ping platform previews projects project-categories project-skills
+      project-users
+      refresh repositories reset roles role-skills
+      skills slugged-route stars stripe stripe-connect-accounts
+      stripe-connect-plans stripe-connect-subscriptions stripe-platform-cards
+      stripe-platform-customers
+      tags tasks task-images task-likes task-lists task-skills
       teams token tokens
-      user-roles user-skills user users
+      user-categories user-roles user-skills user-tasks user username_available
+      users
+      webhooks
     )
 
     # Routes for the web – www. subdomain

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.1
--- Dumped by pg_dump version 10.1
+-- Dumped from database version 10.0
+-- Dumped by pg_dump version 10.0
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/test/lib/code_corps/validators/slug_validator_test.exs
+++ b/test/lib/code_corps/validators/slug_validator_test.exs
@@ -88,6 +88,21 @@ defmodule CodeCorps.Validators.SlugValidatorTest do
     refute changeset.valid?
   end
 
+  test "reserves all api routes" do
+    CodeCorpsWeb.Router.__routes__
+    |> Enum.map(&Map.get(&1, :path))
+    |> Enum.map(&String.split(&1, "/"))
+    |> List.flatten
+    |> Enum.reject(fn fragment -> fragment == "" end)
+    |> Enum.reject(fn fragment -> fragment |> String.at(0) == ":" end)
+    |> Enum.uniq
+    |> Enum.sort
+    |> Enum.each(fn reserved ->
+      changeset = process_slug(reserved)
+      refute changeset.valid?, "#{reserved} should not be allowed as a slug"
+    end)
+  end
+
   defp process_slug(slug) do
     slug
     |> cast_slug


### PR DESCRIPTION
# What's in this PR?

This PR also includes a dynamically generated test which enumerates all routes defined by the API and generates a list of slugs which need to be reserved.

## References

Fixes #1304 

