### PR TITLE
Move Tasks context and fix bug with date comparison test

### DIFF
--- a/lib/code_corps/tasks/query.ex
+++ b/lib/code_corps/tasks/query.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.Task.Query do
+defmodule CodeCorps.Tasks.Query do
   @moduledoc ~S"""
   Holds queries used to retrieve a list of, or a single `Task` record from the
   database, using a provided map of parameters/filters.
@@ -20,7 +20,7 @@ defmodule CodeCorps.Task.Query do
   """
   @spec list(map) :: list(Project.t)
   def list(%{} = params) do
-    timing("Task.Query", "list") do
+    timing("Tasks.Query", "list") do
       Task
       |> Helpers.Query.id_filter(params)
       |> apply_archived_status(params)

--- a/lib/code_corps/tasks/tasks.ex
+++ b/lib/code_corps/tasks/tasks.ex
@@ -1,4 +1,4 @@
-defmodule CodeCorps.Task.Service do
+defmodule CodeCorps.Tasks do
   @moduledoc """
   Handles special CRUD operations for `CodeCorps.Task`.
   """
@@ -28,8 +28,8 @@ defmodule CodeCorps.Task.Service do
   @doc ~S"""
   Performs all actions involved in creating a task on a project
   """
-  @spec create(map) :: result
-  def create(%{} = attributes) do
+  @spec create_task(map) :: result
+  def create_task(%{} = attributes) do
     Multi.new
     |> Multi.insert(:task, %Task{} |> Task.create_changeset(attributes))
     |> Multi.run(:preload, fn %{task: %Task{} = task} ->
@@ -40,8 +40,8 @@ defmodule CodeCorps.Task.Service do
     |> marshall_result()
   end
 
-  @spec update(Task.t, map) :: result
-  def update(%Task{} = task, %{} = attributes) do
+  @spec update_task(Task.t, map) :: result
+  def update_task(%Task{} = task, %{} = attributes) do
     Multi.new
     |> Multi.update(:task, task |> Task.update_changeset(attributes))
     |> Multi.run(:preload, fn %{task: %Task{} = task} ->

--- a/mix.exs
+++ b/mix.exs
@@ -141,10 +141,10 @@ defmodule CodeCorps.Mixfile do
         CodeCorps.StripeInvoice,
         CodeCorps.StripePlatformCard,
         CodeCorps.StripePlatformCustomer,
-        CodeCorps.Task,
-        CodeCorps.Task.Query,
         CodeCorps.TaskList,
         CodeCorps.TaskSkill,
+        CodeCorps.Tasks,
+        CodeCorps.Tasks.Query,
         CodeCorps.Transition.UserState,
         CodeCorps.User,
         CodeCorps.UserCategory,
@@ -162,7 +162,7 @@ defmodule CodeCorps.Mixfile do
         CodeCorps.Services.MarkdownRendererService,
         CodeCorps.Services.ProjectService,
         CodeCorps.Services.UserService,
-        CodeCorps.Task.Service
+        CodeCorps.Tasks
       ],
 
       "Policies": [

--- a/test/lib/code_corps/messages/conversations_test.exs
+++ b/test/lib/code_corps/messages/conversations_test.exs
@@ -1,6 +1,8 @@
 defmodule CodeCorps.Messages.ConversationsTest do
   @moduledoc false
 
+  import DateTime, only: [compare: 2]
+
   use CodeCorps.DbAccessCase
 
   alias CodeCorps.{
@@ -9,10 +11,10 @@ defmodule CodeCorps.Messages.ConversationsTest do
 
   describe "part_added_changeset/1" do
     test "sets the updated_at to the current time" do
-      old_updated_at = Timex.now |> Timex.shift(days: -5)
+      old_updated_at = DateTime.utc_now() |> Timex.shift(days: -5)
       conversation = %Conversation{updated_at: old_updated_at}
       changeset = conversation |> Messages.Conversations.part_added_changeset()
-      assert changeset.changes[:updated_at] > old_updated_at
+      assert compare(old_updated_at, changeset.changes[:updated_at]) == :lt
     end
 
     test "sets status to open" do

--- a/test/lib/code_corps/tasks/query_test.exs
+++ b/test/lib/code_corps/tasks/query_test.exs
@@ -1,9 +1,9 @@
-defmodule CodeCorps.Task.QueryTest do
+defmodule CodeCorps.Tasks.QueryTest do
   @moduledoc false
 
   use CodeCorps.DbAccessCase
 
-  alias CodeCorps.Task
+  alias CodeCorps.Tasks
 
   describe "filter/2" do
     defp get_sorted_ids(tasks) do
@@ -11,11 +11,11 @@ defmodule CodeCorps.Task.QueryTest do
     end
 
     defp list_sorted_ids(params) do
-      params |> Task.Query.list |> get_sorted_ids()
+      params |> Tasks.Query.list |> get_sorted_ids()
     end
 
     defp find_with_query(params) do
-      params |> Task.Query.find
+      params |> Tasks.Query.find
     end
 
     test "filters by project_id" do


### PR DESCRIPTION
# What's in this PR?

- Move `Task` to `Tasks` and changes fn names
- Fix a bug with date comparison in a test