### PR TITLE
Add author_id to response from new:message in conversation channel

### DIFF
--- a/lib/code_corps_web/channels/conversation_channel.ex
+++ b/lib/code_corps_web/channels/conversation_channel.ex
@@ -26,6 +26,7 @@ defmodule CodeCorpsWeb.ConversationChannel do
     channel = "conversation:#{conversation_part.conversation_id}"
     event = "new:conversation-part"
     payload = %{
+      author_id: conversation_part.author_id,
       id: conversation_part.id
     }
 


### PR DESCRIPTION
# What's in this PR?

Add an `author_id` to the `conversation-part` channel event to support the UI looking up the `id` of the author.