### PR TITLE
Fix contributors URL in emails

### DIFF
--- a/lib/code_corps/emails/project_user_request_email.ex
+++ b/lib/code_corps/emails/project_user_request_email.ex
@@ -32,7 +32,7 @@ defmodule CodeCorps.Emails.ProjectUserRequestEmail do
   @spec url(Project.t) :: String.t
   defp url(project) do
     WebClient.url()
-    |> URI.merge(project.organization.slug <> "/" <> project.slug <> "/settings/contributors")
+    |> URI.merge(project.organization.slug <> "/" <> project.slug <> "/people")
     |> URI.to_string
   end
 

--- a/test/lib/code_corps/emails/project_user_request_email_test.exs
+++ b/test/lib/code_corps/emails/project_user_request_email_test.exs
@@ -19,7 +19,7 @@ defmodule CodeCorps.Emails.ProjectUserRequestEmailTest do
     template_model = email.private.template_model
 
     assert template_model == %{
-      contributors_url: "http://localhost:4200/#{project.organization.slug}/#{project.slug}/settings/contributors",
+      contributors_url: "http://localhost:4200/#{project.organization.slug}/#{project.slug}/people",
       project_title: project.title,
       project_logo_url: "#{Application.get_env(:code_corps, :asset_host)}/icons/project_default_large_.png",
       user_image_url: "#{Application.get_env(:code_corps, :asset_host)}/icons/user_default_large_.png",


### PR DESCRIPTION
# What's in this PR?

Fixes an issue where we changed the contributors URL but did not change them in emails.