### PR TITLE
Update conversation for new conversation part

### DIFF
--- a/lib/code_corps/messages/conversation_parts.ex
+++ b/lib/code_corps/messages/conversation_parts.ex
@@ -4,22 +4,47 @@ defmodule CodeCorps.Messages.ConversationParts do
   i.e. a reply to the `CodeCorps.Conversation` by any participant.
   """
 
-  import Ecto.Changeset, only: [assoc_constraint: 2, cast: 3, validate_required: 2,
-                                validate_inclusion: 3]
+  import Ecto.Changeset, only: [
+    assoc_constraint: 2,
+    cast: 3,
+    validate_required: 2,
+    validate_inclusion: 3
+  ]
 
   alias CodeCorps.{
+    Conversation,
     ConversationPart,
+    Messages,
     Repo
   }
   alias CodeCorpsWeb.ConversationChannel
+  alias Ecto.{
+    Changeset,
+    Multi
+  }
 
-  @spec create(map) :: ConversationPart.t | Ecto.Changeset.t
-  def create(attrs) do
-    with {:ok, %ConversationPart{} = conversation_part} <- %ConversationPart{} |> create_changeset(attrs) |> Repo.insert() do
+  @spec create(map) :: {:ok, ConversationPart.t} | {:error, Changeset.t}
+  def create(%{"conversation_id" => id} = attrs) do
+    with %Conversation{} = conversation <- Repo.get(Conversation, id),
+         {:ok, %ConversationPart{} = conversation_part} <- do_create(attrs, conversation) do
       ConversationChannel.broadcast_new_conversation_part(conversation_part)
       {:ok, conversation_part}
     end
   end
+
+  @spec do_create(map, Conversation.t) :: {:ok, Conversation.t} | {:error, Changeset.t}
+  defp do_create(attrs, conversation) do
+    Multi.new
+    |> Multi.insert(:conversation_part, create_changeset(%ConversationPart{}, attrs))
+    |> Multi.update(:conversation, Messages.Conversations.part_added_changeset(conversation))
+    |> Repo.transaction()
+    |> marshall_result()
+  end
+
+  @spec marshall_result(tuple) :: {:ok, ConversationPart.t} | {:error, Changeset.t}
+  defp marshall_result({:ok, %{conversation_part: %ConversationPart{} = conversation_part}}), do: {:ok, conversation_part}
+  defp marshall_result({:error, :conversation_part, %Changeset{} = changeset, _steps}), do: {:error, changeset}
+  defp marshall_result({:error, :conversation, %Changeset{} = changeset, _steps}), do: {:error, changeset}
 
   @doc false
   @spec create_changeset(ConversationPart.t, map) :: Ecto.Changeset.t

--- a/lib/code_corps/messages/conversations.ex
+++ b/lib/code_corps/messages/conversations.ex
@@ -16,4 +16,16 @@ defmodule CodeCorps.Messages.Conversations do
     |> Changeset.validate_required([:user_id])
     |> Changeset.assoc_constraint(:user)
   end
+
+  @doc false
+  @spec part_added_changeset(Conversation.t) :: Ecto.Changeset.t
+  def part_added_changeset(%Conversation{} = conversation) do
+    params = %{
+      status: "open",
+      updated_at: Ecto.DateTime.utc()
+    }
+
+    conversation
+    |> Changeset.cast(params, [:status, :updated_at])
+  end
 end

--- a/test/lib/code_corps/messages/conversations_test.exs
+++ b/test/lib/code_corps/messages/conversations_test.exs
@@ -1,0 +1,24 @@
+defmodule CodeCorps.Messages.ConversationsTest do
+  @moduledoc false
+
+  use CodeCorps.DbAccessCase
+
+  alias CodeCorps.{
+    Conversation, Messages
+  }
+
+  describe "part_added_changeset/1" do
+    test "sets the updated_at to the current time" do
+      old_updated_at = Timex.now |> Timex.shift(days: -5)
+      conversation = %Conversation{updated_at: old_updated_at}
+      changeset = conversation |> Messages.Conversations.part_added_changeset()
+      assert changeset.changes[:updated_at] > old_updated_at
+    end
+
+    test "sets status to open" do
+      conversation = %Conversation{status: "closed"}
+      changeset = conversation |> Messages.Conversations.part_added_changeset()
+      assert changeset.changes[:status] == "open"
+    end
+  end
+end


### PR DESCRIPTION
# What's in this PR?

Update conversation for new conversation part
- Set the status to "open"
- Set the updated_at to the current UTC time

## References
Fixes #1317 