### PR TITLE
Add check_origin to UserSocket

### DIFF
--- a/lib/code_corps_web/channels/user_socket.ex
+++ b/lib/code_corps_web/channels/user_socket.ex
@@ -6,7 +6,8 @@ defmodule CodeCorpsWeb.UserSocket do
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket,
-    timeout: 45_000
+    timeout: 45_000,
+    check_origin: Application.get_env(:code_corps, :allowed_origins)
   # transport :longpoll, Phoenix.Transports.LongPoll
 
   # Socket params are passed from the client and can


### PR DESCRIPTION
# What's in this PR?

Adds a `check_origin` option to the `UserSocket` which should fix the following issue:

```
Could not check origin for Phoenix.Socket transport.

This happens when you are attempting a socket connection to
a different host than the one configured in your config/
files. For example, in development the host is configured
to "localhost" but you may be trying to access it from
"127.0.0.1". To fix this issue, you may either:

  1. update [url: [host: ...]] to your actual host in the
     config file for your current environment (recommended)

  2. pass the :check_origin option when configuring your
     endpoint or when configuring the transport in your
     UserSocket module, explicitly outlining which origins
     are allowed:

        check_origin: ["https://example.com",
                       "//another.com:888", "//other.com"]
```