### PR TITLE
Alias user on create

### DIFF
--- a/lib/code_corps/analytics/in_memory_api.ex
+++ b/lib/code_corps/analytics/in_memory_api.ex
@@ -7,9 +7,15 @@ defmodule CodeCorps.Analytics.InMemoryAPI do
 
   require Logger
 
+  def alias(user_id, previous_id), do: log_alias(user_id, previous_id)
+
   def identify(user_id, _traits), do: log_identify(user_id)
 
   def track(user_id, event_name, properties), do: log_track(user_id, event_name, properties)
+
+  defp log_alias(user_id, previous_id) do
+    Logger.info "Called alias for User #{user_id} with anonymous id #{previous_id}"
+  end
 
   defp log_identify(user_id) do
     Logger.info "Called identify for User #{user_id}"

--- a/lib/code_corps/analytics/segment_api.ex
+++ b/lib/code_corps/analytics/segment_api.ex
@@ -3,6 +3,10 @@ defmodule CodeCorps.Analytics.SegmentAPI do
   Interface to the Segment API through the [`analytics-elixir` package](https://github.com/stueccles/analytics-elixir).
   """
 
+  def alias(user_id, previous_id) do
+    Segment.Analytics.alias(user_id, previous_id)
+  end
+
   def identify(user_id, traits) do
     Segment.Analytics.identify(user_id, traits)
   end

--- a/lib/code_corps/analytics/segment_tracker.ex
+++ b/lib/code_corps/analytics/segment_tracker.ex
@@ -11,6 +11,14 @@ defmodule CodeCorps.Analytics.SegmentTracker do
   @api Application.get_env(:code_corps, :analytics)
 
   @doc """
+  Calls `alias` in the configured API module.
+  """
+  @spec alias(String.t, String.t) :: any
+  def alias(user_id, previous_id) do
+    @api.alias(user_id, previous_id)
+  end
+
+  @doc """
   Calls `identify` in the configured API module.
   """
   @spec identify(CodeCorps.User.t) :: any

--- a/lib/code_corps/analytics/test_api.ex
+++ b/lib/code_corps/analytics/test_api.ex
@@ -6,6 +6,11 @@ defmodule CodeCorps.Analytics.TestAPI do
   Each function should have the same signature as `CodeCorps.Analytics.SegmentAPI` and simply return `nil`.
   """
 
+  def alias(user_id, previous_id) do
+    send self(), {:alias, user_id, previous_id}
+    nil
+  end
+
   def identify(user_id, traits) do
     send self(), {:identify, user_id, traits}
     nil

--- a/lib/code_corps_web/controllers/user_controller.ex
+++ b/lib/code_corps_web/controllers/user_controller.ex
@@ -40,6 +40,7 @@ defmodule CodeCorpsWeb.UserController do
     with {:ok, %User{} = user} <- %User{} |> User.registration_changeset(params) |> Repo.insert(),
          user <- preload(user)
     do
+      maybe_alias(user, params)
       conn |> put_status(:created) |> render("show.json-api", data: user)
     end
   end
@@ -91,4 +92,10 @@ defmodule CodeCorpsWeb.UserController do
   def preload(data) do
     Repo.preload(data, @preloads)
   end
+
+  @spec maybe_alias(User.t, map) :: any
+  defp maybe_alias(%User{id: id}, %{"previous_id" => previous_id}) do
+    Analytics.SegmentTracker.alias(id, previous_id)
+  end
+  defp maybe_alias(_user, _params), do: nil
 end

--- a/test/lib/code_corps_web/controllers/user_controller_test.exs
+++ b/test/lib/code_corps_web/controllers/user_controller_test.exs
@@ -8,20 +8,21 @@ defmodule CodeCorpsWeb.UserControllerTest do
   alias CodeCorps.{User, Repo}
 
   @valid_attrs %{
+    biography: "Just a test user",
     email: "test@user.com",
-    username: "testuser",
     first_name: "Test",
     last_name: "User",
-    website: "http://www.example.com",
+    previous_id: "abc123",
     twitter: "testuser",
-    biography: "Just a test user"
+    username: "testuser",
+    website: "http://www.example.com"
   }
 
   @invalid_attrs %{
     email: "",
+    twitter: " @ testuser",
     username: "",
-    website: "---_<>-blank.com",
-    twitter: " @ testuser"
+    website: "---_<>-blank.com"
   }
 
   @relationships %{}
@@ -134,6 +135,8 @@ defmodule CodeCorpsWeb.UserControllerTest do
         }
       }
       id = json_response(conn, 201)["data"]["id"] |> String.to_integer
+      previous_id = @valid_attrs.previous_id
+      assert_received {:alias, ^id, ^previous_id}
       assert_received {:track, ^id, "Signed Up", %{}}
     end
 
@@ -192,7 +195,6 @@ defmodule CodeCorpsWeb.UserControllerTest do
         |> put(path, params)
 
       id = json_response(conn, 200)["data"]["id"] |> String.to_integer
-      assert_received {:identify, ^id, %{email: "original@mail.com"}}
       assert_received {:track, ^id, "Updated Profile", %{}}
     end
 


### PR DESCRIPTION
# What's in this PR?

Allows us to alias the user on creation.

This is a WIP and very much incomplete.

A few of the issues we have with this:

- it's not recommended to alias on the server-side
- we're sending too many events close to the `alias`, leading to a race condition
- it's not clear whether we should be aliasing to the segment ID or the mixpanel ID